### PR TITLE
Add crash logging, persistent defaults, sub-agent inheritance

### DIFF
--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -126,6 +126,15 @@ final class HookRouter {
             return
         }
 
+        // Stage 2.5: Sub-agent inheritance — auto-approve sub-agent calls
+        // (deny rules already checked in Stage 1, so blocks are respected)
+        if payload.isSubAgent && session.isSubAgentInheritEnabled {
+            session.allowCount += 1
+            emitFeed(.decision(badge: .autoApprove, reason: "Sub-agent: \(payload.agentType ?? "unknown")", pid: session.pid, at: timestamp))
+            sendResponse(Decision(verdict: .allow, reason: "Sub-agent inherited"), respond: respond)
+            return
+        }
+
         // Stage 3: Interactive approval (blocks until user responds)
         let decision = approvalCoordinator.requestApproval(
             payload: payload,

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -11,7 +11,16 @@ final class SessionManager: ObservableObject {
     private let cleanupInterval: TimeInterval = 5.0
     private var cleanupTimer: DispatchSourceTimer?
 
+    /// Default settings applied to new sessions (survives daemon restarts).
+    @Published var defaultAutoApprove: Bool = false
+    @Published var defaultSubAgentInherit: Bool = false
+
+    private static var defaultsPath: String {
+        FileManager.default.homeDirectoryForCurrentUser.path + "/.claude/gavel/session-defaults.json"
+    }
+
     init() {
+        loadDefaults()
         startCleanupTimer()
     }
 
@@ -20,6 +29,7 @@ final class SessionManager: ObservableObject {
     }
 
     /// Get or create a session for the given PID.
+    /// New sessions inherit the default Auto/Sub settings.
     func session(for pid: Int) -> Session {
         lock.lock()
         defer { lock.unlock() }
@@ -27,8 +37,28 @@ final class SessionManager: ObservableObject {
             return existing
         }
         let session = Session(pid: pid)
+        session.isAutoApproveEnabled = defaultAutoApprove
+        session.isSubAgentInheritEnabled = defaultSubAgentInherit
         sessions[pid] = session
         return session
+    }
+
+    /// Save current defaults to disk (called when user toggles).
+    func saveDefaults() {
+        let data: [String: Bool] = [
+            "autoApprove": defaultAutoApprove,
+            "subAgentInherit": defaultSubAgentInherit
+        ]
+        if let json = try? JSONSerialization.data(withJSONObject: data, options: .prettyPrinted) {
+            FileManager.default.createFile(atPath: Self.defaultsPath, contents: json)
+        }
+    }
+
+    private func loadDefaults() {
+        guard let data = FileManager.default.contents(atPath: Self.defaultsPath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Bool] else { return }
+        defaultAutoApprove = json["autoApprove"] ?? false
+        defaultSubAgentInherit = json["subAgentInherit"] ?? false
     }
 
     /// Remove a session (e.g., when the process exits).

--- a/Sources/Gavel/Models/HookEvent.swift
+++ b/Sources/Gavel/Models/HookEvent.swift
@@ -86,6 +86,8 @@ struct PreToolUsePayload: Codable {
     let cwd: String?
     let permissionMode: String?
     let toolUseId: String?
+    let agentId: String?
+    let agentType: String?
 
     enum CodingKeys: String, CodingKey {
         case toolName = "tool_name"
@@ -94,17 +96,24 @@ struct PreToolUsePayload: Codable {
         case cwd
         case permissionMode = "permission_mode"
         case toolUseId = "tool_use_id"
+        case agentId = "agent_id"
+        case agentType = "agent_type"
     }
+
+    var isSubAgent: Bool { agentId != nil }
 
     init(toolName: String, toolInput: [String: AnyCodable],
          sessionId: String? = nil, cwd: String? = nil,
-         permissionMode: String? = nil, toolUseId: String? = nil) {
+         permissionMode: String? = nil, toolUseId: String? = nil,
+         agentId: String? = nil, agentType: String? = nil) {
         self.toolName = toolName
         self.toolInput = toolInput
         self.sessionId = sessionId
         self.cwd = cwd
         self.permissionMode = permissionMode
         self.toolUseId = toolUseId
+        self.agentId = agentId
+        self.agentType = agentType
     }
 
     var command: String? {

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -11,6 +11,7 @@ final class Session: ObservableObject, Identifiable {
     @Published var isPaused: Bool = false
     @Published var isAlive: Bool = true
     @Published var isAutoApproveEnabled: Bool = false
+    @Published var isSubAgentInheritEnabled: Bool = false
     @Published var lastPrompt: String?
 
     // Timed auto-approve

--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -44,6 +44,10 @@ final class MonitorViewModel: ObservableObject {
         } else {
             approvalCoordinator.enableAutoApprove(for: session)
         }
+        // Persist as default for new sessions / daemon restarts
+        let allAuto = sessionManager.sessions.values.allSatisfy { $0.isAutoApproveEnabled }
+        sessionManager.defaultAutoApprove = allAuto
+        sessionManager.saveDefaults()
     }
 
     func togglePause() {
@@ -55,6 +59,13 @@ final class MonitorViewModel: ObservableObject {
     func revokeAutoApprove() {
         for session in sessionManager.sessions.values {
             session.revokeAutoApprove()
+        }
+    }
+
+    func setPinned(_ pinned: Bool) {
+        // Find the monitor window and set its level
+        for window in NSApp.windows where window.title.contains("Monitor") {
+            window.level = pinned ? .floating : .normal
         }
     }
 

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -3,14 +3,27 @@ import SwiftUI
 /// The main monitor window showing the live feed of all Claude Code sessions.
 struct MonitorWindow: View {
     @ObservedObject var viewModel: MonitorViewModel
+    @State private var isPinned: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
-            // Status bar
-            StatusView(viewModel: viewModel)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(Color(nsColor: .controlBackgroundColor))
+            // Status bar with pin toggle
+            HStack {
+                StatusView(viewModel: viewModel)
+                Spacer()
+                Button(action: { [vm = viewModel] in
+                    isPinned.toggle()
+                    vm.setPinned(isPinned)
+                }) {
+                    Image(systemName: isPinned ? "pin.fill" : "pin")
+                        .foregroundColor(isPinned ? .orange : .secondary)
+                }
+                .buttonStyle(.plain)
+                .help(isPinned ? "Unpin window" : "Pin window on top")
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color(nsColor: .controlBackgroundColor))
 
             Divider()
 
@@ -29,7 +42,6 @@ struct MonitorWindow: View {
 
     private var sessionControls: some View {
         VStack(spacing: 4) {
-            // Session rows with per-session auto-approve
             let sessions = Array(viewModel.sessionManager.sessions.values)
                 .sorted { $0.pid < $1.pid }
 
@@ -49,7 +61,6 @@ struct MonitorWindow: View {
             Divider()
                 .padding(.vertical, 2)
 
-            // Global controls
             HStack {
                 Button("Revoke All Rules") {
                     viewModel.revokeAutoApprove()
@@ -70,7 +81,6 @@ struct MonitorWindow: View {
 
     private func sessionRow(_ session: Session) -> some View {
         HStack(spacing: 8) {
-            // Session identity
             Circle()
                 .fill(session.isAlive ? .green : .gray)
                 .frame(width: 8, height: 8)
@@ -78,12 +88,6 @@ struct MonitorWindow: View {
             Text("PID \(session.pid)")
                 .font(.system(.caption, design: .monospaced))
                 .frame(width: 70, alignment: .leading)
-
-            if let sid = session.sessionId {
-                Text(String(sid.prefix(12)))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
 
             if let cwd = session.cwd {
                 Text(cwd.split(separator: "/").suffix(2).joined(separator: "/"))
@@ -93,6 +97,24 @@ struct MonitorWindow: View {
             }
 
             Spacer()
+
+            // Sub-agent inheritance toggle
+            Toggle(isOn: Binding(
+                get: { session.isSubAgentInheritEnabled },
+                set: { newVal in
+                    session.isSubAgentInheritEnabled = newVal
+                    let allSub = viewModel.sessionManager.sessions.values.allSatisfy { $0.isSubAgentInheritEnabled }
+                    viewModel.sessionManager.defaultSubAgentInherit = allSub
+                    viewModel.sessionManager.saveDefaults()
+                }
+            )) {
+                Text("Sub")
+                    .font(.caption)
+            }
+            .toggleStyle(.switch)
+            .tint(.cyan)
+            .controlSize(.small)
+            .help("Auto-approve sub-agent calls (deny rules still block)")
 
             // Per-session auto-approve toggle
             Toggle(isOn: Binding(

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -171,6 +171,38 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
 
 // MARK: - Launch
 
+// Crash logging — write last words before dying
+let logPath = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".claude/gavel/gavel.log").path
+
+func gavelLog(_ msg: String) {
+    let ts = ISO8601DateFormatter().string(from: Date())
+    let line = "[\(ts)] \(msg)\n"
+    if let fh = FileHandle(forWritingAtPath: logPath) {
+        fh.seekToEndOfFile()
+        fh.write(Data(line.utf8))
+        fh.closeFile()
+    } else {
+        FileManager.default.createFile(atPath: logPath, contents: Data(line.utf8))
+    }
+}
+
+// Catch uncaught exceptions
+NSSetUncaughtExceptionHandler { exception in
+    gavelLog("CRASH: \(exception.name.rawValue) — \(exception.reason ?? "no reason")")
+    gavelLog("STACK: \(exception.callStackSymbols.prefix(10).joined(separator: "\n  "))")
+}
+
+// Catch signals
+for sig: Int32 in [SIGABRT, SIGSEGV, SIGBUS, SIGILL, SIGFPE] {
+    signal(sig) { signum in
+        gavelLog("SIGNAL: \(signum)")
+        exit(signum)
+    }
+}
+
+gavelLog("Gavel starting")
+
 let app = NSApplication.shared
 let delegate = GavelAppDelegate()
 app.delegate = delegate


### PR DESCRIPTION
## Summary
- Crash logging: uncaught exception/signal handlers write stack traces to gavel.log
- Session defaults persist to disk — Auto/Sub toggles survive daemon restarts
- Sub-agent inheritance: per-session toggle auto-approves sub-agent calls while preserving deny rules
- Pin mode: keep monitor window always-on-top
- Reverted bash shim to clean exec path (removed broken subshell approach)

## Test plan
- [x] 33 tests passing
- [x] Daemon restart preserves Auto/Sub defaults
- [x] Sub-agent calls auto-approve with Sub toggle on
- [x] Deny rules still block under Sub-agent mode
- [x] Pin mode keeps monitor floating
- [x] Crash handler writes to gavel.log