### PR TITLE
Add Always Prompt verdict, restore pin button

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -14,6 +14,7 @@ final class ApprovalCoordinator: ObservableObject {
         case allowPatternForSession(pattern: String, context: String?, updatedCommand: String?)
         case alwaysDenyPattern(pattern: String, isRegex: Bool)
         case alwaysAllowPattern(pattern: String, isRegex: Bool)
+        case alwaysPromptPattern(pattern: String, isRegex: Bool)
     }
 
     /// RuleStore for persistent always-deny/always-allow rules.
@@ -125,6 +126,14 @@ final class ApprovalCoordinator: ObservableObject {
             let rule = PersistentRule(toolName: current.payload.toolName, pattern: sanitized, isRegex: isRegex, verdict: .allow)
             ruleStore?.addRule(rule)
             current.respond(Decision(verdict: .allow, reason: "Always allow: \(current.payload.toolName): \(pattern)"))
+
+        case .alwaysPromptPattern(let pattern, let isRegex):
+            ctx = nil; updated = nil
+            let sanitized = Self.sanitizeDashes(pattern)
+            let rule = PersistentRule(toolName: current.payload.toolName, pattern: sanitized, isRegex: isRegex, verdict: .prompt)
+            ruleStore?.addRule(rule)
+            // For this invocation, still need user to decide — show as allow (they already saw the dialog)
+            current.respond(Decision(verdict: .allow, reason: "Always prompt rule saved: \(current.payload.toolName): \(pattern)"))
         }
 
         advanceQueue()

--- a/Sources/Gavel/Approval/ApprovalEngine.swift
+++ b/Sources/Gavel/Approval/ApprovalEngine.swift
@@ -35,23 +35,27 @@ final class ApprovalEngine {
             return Decision(verdict: .block, reason: "Session paused via Gavel")
         }
 
-        // 4. Persistent ALLOW rules
+        // 4. Persistent PROMPT rules — force dialog even under auto-approve
+        if let decision = ruleStore.evaluatePrompt(payload: payload) {
+            return decision
+        }
+
+        // 5. Persistent ALLOW rules
         if let decision = ruleStore.evaluateAllow(payload: payload) {
             return decision
         }
 
-        // 5. MCP tool blocking (after allow rules, so users can override)
-        // Returns .block but with askUser flag — router shows dialog instead of hard block
+        // 6. MCP tool blocking (after allow rules, so users can override)
         if let reason = patternMatcher.matchMcpDangerous(payload: payload) {
             return Decision(verdict: .block, reason: reason, askUser: true)
         }
 
-        // 6. Timed auto-approve
+        // 7. Timed auto-approve
         if session.isAutoApproveActive {
             return Decision(verdict: .allow, reason: "AUTO-APPROVED (timed)")
         }
 
-        // 7. Default: pass through (HookRouter decides: auto-approve, session rules, or dialog)
+        // 8. Default: pass through (HookRouter decides: auto-approve, session rules, or dialog)
         return Decision(verdict: .allow, reason: nil)
     }
 }

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -289,6 +289,15 @@ struct ApprovalPanelView: View {
                 .tint(.blue)
                 .keyboardShortcut("a", modifiers: [.command, .shift])
 
+                Button(action: {
+                    coordinator.handleAction(.alwaysPromptPattern(pattern: sessionPattern, isRegex: isRegexMode))
+                }) {
+                    Label("Always Prompt", systemImage: "bell.badge")
+                }
+                .buttonStyle(.bordered)
+                .tint(.yellow)
+                .keyboardShortcut("p", modifiers: [.command, .shift])
+
                 Spacer()
 
                 Button(action: {

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -39,6 +39,15 @@ final class RuleStore: ObservableObject {
         return nil
     }
 
+    func evaluatePrompt(payload: PreToolUsePayload) -> Decision? {
+        for i in rules.indices where rules[i].verdict == .prompt {
+            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
+                return Decision(verdict: .block, reason: "Always prompt: \(rules[i].name)", askUser: true)
+            }
+        }
+        return nil
+    }
+
     // MARK: - Rule Management
 
     func addRule(_ rule: PersistentRule) {

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -132,7 +132,7 @@ final class HookRouter {
                     forceDialog: true
                 )
                 switch decision.verdict {
-                case .allow:
+                case .allow, .prompt:
                     session.allowCount += 1
                     emitFeed(.decision(badge: .allow, reason: decision.reason, pid: session.pid, at: timestamp))
                 case .block:
@@ -194,7 +194,7 @@ final class HookRouter {
         )
 
         switch decision.verdict {
-        case .allow:
+        case .allow, .prompt:
             session.allowCount += 1
             emitFeed(.decision(badge: .allow, reason: decision.reason, pid: session.pid, at: timestamp))
         case .block:

--- a/Sources/Gavel/Models/Decision.swift
+++ b/Sources/Gavel/Models/Decision.swift
@@ -4,6 +4,7 @@ import Foundation
 enum DecisionVerdict: String, Codable {
     case allow
     case block
+    case prompt  // Always show interactive dialog, even under auto-approve
 }
 
 /// A decision returned to the hook shim via the Unix socket.
@@ -60,6 +61,9 @@ struct Decision: Codable {
                 return str
             }
             return #"{"verdict":"block","reason":"Blocked by Gavel"}"#
+        case .prompt:
+            // Prompt rules are handled in the router (show dialog) — should never reach hookResponse
+            return #"{"verdict":"block","reason":"Requires approval"}"#
         }
     }
 }

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -189,12 +189,12 @@ struct RulesView: View {
 
     private func ruleRow(_ rule: PersistentRule) -> some View {
         HStack(spacing: 6) {
-            Text(rule.verdict == .block ? "DENY" : "ALLOW")
+            Text(rule.verdict == .block ? "DENY" : rule.verdict == .prompt ? "PROMPT" : "ALLOW")
                 .font(.caption.bold())
                 .foregroundColor(.white)
                 .padding(.horizontal, 6)
                 .padding(.vertical, 2)
-                .background(rule.verdict == .block ? Color.red : Color.green)
+                .background(rule.verdict == .block ? Color.red : rule.verdict == .prompt ? Color.yellow : Color.green)
                 .cornerRadius(4)
 
             Text(rule.toolName)


### PR DESCRIPTION
## Summary
- **Always Prompt**: new persistent rule type (`.prompt` verdict) that forces the interactive dialog even under auto-approve. Yellow PROMPT badge in Rules tab.
- Restored pin button for monitor window
- Reverted monitor to standard NSWindow (AlwaysActivePanel override caused green circle bug)

## Test plan
- [x] 117 tests passing
- [x] Always Prompt button saves rule to rules.json
- [x] Prompt rules force dialog under auto-approve
- [x] Pin button toggles window level