### PR TITLE
Fix SIGPIPE killing daemon when clients disconnect

### DIFF
--- a/Sources/Gavel/Daemon/SocketServer.swift
+++ b/Sources/Gavel/Daemon/SocketServer.swift
@@ -99,6 +99,10 @@ final class SocketServer {
     private func handleConnection(fd: Int32) {
         defer { close(fd) }
 
+        // Prevent SIGPIPE on this socket if client disconnects during write
+        var noSigPipe: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
+
         // Set read timeout (2 seconds)
         var timeout = timeval(tv_sec: 2, tv_usec: 0)
         setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -193,7 +193,10 @@ NSSetUncaughtExceptionHandler { exception in
     gavelLog("STACK: \(exception.callStackSymbols.prefix(10).joined(separator: "\n  "))")
 }
 
-// Catch signals
+// Ignore SIGPIPE — clients disconnect, we don't want to die
+signal(SIGPIPE, SIG_IGN)
+
+// Catch fatal signals
 for sig: Int32 in [SIGABRT, SIGSEGV, SIGBUS, SIGILL, SIGFPE] {
     signal(sig) { signum in
         gavelLog("SIGNAL: \(signum)")


### PR DESCRIPTION
## Summary
Root cause of daemon crashes: SIGPIPE (signal 13) when writing to disconnected client sockets. This caused 15+ silent restarts — crash handlers never fired because SIGPIPE wasn't caught.

- `signal(SIGPIPE, SIG_IGN)` at daemon startup
- `SO_NOSIGPIPE` on each client socket

## Test plan
- [x] 33 tests passing
- [x] Daemon stable under rapid client connect/disconnect