### PR TITLE
Refactor: extract TaintTracker, add Constants

### DIFF
--- a/Sources/Gavel/Approval/TaintTracker.swift
+++ b/Sources/Gavel/Approval/TaintTracker.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Tracks sensitive data flow across tool calls to detect multi-step exfiltration.
+///
+/// When a command copies sensitive data (SSH keys, AWS creds, etc.) to a temp/intermediate
+/// file, that path is "tainted." If a later command sends a tainted file over the network
+/// or executes a tainted binary, it is blocked.
+///
+/// This catches attacks that split "read credentials" and "send data" across separate
+/// Bash calls where each individual call looks innocent.
+struct TaintTracker {
+
+    /// File paths that contain sensitive data -- when referenced in a command
+    /// that redirects/copies output, the destination becomes tainted.
+    private static let sensitiveSourcePatterns = [
+        "\\.ssh/", "\\.gnupg/", "\\.aws/", "\\.kube/config",
+        "\\.env$", "\\.npmrc$", "\\.netrc$", "\\.docker/config",
+    ]
+
+    /// Commands that can send data over the network -- used to detect
+    /// exfiltration of tainted files.
+    private static let networkExfilPatterns = [
+        "\\bcurl\\b", "\\bwget\\b", "\\bscp\\b", "\\brsync\\b",
+        "\\bpython3?\\b.*\\b(urlopen|requests|socket)",
+        "\\bnc\\b", "\\bncat\\b", "\\bopenssl\\b.*s_client",
+    ]
+
+    /// Check if a command exfiltrates or executes any tainted file.
+    /// Returns a block reason if detected, nil if safe.
+    static func checkExfiltration(command: String, taintedPaths: Set<String>) -> String? {
+        guard !taintedPaths.isEmpty else { return nil }
+        let range = NSRange(command.startIndex..., in: command)
+
+        for taintedPath in taintedPaths {
+            guard command.contains(taintedPath) else { continue }
+
+            if let reason = checkNetworkExfil(command: command, taintedPath: taintedPath, range: range) {
+                return reason
+            }
+            if let reason = checkDirectExecution(command: command, taintedPath: taintedPath, range: range) {
+                return reason
+            }
+        }
+        return nil
+    }
+
+    /// Record new tainted paths from a command that copies sensitive data.
+    static func recordTaints(command: String, into taintedPaths: inout Set<String>) {
+        guard referencesSensitiveSource(command) else { return }
+        extractRedirectTarget(from: command, into: &taintedPaths)
+        extractCompileOutput(from: command, into: &taintedPaths)
+        extractCopyDestination(from: command, into: &taintedPaths)
+    }
+
+    // MARK: - Private
+
+    private static func checkNetworkExfil(command: String, taintedPath: String, range: NSRange) -> String? {
+        for pattern in networkExfilPatterns {
+            if let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
+               regex.firstMatch(in: command, range: range) != nil {
+                return "Taint detected: \(taintedPath) contains sensitive data and is being sent over network"
+            }
+        }
+        return nil
+    }
+
+    private static func checkDirectExecution(command: String, taintedPath: String, range: NSRange) -> String? {
+        let escapedPath = NSRegularExpression.escapedPattern(for: taintedPath)
+        let positions = [
+            "^\\s*\(escapedPath)\\b",
+            "&&\\s*\(escapedPath)\\b",
+            ";\\s*\(escapedPath)\\b",
+            "\\|\\s*\(escapedPath)\\b",
+        ]
+        for pattern in positions {
+            if let regex = try? NSRegularExpression(pattern: pattern),
+               regex.firstMatch(in: command, range: range) != nil {
+                return "Taint detected: executing Claude-compiled binary \(taintedPath)"
+            }
+        }
+        return nil
+    }
+
+    private static func referencesSensitiveSource(_ command: String) -> Bool {
+        let range = NSRange(command.startIndex..., in: command)
+        for pattern in sensitiveSourcePatterns {
+            if let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
+               regex.firstMatch(in: command, range: range) != nil {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func extractRedirectTarget(from command: String, into paths: inout Set<String>) {
+        guard let regex = try? NSRegularExpression(pattern: #">>?\s*(\S+)"#),
+              let match = regex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)),
+              let pathRange = Range(match.range(at: 1), in: command) else { return }
+        paths.insert(String(command[pathRange]))
+    }
+
+    private static func extractCompileOutput(from command: String, into paths: inout Set<String>) {
+        if let regex = try? NSRegularExpression(pattern: #"\b(gcc|g\+\+|clang|rustc|swiftc|javac)\b.*-o\s+(\S+)"#),
+           let match = regex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)),
+           let pathRange = Range(match.range(at: 2), in: command) {
+            paths.insert(String(command[pathRange]))
+        }
+        if let regex = try? NSRegularExpression(pattern: #"\bgo\s+build\b.*-o\s+(\S+)"#),
+           let match = regex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)),
+           let pathRange = Range(match.range(at: 1), in: command) {
+            paths.insert(String(command[pathRange]))
+        }
+    }
+
+    private static func extractCopyDestination(from command: String, into paths: inout Set<String>) {
+        guard let regex = try? NSRegularExpression(pattern: #"\b(cp|mv)\b\s+\S+\s+(/\S+)"#),
+              let match = regex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)),
+              let pathRange = Range(match.range(at: 2), in: command) else { return }
+        paths.insert(String(command[pathRange]))
+    }
+}

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -39,7 +39,7 @@ final class HookRouter {
 
             // AskUserQuestion and ExitPlanMode are user interaction tools —
             // don't intercept, let Claude's built-in UI handle them
-            if ["AskUserQuestion", "ExitPlanMode"].contains(payload.toolName) {
+            if GavelConstants.userInteractionTools.contains(payload.toolName) {
                 if let respond = respond,
                    let data = "{}".data(using: .utf8) {
                     respond(data)
@@ -101,23 +101,19 @@ final class HookRouter {
             at: timestamp
         ))
 
-        // Stage 0a: Track files Claude writes (for execution taint checking)
+        // Stage 0: Taint tracking — detect multi-step exfiltration
         if ["Write", "Edit", "MultiEdit"].contains(payload.toolName), let path = payload.filePath {
             session.taintedPaths.insert(path)
         }
-
-        // Stage 0b: Taint tracking — check if command exfiltrates tainted data
         if payload.toolName == "Bash", let command = payload.command {
-            // Check if this command sends a tainted file over the network
-            if let taintReason = checkTaintedExfil(command: command, session: session) {
+            if let taintReason = TaintTracker.checkExfiltration(command: command, taintedPaths: session.taintedPaths) {
                 let decision = Decision(verdict: .block, reason: taintReason)
                 session.blockCount += 1
                 emitFeed(.decision(badge: .block, reason: taintReason, pid: session.pid, at: timestamp))
                 sendResponse(decision, respond: respond)
                 return
             }
-            // Track new taints: commands that copy sensitive data to temp paths
-            trackTaint(command: command, session: session)
+            TaintTracker.recordTaints(command: command, into: &session.taintedPaths)
         }
 
         // Stage 1: Check engine (dangerous patterns, persistent deny/allow, pause)
@@ -225,97 +221,6 @@ final class HookRouter {
 
         if !output.isEmpty {
             emitFeed(.toolResult(output: output, pid: session.pid, at: timestamp))
-        }
-    }
-
-    // MARK: - Taint Tracking
-
-    /// Sensitive path patterns that, when read/copied, taint the destination.
-    private static let sensitiveSources = [
-        "\\.ssh/", "\\.gnupg/", "\\.aws/", "\\.kube/config",
-        "\\.env$", "\\.npmrc$", "\\.netrc$", "\\.docker/config",
-    ]
-
-    /// Network commands that could exfiltrate tainted data.
-    private static let networkCommands = [
-        "\\bcurl\\b", "\\bwget\\b", "\\bscp\\b", "\\brsync\\b",
-        "\\bpython3?\\b.*\\b(urlopen|requests|socket)",
-        "\\bnc\\b", "\\bncat\\b", "\\bopenssl\\b.*s_client",
-    ]
-
-    /// Check if a command references any tainted file in a dangerous context.
-    private func checkTaintedExfil(command: String, session: Session) -> String? {
-        guard !session.taintedPaths.isEmpty else { return nil }
-
-        for taintedPath in session.taintedPaths {
-            guard command.contains(taintedPath) else { continue }
-
-            // Check if tainted file is being sent over network
-            for pattern in Self.networkCommands {
-                if let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
-                   regex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)) != nil {
-                    return "Taint detected: \(taintedPath) contains sensitive data and is being sent over network"
-                }
-            }
-
-            // Check if tainted file is being executed directly (compiled binary from Claude-written source)
-            // Match: /path/to/binary at start of command, after &&, after ;, or after |
-            let execPatterns = [
-                "^\\s*\(NSRegularExpression.escapedPattern(for: taintedPath))\\b",
-                "&&\\s*\(NSRegularExpression.escapedPattern(for: taintedPath))\\b",
-                ";\\s*\(NSRegularExpression.escapedPattern(for: taintedPath))\\b",
-                "\\|\\s*\(NSRegularExpression.escapedPattern(for: taintedPath))\\b",
-            ]
-            for pattern in execPatterns {
-                if let regex = try? NSRegularExpression(pattern: pattern),
-                   regex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)) != nil {
-                    return "Taint detected: executing Claude-compiled binary \(taintedPath)"
-                }
-            }
-        }
-        return nil
-    }
-
-    /// Track commands that copy sensitive data to temp/intermediate files.
-    /// e.g., "cat ~/.ssh/id_rsa > /tmp/key.txt" taints /tmp/key.txt
-    private func trackTaint(command: String, session: Session) {
-        // Check if any sensitive source is referenced
-        var hasSensitiveSource = false
-        for pattern in Self.sensitiveSources {
-            if let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
-               regex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)) != nil {
-                hasSensitiveSource = true
-                break
-            }
-        }
-        guard hasSensitiveSource else { return }
-
-        // Look for output redirection to a file: > /path or > relative_path or >> /path
-        if let redirectRegex = try? NSRegularExpression(pattern: #">>?\s*(\S+)"#),
-           let match = redirectRegex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)) {
-            let pathRange = Range(match.range(at: 1), in: command)!
-            let taintedPath = String(command[pathRange])
-            session.taintedPaths.insert(taintedPath)
-        }
-
-        // Look for compile outputs: gcc -o /path/binary, go build -o /path/binary, etc.
-        if let outputRegex = try? NSRegularExpression(pattern: #"\b(gcc|g\+\+|clang|rustc|swiftc|javac)\b.*-o\s+(\S+)"#),
-           let match = outputRegex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)) {
-            let pathRange = Range(match.range(at: 2), in: command)!
-            session.taintedPaths.insert(String(command[pathRange]))
-        }
-        if let goOutputRegex = try? NSRegularExpression(pattern: #"\bgo\s+build\b.*-o\s+(\S+)"#),
-           let match = goOutputRegex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)) {
-            let pathRange = Range(match.range(at: 1), in: command)!
-            session.taintedPaths.insert(String(command[pathRange]))
-        }
-
-        // Look for cp/mv destination: cp source dest
-        if let cpRegex = try? NSRegularExpression(pattern: #"\b(cp|mv)\b\s+\S+\s+(/\S+)"#),
-           let match = cpRegex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)) {
-            let pathRange = Range(match.range(at: 2), in: command)!
-            let taintedPath = String(command[pathRange])
-            session.taintedPaths.insert(taintedPath)
         }
     }
 

--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -13,7 +13,7 @@ final class MonitorViewModel: ObservableObject {
 
     let approvalCoordinator: ApprovalCoordinator
     let sessionManager: SessionManager
-    private let maxFeedEntries = 2000
+    private let maxFeedEntries = GavelConstants.maxFeedEntries
     private let startTime = Date()
     private var cancellables = Set<AnyCancellable>()
     private var statsTimer: Timer?

--- a/Sources/Gavel/System/Constants.swift
+++ b/Sources/Gavel/System/Constants.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Shared constants used across the gavel daemon.
+enum GavelConstants {
+    /// 24 hours in seconds — effectively no timeout for interactive approval.
+    /// Long enough for user to return from AFK, short enough to not hang forever.
+    static let approvalTimeoutSeconds: TimeInterval = 86400
+
+    /// Maximum feed entries before oldest are dropped to prevent unbounded memory growth.
+    static let maxFeedEntries = 2000
+
+    /// Socket read buffer size (64KB chunks).
+    static let socketBufferSize = 64 * 1024
+
+    /// Socket read timeout in seconds.
+    static let socketReadTimeoutSeconds: Int = 2
+
+    /// Stats update interval in seconds.
+    static let statsUpdateInterval: TimeInterval = 2.0
+
+    /// Session cleanup check interval in seconds.
+    static let sessionCleanupInterval: TimeInterval = 5.0
+
+    /// Grace period before removing dead sessions.
+    static let sessionRemovalGraceSeconds: TimeInterval = 3.0
+
+    /// Minimum content length to scan for dangerous patterns.
+    /// Short content can't contain both file I/O and network code.
+    static let minContentScanLength = 50
+
+    /// Tools that are user interaction, not tool execution.
+    /// These should pass through to Claude's built-in UI.
+    static let userInteractionTools = ["AskUserQuestion", "ExitPlanMode"]
+}


### PR DESCRIPTION
## Summary
Engineering principles refactor (first pass):
- Extract TaintTracker from HookRouter (single responsibility)
- Add GavelConstants for magic numbers
- HookRouter: 358 → 274 lines

## Test plan
- [x] 117 tests passing
- [x] Taint tracking behavior unchanged