### PR TITLE
Fix AskUserQuestion bypass: passthrough instead of auto-approve

### DIFF
--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -36,6 +36,17 @@ final class HookRouter {
         case .preToolUse(let payload):
             if let sid = payload.sessionId { session.sessionId = sid }
             if let cwd = payload.cwd { session.cwd = cwd }
+
+            // AskUserQuestion and ExitPlanMode are user interaction tools —
+            // don't intercept, let Claude's built-in UI handle them
+            if ["AskUserQuestion", "ExitPlanMode"].contains(payload.toolName) {
+                if let respond = respond,
+                   let data = "{}".data(using: .utf8) {
+                    respond(data)
+                }
+                return
+            }
+
             handlePreToolUse(payload: payload, session: session, timestamp: ts, respond: respond)
 
         case .postToolUse(let payload):

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -46,9 +46,9 @@ final class SessionManager: ObservableObject {
     }
 
     /// Save current defaults to disk (called when user toggles).
+    /// Auto-approve is intentionally NOT persisted — new sessions must opt in.
     func saveDefaults() {
         let data: [String: Bool] = [
-            "autoApprove": defaultAutoApprove,
             "subAgentInherit": defaultSubAgentInherit,
             "paused": defaultPaused
         ]
@@ -60,7 +60,7 @@ final class SessionManager: ObservableObject {
     private func loadDefaults() {
         guard let data = FileManager.default.contents(atPath: Self.defaultsPath),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Bool] else { return }
-        defaultAutoApprove = json["autoApprove"] ?? false
+        // Auto-approve is never loaded from disk — always starts OFF (opt-in per session)
         defaultSubAgentInherit = json["subAgentInherit"] ?? false
         defaultPaused = json["paused"] ?? false
     }

--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -44,9 +44,8 @@ final class MonitorViewModel: ObservableObject {
         } else {
             approvalCoordinator.enableAutoApprove(for: session)
         }
-        // Persist as default for new sessions / daemon restarts
-        let allAuto = sessionManager.sessions.values.allSatisfy { $0.isAutoApproveEnabled }
-        sessionManager.defaultAutoApprove = allAuto
+        // Never persist auto-approve as default — new sessions must opt in explicitly.
+        // This prevents a minimized/hidden monitor from silently auto-approving new sessions.
         sessionManager.saveDefaults()
     }
 

--- a/Sources/GavelHook/main.swift
+++ b/Sources/GavelHook/main.swift
@@ -124,9 +124,20 @@ if needsResponse {
     }
     close(fd)
 
-    // Parse daemon response: {"verdict":"allow",...} or {"verdict":"block","reason":"..."}
-    if let json = try? JSONSerialization.jsonObject(with: response) as? [String: Any],
-       let verdict = json["verdict"] as? String {
+    // Parse daemon response: {"verdict":"allow",...} or {"verdict":"block","reason":"..."} or {} (passthrough)
+    if let json = try? JSONSerialization.jsonObject(with: response) as? [String: Any] {
+
+        // Empty {} = passthrough (daemon says "let Claude handle it")
+        if json.isEmpty {
+            print("{}")
+            exit(0)
+        }
+
+        guard let verdict = json["verdict"] as? String else {
+            // Has fields but no verdict — passthrough
+            print("{}")
+            exit(0)
+        }
         if verdict == "block" {
             let reason = (json["reason"] as? String) ?? "Blocked by Gavel"
             printBlock(reason)

--- a/hooks/permission_request.sh
+++ b/hooks/permission_request.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Gavel PermissionRequest hook — suppresses Claude's built-in permission dialogs.
-# The real approval decision already happened in PreToolUse via the daemon.
-# This hook just tells Claude to skip its own prompt.
-cat > /dev/null
-echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
+# Exception: AskUserQuestion must pass through so the user can actually answer.
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_name',''))" 2>/dev/null)
+
+if [[ "$TOOL" == "AskUserQuestion" || "$TOOL" == "ExitPlanMode" ]]; then
+    # Let Claude's built-in UI handle user interaction tools
+    echo '{}'
+else
+    echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
+fi


### PR DESCRIPTION
## Summary
AskUserQuestion was being auto-approved by gavel, preventing Claude's question dialog from showing. Users never saw the questions.

- Daemon returns `{}` (passthrough) for AskUserQuestion and ExitPlanMode
- gavel-hook treats empty `{}` as passthrough
- PermissionRequest hook passes through for user interaction tools
- Verified: dialog shows even with auto-approve ON

## Test plan
- [x] 103 tests passing
- [x] AskUserQuestion dialog shows with auto-approve OFF
- [x] AskUserQuestion dialog shows with auto-approve ON
- [x] User can answer questions and Claude receives responses