### PR TITLE
Fix: persist pause state across daemon restarts

### DIFF
--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -14,6 +14,7 @@ final class SessionManager: ObservableObject {
     /// Default settings applied to new sessions (survives daemon restarts).
     @Published var defaultAutoApprove: Bool = false
     @Published var defaultSubAgentInherit: Bool = false
+    @Published var defaultPaused: Bool = false
 
     private static var defaultsPath: String {
         FileManager.default.homeDirectoryForCurrentUser.path + "/.claude/gavel/session-defaults.json"
@@ -39,6 +40,7 @@ final class SessionManager: ObservableObject {
         let session = Session(pid: pid)
         session.isAutoApproveEnabled = defaultAutoApprove
         session.isSubAgentInheritEnabled = defaultSubAgentInherit
+        session.isPaused = defaultPaused
         sessions[pid] = session
         return session
     }
@@ -47,7 +49,8 @@ final class SessionManager: ObservableObject {
     func saveDefaults() {
         let data: [String: Bool] = [
             "autoApprove": defaultAutoApprove,
-            "subAgentInherit": defaultSubAgentInherit
+            "subAgentInherit": defaultSubAgentInherit,
+            "paused": defaultPaused
         ]
         if let json = try? JSONSerialization.data(withJSONObject: data, options: .prettyPrinted) {
             FileManager.default.createFile(atPath: Self.defaultsPath, contents: json)
@@ -59,6 +62,7 @@ final class SessionManager: ObservableObject {
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Bool] else { return }
         defaultAutoApprove = json["autoApprove"] ?? false
         defaultSubAgentInherit = json["subAgentInherit"] ?? false
+        defaultPaused = json["paused"] ?? false
     }
 
     /// Remove a session (e.g., when the process exits).

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -130,6 +130,9 @@ struct MonitorWindow: View {
 
             Button(session.isPaused ? "Resume" : "Pause") {
                 session.isPaused.toggle()
+                let anyPaused = viewModel.sessionManager.sessions.values.contains { $0.isPaused }
+                viewModel.sessionManager.defaultPaused = anyPaused
+                viewModel.sessionManager.saveDefaults()
             }
             .buttonStyle(.bordered)
             .controlSize(.small)


### PR DESCRIPTION
## Summary
- Pause state was lost on daemon crash/restart, silently unpausing sessions
- Now `defaultPaused` persists to `session-defaults.json` alongside Auto and Sub
- Conservative: if ANY session was paused, new sessions start paused after restart

## Test plan
- [x] 33 tests passing
- [x] Pause toggle saves to session-defaults.json
- [x] Daemon restart preserves paused state