### PR TITLE
Post-merge fixes: regex rules, fail-closed, UX polish

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -64,8 +64,8 @@ final class ApprovalCoordinator: ObservableObject {
             }
         }
 
-        // Block socket handler until user responds (5 min timeout)
-        let waitResult = semaphore.wait(timeout: .now() + 300)
+        // Block socket handler until user responds (24 hours — effectively no timeout)
+        let waitResult = semaphore.wait(timeout: .now() + 86400)
         if waitResult == .timedOut {
             DispatchQueue.main.async {
                 self.dismissCurrent()
@@ -112,13 +112,15 @@ final class ApprovalCoordinator: ObservableObject {
 
         case .alwaysDenyPattern(let pattern, let isRegex):
             ctx = nil; updated = nil
-            let rule = PersistentRule(toolName: current.payload.toolName, pattern: pattern, isRegex: isRegex, verdict: .block)
+            let sanitized = Self.sanitizeDashes(pattern)
+            let rule = PersistentRule(toolName: current.payload.toolName, pattern: sanitized, isRegex: isRegex, verdict: .block)
             ruleStore?.addRule(rule)
             current.respond(Decision(verdict: .block, reason: "Always deny: \(current.payload.toolName): \(pattern)"))
 
         case .alwaysAllowPattern(let pattern, let isRegex):
             ctx = nil; updated = nil
-            let rule = PersistentRule(toolName: current.payload.toolName, pattern: pattern, isRegex: isRegex, verdict: .allow)
+            let sanitized = Self.sanitizeDashes(pattern)
+            let rule = PersistentRule(toolName: current.payload.toolName, pattern: sanitized, isRegex: isRegex, verdict: .allow)
             ruleStore?.addRule(rule)
             current.respond(Decision(verdict: .allow, reason: "Always allow: \(current.payload.toolName): \(pattern)"))
         }
@@ -199,7 +201,7 @@ final class ApprovalCoordinator: ObservableObject {
 
         let p = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: 640, height: 480),
-            styleMask: [.titled, .closable, .resizable, .utilityWindow, .nonactivatingPanel],
+            styleMask: [.titled, .closable, .resizable, .utilityWindow],
             backing: .buffered,
             defer: false
         )
@@ -210,7 +212,16 @@ final class ApprovalCoordinator: ObservableObject {
         p.level = .floating
         p.isReleasedWhenClosed = false
         p.hidesOnDeactivate = false
+        // Allow text editing operations (paste, cut, copy, select all)
+        p.acceptsMouseMovedEvents = true
         panel = p
+    }
+
+    /// Replace typographic dashes (macOS smart dashes) with ASCII hyphens.
+    static func sanitizeDashes(_ input: String) -> String {
+        input.replacingOccurrences(of: "\u{2013}", with: "-")  // en-dash
+             .replacingOccurrences(of: "\u{2014}", with: "--") // em-dash
+             .replacingOccurrences(of: "\u{2012}", with: "-")  // figure dash
     }
 
     private func closePanel() {

--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -12,8 +12,8 @@ final class ApprovalCoordinator: ObservableObject {
         case allow(context: String?, updatedCommand: String?)
         case deny(context: String?)
         case allowPatternForSession(pattern: String, context: String?, updatedCommand: String?)
-        case alwaysDenyPattern(pattern: String)
-        case alwaysAllowPattern(pattern: String)
+        case alwaysDenyPattern(pattern: String, isRegex: Bool)
+        case alwaysAllowPattern(pattern: String, isRegex: Bool)
     }
 
     /// RuleStore for persistent always-deny/always-allow rules.
@@ -110,15 +110,15 @@ final class ApprovalCoordinator: ObservableObject {
             current.session.sessionRules.append(rule)
             current.respond(Decision(verdict: .allow, reason: "User approved (\(current.payload.toolName): \(pattern))", additionalContext: ctx, updatedInput: updated))
 
-        case .alwaysDenyPattern(let pattern):
+        case .alwaysDenyPattern(let pattern, let isRegex):
             ctx = nil; updated = nil
-            let rule = PersistentRule(toolName: current.payload.toolName, pattern: pattern, verdict: .block)
+            let rule = PersistentRule(toolName: current.payload.toolName, pattern: pattern, isRegex: isRegex, verdict: .block)
             ruleStore?.addRule(rule)
             current.respond(Decision(verdict: .block, reason: "Always deny: \(current.payload.toolName): \(pattern)"))
 
-        case .alwaysAllowPattern(let pattern):
+        case .alwaysAllowPattern(let pattern, let isRegex):
             ctx = nil; updated = nil
-            let rule = PersistentRule(toolName: current.payload.toolName, pattern: pattern, verdict: .allow)
+            let rule = PersistentRule(toolName: current.payload.toolName, pattern: pattern, isRegex: isRegex, verdict: .allow)
             ruleStore?.addRule(rule)
             current.respond(Decision(verdict: .allow, reason: "Always allow: \(current.payload.toolName): \(pattern)"))
         }

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -6,6 +6,8 @@ struct ApprovalPanelView: View {
     @State private var sessionPattern: String = ""
     @State private var noteToClaudeText: String = ""
     @State private var editedCommand: String = ""
+    @State private var isRegexMode: Bool = false
+    @State private var testString: String = ""
 
     var body: some View {
         VStack(spacing: 0) {
@@ -238,20 +240,39 @@ struct ApprovalPanelView: View {
     @ViewBuilder
     private func actionBar(_ approval: ApprovalCoordinator.PendingApproval) -> some View {
         VStack(spacing: 6) {
-            // Pattern field (shared by session and persistent rules)
+            // Pattern field with regex toggle
             HStack(spacing: 4) {
                 Text("\(approval.payload.toolName):")
                     .font(.system(.body, design: .monospaced).bold())
                     .foregroundColor(colorForTool(approval.payload.toolName))
-                TextField("pattern", text: $sessionPattern)
+
+                if isRegexMode {
+                    Text("/")
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundColor(.orange)
+                }
+                TextField(isRegexMode ? "regex pattern" : "glob pattern (* = wildcard)", text: $sessionPattern)
                     .font(.system(.body, design: .monospaced))
                     .textFieldStyle(.roundedBorder)
+                if isRegexMode {
+                    Text("/")
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundColor(.orange)
+                }
+
+                Toggle("Regex", isOn: $isRegexMode)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .tint(.orange)
             }
+
+            // Live pattern tester
+            patternTester(approval)
 
             // Persistent + session rules row
             HStack(spacing: 6) {
                 Button(action: {
-                    coordinator.handleAction(.alwaysDenyPattern(pattern: sessionPattern))
+                    coordinator.handleAction(.alwaysDenyPattern(pattern: sessionPattern, isRegex: isRegexMode))
                 }) {
                     Label("Always Deny", systemImage: "hand.raised")
                 }
@@ -260,7 +281,7 @@ struct ApprovalPanelView: View {
                 .keyboardShortcut("d", modifiers: [.command, .shift])
 
                 Button(action: {
-                    coordinator.handleAction(.alwaysAllowPattern(pattern: sessionPattern))
+                    coordinator.handleAction(.alwaysAllowPattern(pattern: sessionPattern, isRegex: isRegexMode))
                 }) {
                     Label("Always Allow", systemImage: "shield.checkered")
                 }
@@ -314,6 +335,67 @@ struct ApprovalPanelView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+    }
+
+    // MARK: - Pattern Tester
+
+    @ViewBuilder
+    private func patternTester(_ approval: ApprovalCoordinator.PendingApproval) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 4) {
+                Image(systemName: "flask")
+                    .foregroundColor(.secondary)
+                    .font(.caption)
+                TextField("Test string (try commands here)", text: $testString)
+                    .font(.system(.caption, design: .monospaced))
+                    .textFieldStyle(.roundedBorder)
+
+                // Live match indicator
+                let result = PersistentRule.testPattern(sessionPattern, isRegex: isRegexMode, against: testString)
+                if !testString.isEmpty {
+                    if let error = result.error {
+                        Text(error)
+                            .font(.caption2)
+                            .foregroundColor(.red)
+                    } else if result.matches {
+                        Text("MATCH")
+                            .font(.caption.bold())
+                            .foregroundColor(.red)
+                            .padding(.horizontal, 4)
+                            .background(Color.red.opacity(0.15))
+                            .cornerRadius(3)
+                    } else {
+                        Text("no match")
+                            .font(.caption)
+                            .foregroundColor(.green)
+                    }
+                }
+            }
+
+            // Show current command match status
+            let currentCmd = approval.payload.command ?? approval.payload.filePath ?? ""
+            if !currentCmd.isEmpty && !sessionPattern.isEmpty {
+                let currentResult = PersistentRule.testPattern(sessionPattern, isRegex: isRegexMode, against: currentCmd)
+                HStack(spacing: 4) {
+                    Text("Current:")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    Text(String(currentCmd.prefix(60)))
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                    if currentResult.matches {
+                        Text("MATCH")
+                            .font(.caption2.bold())
+                            .foregroundColor(.red)
+                    } else {
+                        Text("no match")
+                            .font(.caption2)
+                            .foregroundColor(.green)
+                    }
+                }
+            }
+        }
     }
 
     /// Returns the edited command only if it differs from the original.

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -7,7 +7,6 @@ struct ApprovalPanelView: View {
     @State private var noteToClaudeText: String = ""
     @State private var editedCommand: String = ""
     @State private var isRegexMode: Bool = false
-    @State private var testString: String = ""
 
     var body: some View {
         VStack(spacing: 0) {
@@ -41,7 +40,7 @@ struct ApprovalPanelView: View {
                 command: a.payload.command,
                 filePath: a.payload.filePath
             )
-            editedCommand = a.payload.command ?? ""
+            editedCommand = ApprovalCoordinator.sanitizeDashes(a.payload.command ?? "")
             noteToClaudeText = ""
         }
     }
@@ -341,61 +340,63 @@ struct ApprovalPanelView: View {
 
     @ViewBuilder
     private func patternTester(_ approval: ApprovalCoordinator.PendingApproval) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 4) {
-                Image(systemName: "flask")
-                    .foregroundColor(.secondary)
-                    .font(.caption)
-                TextField("Test string (try commands here)", text: $testString)
-                    .font(.system(.caption, design: .monospaced))
-                    .textFieldStyle(.roundedBorder)
-
-                // Live match indicator
-                let result = PersistentRule.testPattern(sessionPattern, isRegex: isRegexMode, against: testString)
-                if !testString.isEmpty {
-                    if let error = result.error {
-                        Text(error)
-                            .font(.caption2)
-                            .foregroundColor(.red)
-                    } else if result.matches {
-                        Text("MATCH")
-                            .font(.caption.bold())
-                            .foregroundColor(.red)
-                            .padding(.horizontal, 4)
-                            .background(Color.red.opacity(0.15))
-                            .cornerRadius(3)
-                    } else {
-                        Text("no match")
-                            .font(.caption)
-                            .foregroundColor(.green)
-                    }
-                }
-            }
-
-            // Show current command match status
-            let currentCmd = approval.payload.command ?? approval.payload.filePath ?? ""
-            if !currentCmd.isEmpty && !sessionPattern.isEmpty {
-                let currentResult = PersistentRule.testPattern(sessionPattern, isRegex: isRegexMode, against: currentCmd)
-                HStack(spacing: 4) {
+        let currentCmd = editedCommand.isEmpty
+            ? (approval.payload.filePath ?? "")
+            : editedCommand
+        if !currentCmd.isEmpty && !sessionPattern.isEmpty {
+            let result = PersistentRule.testPattern(sessionPattern, isRegex: isRegexMode, against: currentCmd)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
                     Text("Current:")
-                        .font(.caption2)
+                        .font(.system(.body, design: .monospaced).bold())
                         .foregroundColor(.secondary)
-                    Text(String(currentCmd.prefix(60)))
-                        .font(.system(.caption2, design: .monospaced))
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                    if currentResult.matches {
-                        Text("MATCH")
-                            .font(.caption2.bold())
-                            .foregroundColor(.red)
-                    } else {
-                        Text("no match")
-                            .font(.caption2)
-                            .foregroundColor(.green)
+                    Text(currentCmd)
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundColor(.primary)
+                        .lineLimit(2)
+                        .textSelection(.enabled)
+                }
+
+                if let error = result.error {
+                    Text(error)
+                        .font(.body)
+                        .foregroundColor(.red)
+                } else {
+                    HStack(spacing: 12) {
+                        HStack(spacing: 4) {
+                            Text("Always Deny:")
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundColor(.secondary)
+                            resultBadge(
+                                text: result.matches ? "BLOCKED" : "passes through",
+                                color: result.matches ? .red : .green
+                            )
+                        }
+                        HStack(spacing: 4) {
+                            Text("Always Allow:")
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundColor(.secondary)
+                            resultBadge(
+                                text: result.matches ? "ALLOWED" : "no effect",
+                                color: result.matches ? .green : .gray
+                            )
+                        }
                     }
                 }
             }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
         }
+    }
+
+    private func resultBadge(text: String, color: Color) -> some View {
+        Text(text)
+            .font(.body.bold())
+            .foregroundColor(.white)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 2)
+            .background(color)
+            .cornerRadius(4)
     }
 
     /// Returns the edited command only if it differs from the original.

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -42,6 +42,7 @@ struct ApprovalPanelView: View {
             )
             editedCommand = ApprovalCoordinator.sanitizeDashes(a.payload.command ?? "")
             noteToClaudeText = ""
+            isRegexMode = false
         }
     }
 

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -126,15 +126,21 @@ struct PersistentRule: Codable, Identifiable {
     func matches(toolName: String, command: String?, filePath: String?) -> Bool {
         guard self.toolName == toolName || self.toolName == "*" else { return false }
 
-        let target: String
+        let raw: String
         switch toolName {
         case "Bash":
-            target = command ?? ""
+            raw = command ?? ""
         case "Edit", "MultiEdit", "Write", "Read", "Glob", "Grep":
-            target = filePath ?? command ?? ""
+            raw = filePath ?? command ?? ""
         default:
-            target = command ?? filePath ?? ""
+            raw = command ?? filePath ?? ""
         }
+
+        // Sanitize typographic dashes so patterns match consistently
+        let target = raw
+            .replacingOccurrences(of: "\u{2013}", with: "-")
+            .replacingOccurrences(of: "\u{2014}", with: "--")
+            .replacingOccurrences(of: "\u{2012}", with: "-")
 
         guard let regex = compiledRegex else { return false }
         return regex.firstMatch(in: target, range: NSRange(target.startIndex..., in: target)) != nil

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -82,26 +82,45 @@ final class RuleStore: ObservableObject {
 }
 
 /// A persistent approval rule saved to rules.json.
-/// Uses glob-style wildcards (* matches any characters).
+///
+/// Supports two pattern modes:
+/// - **Glob** (default): `*` matches any characters. E.g. `swift build*`
+/// - **Regex**: Full regex with lookaheads etc. E.g. `doppler\s+secrets\b(?!.*--only-names)`
+///   Use `/pattern/` syntax in the UI to indicate regex mode.
 struct PersistentRule: Codable, Identifiable {
     let id: UUID
     let name: String
     let toolName: String
     let pattern: String
+    let isRegex: Bool
     let verdict: DecisionVerdict
     let createdAt: Date
+
+    /// Pre-compiled regex (not persisted, rebuilt on load).
+    private var _compiledRegex: NSRegularExpression?
+    var compiledRegex: NSRegularExpression? {
+        if let r = _compiledRegex { return r }
+        return Self.compilePattern(pattern, isRegex: isRegex)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, toolName, pattern, isRegex, verdict, createdAt
+    }
 
     init(
         toolName: String,
         pattern: String,
+        isRegex: Bool = false,
         verdict: DecisionVerdict
     ) {
         self.id = UUID()
-        self.name = "\(toolName): \(pattern)"
         self.toolName = toolName
         self.pattern = pattern
+        self.isRegex = isRegex
         self.verdict = verdict
         self.createdAt = Date()
+        self.name = "\(toolName): \(isRegex ? "/" : "")\(pattern)\(isRegex ? "/" : "")"
+        self._compiledRegex = Self.compilePattern(pattern, isRegex: isRegex)
     }
 
     func matches(toolName: String, command: String?, filePath: String?) -> Bool {
@@ -117,10 +136,16 @@ struct PersistentRule: Codable, Identifiable {
             target = command ?? filePath ?? ""
         }
 
-        return globMatch(pattern: pattern, string: target)
+        guard let regex = compiledRegex else { return false }
+        return regex.firstMatch(in: target, range: NSRange(target.startIndex..., in: target)) != nil
     }
 
-    private func globMatch(pattern: String, string: String) -> Bool {
+    /// Compile a pattern to regex. Glob patterns are converted; regex patterns used as-is.
+    static func compilePattern(_ pattern: String, isRegex: Bool) -> NSRegularExpression? {
+        if isRegex {
+            return try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+        }
+        // Convert glob to regex
         var regex = "^"
         for ch in pattern {
             switch ch {
@@ -131,7 +156,22 @@ struct PersistentRule: Codable, Identifiable {
             }
         }
         regex += "$"
-        return (try? NSRegularExpression(pattern: regex))
-            .flatMap { $0.firstMatch(in: string, range: NSRange(string.startIndex..., in: string)) } != nil
+        return try? NSRegularExpression(pattern: regex)
+    }
+
+    /// Test a pattern against a sample string. Returns match result and any regex error.
+    static func testPattern(_ pattern: String, isRegex: Bool, against sample: String) -> (matches: Bool, error: String?) {
+        if isRegex {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+                return (false, "Invalid regex")
+            }
+            let match = regex.firstMatch(in: sample, range: NSRange(sample.startIndex..., in: sample)) != nil
+            return (match, nil)
+        }
+        guard let regex = compilePattern(pattern, isRegex: false) else {
+            return (false, "Invalid pattern")
+        }
+        let match = regex.firstMatch(in: sample, range: NSRange(sample.startIndex..., in: sample)) != nil
+        return (match, nil)
     }
 }

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -22,18 +22,18 @@ final class RuleStore: ObservableObject {
     // MARK: - Evaluation (split by verdict for priority ordering)
 
     func evaluateDeny(payload: PreToolUsePayload) -> Decision? {
-        for rule in rules where rule.verdict == .block {
-            if rule.matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
-                return Decision(verdict: .block, reason: "Always deny: \(rule.name)")
+        for i in rules.indices where rules[i].verdict == .block {
+            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
+                return Decision(verdict: .block, reason: "Always deny: \(rules[i].name)")
             }
         }
         return nil
     }
 
     func evaluateAllow(payload: PreToolUsePayload) -> Decision? {
-        for rule in rules where rule.verdict == .allow {
-            if rule.matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
-                return Decision(verdict: .allow, reason: "Always allow: \(rule.name)")
+        for i in rules.indices where rules[i].verdict == .allow {
+            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
+                return Decision(verdict: .allow, reason: "Always allow: \(rules[i].name)")
             }
         }
         return nil
@@ -85,8 +85,7 @@ final class RuleStore: ObservableObject {
 ///
 /// Supports two pattern modes:
 /// - **Glob** (default): `*` matches any characters. E.g. `swift build*`
-/// - **Regex**: Full regex with lookaheads etc. E.g. `doppler\s+secrets\b(?!.*--only-names)`
-///   Use `/pattern/` syntax in the UI to indicate regex mode.
+/// - **Regex**: Full regex with lookaheads etc. Toggle Regex in the UI.
 struct PersistentRule: Codable, Identifiable {
     let id: UUID
     let name: String
@@ -96,15 +95,31 @@ struct PersistentRule: Codable, Identifiable {
     let verdict: DecisionVerdict
     let createdAt: Date
 
-    /// Pre-compiled regex (not persisted, rebuilt on load).
+    /// Pre-compiled regex (rebuilt on first access, not persisted).
     private var _compiledRegex: NSRegularExpression?
     var compiledRegex: NSRegularExpression? {
-        if let r = _compiledRegex { return r }
-        return Self.compilePattern(pattern, isRegex: isRegex)
+        mutating get {
+            if _compiledRegex == nil {
+                _compiledRegex = Self.compilePattern(pattern, isRegex: isRegex)
+            }
+            return _compiledRegex
+        }
     }
 
     enum CodingKeys: String, CodingKey {
         case id, name, toolName, pattern, isRegex, verdict, createdAt
+    }
+
+    /// Backward-compatible decoding — isRegex defaults to false for old rules.json.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        toolName = try c.decode(String.self, forKey: .toolName)
+        pattern = try c.decode(String.self, forKey: .pattern)
+        isRegex = try c.decodeIfPresent(Bool.self, forKey: .isRegex) ?? false
+        verdict = try c.decode(DecisionVerdict.self, forKey: .verdict)
+        createdAt = try c.decode(Date.self, forKey: .createdAt)
     }
 
     init(
@@ -123,7 +138,7 @@ struct PersistentRule: Codable, Identifiable {
         self._compiledRegex = Self.compilePattern(pattern, isRegex: isRegex)
     }
 
-    func matches(toolName: String, command: String?, filePath: String?) -> Bool {
+    mutating func matches(toolName: String, command: String?, filePath: String?) -> Bool {
         guard self.toolName == toolName || self.toolName == "*" else { return false }
 
         let raw: String

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -90,12 +90,19 @@ final class HookRouter {
             at: timestamp
         ))
 
-        // Stage 1: Check for hard blocks (dangerous patterns, paused)
+        // Stage 1: Check engine (dangerous patterns, persistent deny/allow, pause)
         let engineDecision = approvalEngine.evaluate(payload: payload, session: session)
         if engineDecision.verdict == .block {
             session.blockCount += 1
             let badge: DecisionBadge = session.isPaused ? .paused : .block
             emitFeed(.decision(badge: badge, reason: engineDecision.reason, pid: session.pid, at: timestamp))
+            sendResponse(engineDecision, respond: respond)
+            return
+        }
+        // Persistent allow rules (have a reason) skip the dialog
+        if engineDecision.reason != nil {
+            session.allowCount += 1
+            emitFeed(.decision(badge: .allow, reason: engineDecision.reason, pid: session.pid, at: timestamp))
             sendResponse(engineDecision, respond: respond)
             return
         }

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -76,15 +76,21 @@ struct SessionRule: Identifiable {
     func matches(toolName: String, command: String?, filePath: String?) -> Bool {
         guard self.toolName == toolName || self.toolName == "*" else { return false }
 
-        let target: String
+        let raw: String
         switch toolName {
         case "Bash":
-            target = command ?? ""
+            raw = command ?? ""
         case "Edit", "MultiEdit", "Write", "Read", "Glob", "Grep":
-            target = filePath ?? command ?? ""
+            raw = filePath ?? command ?? ""
         default:
-            target = command ?? filePath ?? ""
+            raw = command ?? filePath ?? ""
         }
+
+        // Sanitize typographic dashes
+        let target = raw
+            .replacingOccurrences(of: "\u{2013}", with: "-")
+            .replacingOccurrences(of: "\u{2014}", with: "--")
+            .replacingOccurrences(of: "\u{2012}", with: "-")
 
         return globMatch(pattern: pattern, string: target)
     }

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -31,6 +31,12 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
     var socketServer: SocketServer?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Disable macOS smart dashes/quotes — gavel needs exact ASCII for patterns
+        UserDefaults.standard.set(false, forKey: "NSAutomaticDashSubstitutionEnabled")
+        UserDefaults.standard.set(false, forKey: "NSAutomaticQuoteSubstitutionEnabled")
+        UserDefaults.standard.set(false, forKey: "NSAutomaticTextCompletionEnabled")
+
+        setupMainMenu()
         setupMenuBar()
         setupSocketServer()
         setupHookRouter()
@@ -41,6 +47,34 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         socketServer?.stop()
+    }
+
+    // MARK: - Main Menu (needed for Cmd+V/C/X/A in text fields)
+
+    private func setupMainMenu() {
+        let mainMenu = NSMenu()
+
+        // App menu
+        let appMenuItem = NSMenuItem()
+        let appMenu = NSMenu()
+        appMenu.addItem(NSMenuItem(title: "Quit Gavel", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
+        appMenuItem.submenu = appMenu
+        mainMenu.addItem(appMenuItem)
+
+        // Edit menu — enables standard text editing shortcuts
+        let editMenuItem = NSMenuItem()
+        let editMenu = NSMenu(title: "Edit")
+        editMenu.addItem(NSMenuItem(title: "Undo", action: Selector(("undo:")), keyEquivalent: "z"))
+        editMenu.addItem(NSMenuItem(title: "Redo", action: Selector(("redo:")), keyEquivalent: "Z"))
+        editMenu.addItem(NSMenuItem.separator())
+        editMenu.addItem(NSMenuItem(title: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x"))
+        editMenu.addItem(NSMenuItem(title: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c"))
+        editMenu.addItem(NSMenuItem(title: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v"))
+        editMenu.addItem(NSMenuItem(title: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a"))
+        editMenuItem.submenu = editMenu
+        mainMenu.addItem(editMenuItem)
+
+        NSApp.mainMenu = mainMenu
     }
 
     // MARK: - Menu Bar

--- a/Sources/GavelHook/main.swift
+++ b/Sources/GavelHook/main.swift
@@ -114,7 +114,7 @@ if needsResponse {
     let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: bufSize)
     defer { buf.deallocate() }
 
-    var timeout = timeval(tv_sec: 300, tv_usec: 0) // 5 min — user may be reviewing
+    var timeout = timeval(tv_sec: 86400, tv_usec: 0) // 24 hours — effectively no timeout
     setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
 
     while true {

--- a/Sources/GavelHook/main.swift
+++ b/Sources/GavelHook/main.swift
@@ -8,7 +8,9 @@ import Foundation
 ///   - allow → stdout structured hookSpecificOutput JSON, exit 0
 ///   - block → stderr "reason", exit 2
 ///
-/// This replaces per-invocation Python scripts with a ~2ms binary.
+/// SECURITY: If the daemon IS reachable but returns no/unparseable response,
+/// fail CLOSED (block). Only fail open when the daemon isn't running at all,
+/// so Claude works without gavel.
 
 let socketPath = FileManager.default.homeDirectoryForCurrentUser
     .appendingPathComponent(".claude/gavel/gavel.sock").path
@@ -56,13 +58,15 @@ if var payload = stdinJson {
 }
 
 guard let envelopeData = try? JSONSerialization.data(withJSONObject: envelope) else {
-    if needsResponse { printAllow() }
-    exit(0)
+    // Can't even build envelope — fail closed
+    if needsResponse { printBlock("Gavel: failed to serialize hook envelope") }
+    exit(needsResponse ? 2 : 0)
 }
 
 // Connect to daemon socket
 let fd = socket(AF_UNIX, SOCK_STREAM, 0)
 guard fd >= 0 else {
+    // No socket — daemon not running. Fail OPEN so Claude works without gavel.
     if needsResponse { printAllow() }
     exit(0)
 }
@@ -71,8 +75,9 @@ var addr = sockaddr_un()
 addr.sun_family = sa_family_t(AF_UNIX)
 let pathBytes = socketPath.utf8CString
 guard pathBytes.count <= MemoryLayout.size(ofValue: addr.sun_path) else {
-    if needsResponse { printAllow() }
-    exit(0)
+    close(fd)
+    if needsResponse { printBlock("Gavel: socket path too long") }
+    exit(needsResponse ? 2 : 0)
 }
 withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
     ptr.withMemoryRebound(to: CChar.self, capacity: pathBytes.count) { dest in
@@ -90,6 +95,7 @@ let connectResult = withUnsafePointer(to: &addr) { ptr in
 
 guard connectResult == 0 else {
     close(fd)
+    // Can't connect — daemon not running. Fail OPEN so Claude works without gavel.
     if needsResponse { printAllow() }
     exit(0)
 }
@@ -99,7 +105,7 @@ envelopeData.withUnsafeBytes { ptr in
     _ = write(fd, ptr.baseAddress!, envelopeData.count)
 }
 
-// For PreToolUse, read response and translate to Claude's format
+// For PreToolUse/PermissionRequest, read response and translate to Claude's format
 if needsResponse {
     shutdown(fd, SHUT_WR)
 
@@ -123,8 +129,7 @@ if needsResponse {
        let verdict = json["verdict"] as? String {
         if verdict == "block" {
             let reason = (json["reason"] as? String) ?? "Blocked by Gavel"
-            let msg = reason + "\n"
-            FileHandle.standardError.write(Data(msg.utf8))
+            printBlock(reason)
             exit(2)
         }
 
@@ -144,7 +149,6 @@ if needsResponse {
         if let updated = json["updatedInput"] as? [String: Any] {
             output["updatedInput"] = updated
         }
-        // Put additionalContext at both levels — docs are ambiguous on placement
         var wrapper: [String: Any] = ["hookSpecificOutput": output]
         if let ctx = json["additionalContext"] as? String, !ctx.isEmpty {
             wrapper["additionalContext"] = ctx
@@ -156,12 +160,9 @@ if needsResponse {
         }
     }
 
-    // Fallback allow (format depends on hook type)
-    if hookType == "PermissionRequest" {
-        printPermissionAllow()
-    } else {
-        printAllow()
-    }
+    // Daemon was reachable but response was empty/unparseable — FAIL CLOSED
+    printBlock("Gavel: daemon returned invalid response")
+    exit(2)
 } else {
     close(fd)
 }
@@ -174,6 +175,10 @@ func printAllow() {
 
 func printPermissionAllow() {
     print(#"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}"#)
+}
+
+func printBlock(_ reason: String) {
+    FileHandle.standardError.write(Data((reason + "\n").utf8))
 }
 
 // MARK: - Process tree walk (native, no subprocess)

--- a/Tests/GavelTests/PersistentRuleTests.swift
+++ b/Tests/GavelTests/PersistentRuleTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import Gavel
+
+final class PersistentRuleTests: XCTestCase {
+
+    // MARK: - Glob patterns
+
+    func testGlobMatchesWildcard() {
+        var rule = PersistentRule(toolName: "Bash", pattern: "swift build*", verdict: .allow)
+        XCTAssertTrue(rule.matches(toolName: "Bash", command: "swift build -c release", filePath: nil))
+        XCTAssertFalse(rule.matches(toolName: "Bash", command: "swift test", filePath: nil))
+    }
+
+    func testGlobWildcardMatchesAll() {
+        var rule = PersistentRule(toolName: "Read", pattern: "*", verdict: .allow)
+        XCTAssertTrue(rule.matches(toolName: "Read", command: nil, filePath: "/any/path"))
+    }
+
+    func testGlobWrongToolNoMatch() {
+        var rule = PersistentRule(toolName: "Bash", pattern: "ls*", verdict: .allow)
+        XCTAssertFalse(rule.matches(toolName: "Edit", command: "ls -la", filePath: nil))
+    }
+
+    // MARK: - Regex patterns
+
+    func testRegexNegativeLookahead() {
+        var rule = PersistentRule(toolName: "Bash", pattern: "doppler\\s+secrets\\b(?!.*--only-names)", isRegex: true, verdict: .block)
+        // Without --only-names → matches (blocked)
+        XCTAssertTrue(rule.matches(toolName: "Bash", command: "doppler secrets -p test -c dev", filePath: nil))
+        // With --only-names → no match (allowed through)
+        XCTAssertFalse(rule.matches(toolName: "Bash", command: "doppler secrets --only-names -p test", filePath: nil))
+        XCTAssertFalse(rule.matches(toolName: "Bash", command: "doppler secrets -p test --only-names", filePath: nil))
+    }
+
+    func testRegexPositiveMatch() {
+        var rule = PersistentRule(toolName: "Bash", pattern: "doppler\\s+secrets\\b.*--only-names", isRegex: true, verdict: .allow)
+        XCTAssertTrue(rule.matches(toolName: "Bash", command: "doppler secrets --only-names", filePath: nil))
+        XCTAssertTrue(rule.matches(toolName: "Bash", command: "doppler secrets -p test -c dev --only-names", filePath: nil))
+        XCTAssertFalse(rule.matches(toolName: "Bash", command: "doppler secrets -p test", filePath: nil))
+    }
+
+    func testRegexDopplerRunEnvBlocked() {
+        var rule = PersistentRule(toolName: "Bash", pattern: "doppler\\s+run\\b.*--\\s+(env|printenv|set)\\b", isRegex: true, verdict: .block)
+        XCTAssertTrue(rule.matches(toolName: "Bash", command: "doppler run -p test -c dev -- env 2>&1", filePath: nil))
+        XCTAssertTrue(rule.matches(toolName: "Bash", command: "doppler run -- printenv", filePath: nil))
+        XCTAssertFalse(rule.matches(toolName: "Bash", command: "doppler run -- python app.py", filePath: nil))
+    }
+
+    // MARK: - Backward compatibility
+
+    func testDecodesOldRulesWithoutIsRegex() throws {
+        let json = """
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "name": "Bash: git*",
+            "toolName": "Bash",
+            "pattern": "git*",
+            "verdict": "allow",
+            "createdAt": 797440000.0
+        }
+        """
+        let rule = try JSONDecoder().decode(PersistentRule.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(rule.isRegex, false)
+        XCTAssertEqual(rule.pattern, "git*")
+    }
+
+    // MARK: - Em-dash sanitization in match targets
+
+    func testEmDashSanitizedInTarget() {
+        var rule = PersistentRule(toolName: "Bash", pattern: "doppler\\s+secrets\\b.*--only-names", isRegex: true, verdict: .allow)
+        // Em-dash in command should be sanitized to ASCII before matching
+        let cmdWithEmDash = "doppler secrets \u{2014}only-names"
+        XCTAssertTrue(rule.matches(toolName: "Bash", command: cmdWithEmDash, filePath: nil))
+    }
+
+    // MARK: - Priority chain (deny wins over allow)
+
+    func testDenyWinsOverAllow() {
+        let store = RuleStore(configPath: "/dev/null")
+        // Add allow rule
+        store.addRule(PersistentRule(toolName: "Bash", pattern: "doppler*", verdict: .allow))
+        // Add deny rule
+        store.addRule(PersistentRule(toolName: "Bash", pattern: "doppler\\s+secrets\\b(?!.*--only-names)", isRegex: true, verdict: .block))
+
+        let payload = PreToolUsePayload(toolName: "Bash", toolInput: ["command": AnyCodable("doppler secrets")])
+
+        // Deny should fire first
+        let deny = store.evaluateDeny(payload: payload)
+        XCTAssertNotNil(deny)
+        XCTAssertEqual(deny?.verdict, .block)
+    }
+
+    // MARK: - Engine integration: persistent allow skips dialog
+
+    func testEngineReturnsAllowWithReasonForPersistentRule() {
+        let store = RuleStore(configPath: "/dev/null")
+        store.addRule(PersistentRule(toolName: "Bash", pattern: "git *", verdict: .allow))
+
+        let engine = ApprovalEngine(ruleStore: store)
+        let session = Session(pid: 99999)
+        let payload = PreToolUsePayload(toolName: "Bash", toolInput: ["command": AnyCodable("git status")])
+
+        let decision = engine.evaluate(payload: payload, session: session)
+        XCTAssertEqual(decision.verdict, .allow)
+        XCTAssertNotNil(decision.reason) // non-nil reason = skip dialog in HookRouter
+    }
+}

--- a/hooks/post_tool_use.sh
+++ b/hooks/post_tool_use.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Gavel PostToolUse hook — fire-and-forget to daemon.
-exec 2>/dev/null
-GAVEL_HOOK="${GAVEL_HOOK:-$(dirname "$0")/../.build/release/gavel-hook}"
+GAVEL_HOOK="${GAVEL_HOOK:-$HOME/.claude/gavel/bin/gavel-hook}"
+[[ -x "$GAVEL_HOOK" ]] || GAVEL_HOOK="$(dirname "$0")/../.build/release/gavel-hook"
 if [[ -x "$GAVEL_HOOK" ]]; then
     CLAUDE_HOOK_TYPE=PostToolUse exec "$GAVEL_HOOK"
 else

--- a/hooks/pre_tool_use.sh
+++ b/hooks/pre_tool_use.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 # Gavel PreToolUse hook — pipes stdin to daemon, prints response.
-# Preserve stderr for gavel-hook (it writes deny reasons there),
-# but suppress bash's own errors on fd 3.
-exec 3>&2
-GAVEL_HOOK="${GAVEL_HOOK:-$(dirname "$0")/../.build/release/gavel-hook}"
+# Checks installed path first, falls back to dev .build/ path.
+GAVEL_HOOK="${GAVEL_HOOK:-$HOME/.claude/gavel/bin/gavel-hook}"
+[[ -x "$GAVEL_HOOK" ]] || GAVEL_HOOK="$(dirname "$0")/../.build/release/gavel-hook"
 if [[ -x "$GAVEL_HOOK" ]]; then
     CLAUDE_HOOK_TYPE=PreToolUse exec "$GAVEL_HOOK"
 else
-    # Daemon not available — allow and skip Claude's own prompt
     cat > /dev/null
     echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
 fi

--- a/hooks/session_start.sh
+++ b/hooks/session_start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Gavel SessionStart hook — registers session with daemon.
-exec 2>/dev/null
-GAVEL_HOOK="${GAVEL_HOOK:-$(dirname "$0")/../.build/release/gavel-hook}"
+GAVEL_HOOK="${GAVEL_HOOK:-$HOME/.claude/gavel/bin/gavel-hook}"
+[[ -x "$GAVEL_HOOK" ]] || GAVEL_HOOK="$(dirname "$0")/../.build/release/gavel-hook"
 if [[ -x "$GAVEL_HOOK" ]]; then
     CLAUDE_HOOK_TYPE=SessionStart exec "$GAVEL_HOOK"
 else

--- a/hooks/stop.sh
+++ b/hooks/stop.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Gavel Stop hook — notifies daemon session is idle.
 # Daemon handles notifications via GavelNotifications.notify().
-GAVEL_HOOK="${GAVEL_HOOK:-$(dirname "$0")/../.build/release/gavel-hook}"
+GAVEL_HOOK="${GAVEL_HOOK:-$HOME/.claude/gavel/bin/gavel-hook}"
+[[ -x "$GAVEL_HOOK" ]] || GAVEL_HOOK="$(dirname "$0")/../.build/release/gavel-hook"
 if [[ -x "$GAVEL_HOOK" ]]; then
     CLAUDE_HOOK_TYPE=Stop exec "$GAVEL_HOOK"
 else

--- a/hooks/stop.sh
+++ b/hooks/stop.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 # Gavel Stop hook — notifies daemon session is idle.
-exec 2>/dev/null
+# Daemon handles notifications via GavelNotifications.notify().
 GAVEL_HOOK="${GAVEL_HOOK:-$(dirname "$0")/../.build/release/gavel-hook}"
 if [[ -x "$GAVEL_HOOK" ]]; then
     CLAUDE_HOOK_TYPE=Stop exec "$GAVEL_HOOK"
 else
     cat > /dev/null
 fi
-# Native macOS notification as fallback
-osascript -e 'display notification "Ready for input" with title "Claude Code" sound name "Glass"' 2>/dev/null &

--- a/install.sh
+++ b/install.sh
@@ -1,22 +1,56 @@
 #!/bin/bash
-# Install gavel — copies release binaries and restarts the daemon.
+# Install gavel — builds, installs binaries, hooks, LaunchAgent, and restarts.
 # Usage: ./install.sh
 
 set -e
 
 INSTALL_DIR="$HOME/.claude/gavel/bin"
+HOOKS_DIR="$HOME/.claude/gavel/hooks"
+PLIST_DIR="$HOME/Library/LaunchAgents"
 LABEL="com.gavel.daemon"
+PLIST="$PLIST_DIR/$LABEL.plist"
 
 echo "Building release..."
 swift build -c release
 
 echo "Installing binaries to $INSTALL_DIR..."
-mkdir -p "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR" "$HOOKS_DIR"
 cp .build/release/gavel .build/release/gavel-hook "$INSTALL_DIR/"
+
+echo "Installing hook shims to $HOOKS_DIR..."
+for f in hooks/*.sh; do
+    cp "$f" "$HOOKS_DIR/$(basename "$f")"
+    chmod +x "$HOOKS_DIR/$(basename "$f")"
+done
+
+echo "Installing LaunchAgent..."
+mkdir -p "$PLIST_DIR"
+cat > "$PLIST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$INSTALL_DIR/gavel</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>$HOME/.claude/gavel/gavel.log</string>
+    <key>StandardErrorPath</key>
+    <string>$HOME/.claude/gavel/gavel.log</string>
+</dict>
+</plist>
+PLIST
 
 echo "Restarting daemon..."
 launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
 sleep 1
-launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/$LABEL.plist"
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
 
 echo "Done. Gavel is running."


### PR DESCRIPTION
## Summary
Follow-up fixes after v1 merge:
- Regex pattern support in persistent rules (enables `doppler\s+secrets\b(?!.*--only-names)` style deny rules)
- Live pattern tester with dual Always Deny/Always Allow outcome badges
- Fail-closed hook shim (daemon reachable but invalid response → block, not allow)
- 24-hour timeout on approval (effectively no timeout)
- macOS smart dashes/quotes disabled app-wide
- Edit menu for Cmd+V/C/X/A support in approval panel
- install.sh generates LaunchAgent plist on fresh installs
- Dead code cleanup in stop.sh

## Test plan
- [x] 23 unit tests passing
- [x] Regex deny rule tested live: `doppler\s+secrets\b(?!.*--only-names)`
- [x] Pattern tester shows correct BLOCKED/ALLOWED for both rule types
- [x] Cmd+V paste working in all text fields
- [x] Smart dashes no longer corrupt regex patterns