### PR TITLE
Rule management UI: editor, tester, import/export, cheat sheet

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -24,6 +24,7 @@ final class ApprovalCoordinator: ObservableObject {
         let payload: PreToolUsePayload
         let session: Session
         let timestamp: Date
+        let forceDialog: Bool
         let respond: (Decision) -> Void
     }
 
@@ -52,7 +53,8 @@ final class ApprovalCoordinator: ObservableObject {
         let pending = PendingApproval(
             payload: payload,
             session: session,
-            timestamp: timestamp
+            timestamp: timestamp,
+            forceDialog: forceDialog
         ) { decision in
             result = decision
             semaphore.signal()
@@ -140,16 +142,17 @@ final class ApprovalCoordinator: ObservableObject {
     }
 
     /// Enable auto-approve for a session and flush its pending approvals.
+    /// Forced dialogs (from prompt rules / MCP blocks) are NOT flushed — they require explicit action.
     func enableAutoApprove(for session: Session) {
         session.isAutoApproveEnabled = true
 
-        // Flush current if it belongs to this session
-        if let current = currentApproval, current.session.pid == session.pid {
+        // Flush current if it belongs to this session — but not if forced
+        if let current = currentApproval, current.session.pid == session.pid, !current.forceDialog {
             current.respond(Decision(verdict: .allow, reason: "Auto-approved"))
             currentApproval = nil
         }
-        // Flush queued items for this session
-        let (forSession, remaining) = pendingQueue.partitioned { $0.session.pid == session.pid }
+        // Flush queued items for this session — but not forced ones
+        let (forSession, remaining) = pendingQueue.partitioned { $0.session.pid == session.pid && !$0.forceDialog }
         for pending in forSession {
             pending.respond(Decision(verdict: .allow, reason: "Auto-approved"))
         }

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -167,7 +167,20 @@ struct PersistentRule: Codable, Identifiable {
             .replacingOccurrences(of: "\u{2012}", with: "-")
 
         guard let regex = compiledRegex else { return false }
-        return regex.firstMatch(in: target, range: NSRange(target.startIndex..., in: target)) != nil
+
+        // Match against command/filePath first
+        if regex.firstMatch(in: target, range: NSRange(target.startIndex..., in: target)) != nil {
+            return true
+        }
+
+        // For wildcard rules, also match against the tool name itself.
+        // MCP tools carry their identity in the name (e.g. mcp__LinkedIn__linkedin_create_post)
+        // and typically have no command or filePath.
+        if self.toolName == "*" {
+            return regex.firstMatch(in: toolName, range: NSRange(toolName.startIndex..., in: toolName)) != nil
+        }
+
+        return false
     }
 
     /// Compile a pattern to regex. Glob patterns are converted; regex patterns used as-is.

--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -11,6 +11,11 @@ final class MonitorViewModel: ObservableObject {
     @Published var statsText: String = "Tools: 0 | Allow: 0 | Block: 0"
     @Published var uptimeText: String = "0m"
 
+    // Regex tester state (persists across tab switches)
+    @Published var testerPattern: String = ""
+    @Published var testerTestString: String = ""
+    @Published var testerIsRegex: Bool = true
+
     let approvalCoordinator: ApprovalCoordinator
     let sessionManager: SessionManager
     private let maxFeedEntries = GavelConstants.maxFeedEntries

--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -69,8 +69,32 @@ final class MonitorViewModel: ObservableObject {
         approvalCoordinator.ruleStore?.rules ?? []
     }
 
+    func addRule(_ rule: PersistentRule) {
+        approvalCoordinator.ruleStore?.addRule(rule)
+    }
+
     func deleteRule(id: UUID) {
         approvalCoordinator.ruleStore?.removeRule(id: id)
+    }
+
+    func exportRules(to url: URL) throws {
+        guard let rules = approvalCoordinator.ruleStore?.rules else { return }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(rules)
+        try data.write(to: url)
+    }
+
+    /// Import rules from a JSON file. Returns the number of rules imported.
+    @discardableResult
+    func importRules(from url: URL) throws -> Int {
+        let data = try Data(contentsOf: url)
+        let rules = try JSONDecoder().decode([PersistentRule].self, from: data)
+        guard !rules.isEmpty else { return 0 }
+        for rule in rules {
+            approvalCoordinator.ruleStore?.addRule(rule)
+        }
+        return rules.count
     }
 
     func killSession() {

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
-/// The main monitor window showing the live feed and rules editor.
+/// The main monitor window showing the live feed, rules editor, regex tester, and cheat sheet.
 struct MonitorWindow: View {
     @ObservedObject var viewModel: MonitorViewModel
     @State private var isPinned: Bool = false
     @State private var selectedTab: MonitorTab = .feed
 
     enum MonitorTab {
-        case feed, rules
+        case feed, rules, tester, reference
     }
 
     var body: some View {
@@ -38,6 +38,8 @@ struct MonitorWindow: View {
             Picker("", selection: $selectedTab) {
                 Text("Feed").tag(MonitorTab.feed)
                 Text("Rules (\(viewModel.ruleCount))").tag(MonitorTab.rules)
+                Text("Tester").tag(MonitorTab.tester)
+                Text("Reference").tag(MonitorTab.reference)
             }
             .pickerStyle(.segmented)
             .padding(.horizontal, 8)
@@ -51,6 +53,10 @@ struct MonitorWindow: View {
                 FeedView(entries: viewModel.feedEntries)
             case .rules:
                 RulesView(viewModel: viewModel)
+            case .tester:
+                RegexTesterView()
+            case .reference:
+                RegexCheatSheetView()
             }
 
             Divider()
@@ -163,55 +169,215 @@ struct MonitorWindow: View {
     }
 }
 
-// MARK: - Rules View
+// MARK: - Rules View (enhanced with add form + import/export)
 
 struct RulesView: View {
     @ObservedObject var viewModel: MonitorViewModel
+    @State private var newPattern: String = ""
+    @State private var newToolName: String = "*"
+    @State private var newIsRegex: Bool = false
+    @State private var newVerdict: DecisionVerdict = .block
+    @State private var importError: String?
+
+    private let toolOptions = ["*", "Bash", "Edit", "MultiEdit", "Write", "Read", "Glob", "Grep", "Agent"]
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 8) {
-                if viewModel.persistentRules.isEmpty {
-                    Text("No persistent rules. Use the approval panel to add Always Deny / Always Allow rules.")
-                        .foregroundColor(.secondary)
-                        .padding()
-                } else {
-                    ForEach(viewModel.persistentRules) { rule in
-                        ruleRow(rule)
+        VStack(spacing: 0) {
+            // Add rule form
+            addRuleForm
+                .padding(10)
+                .background(Color(nsColor: .controlBackgroundColor))
+
+            Divider()
+
+            // Import/Export bar
+            importExportBar
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+
+            Divider()
+
+            // Existing rules list
+            ScrollView {
+                VStack(alignment: .leading, spacing: 4) {
+                    if viewModel.persistentRules.isEmpty {
+                        Text("No rules yet. Add one above or use the approval panel.")
+                            .foregroundColor(.secondary)
+                            .padding()
+                    } else {
+                        ForEach(viewModel.persistentRules) { rule in
+                            ruleRow(rule)
+                        }
                     }
                 }
+                .padding(8)
             }
-            .padding(8)
+            .font(.system(.caption, design: .monospaced))
+            .background(Color(nsColor: .textBackgroundColor))
         }
-        .font(.system(.caption, design: .monospaced))
-        .background(Color(nsColor: .textBackgroundColor))
     }
+
+    // MARK: - Add Rule Form
+
+    private var addRuleForm: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 8) {
+                // Tool picker
+                Picker("", selection: $newToolName) {
+                    ForEach(toolOptions, id: \.self) { tool in
+                        Text(tool).tag(tool)
+                    }
+                }
+                .frame(width: 100)
+
+                Text(":")
+                    .font(.system(.body, design: .monospaced).bold())
+                    .foregroundColor(.secondary)
+
+                // Pattern input
+                HStack(spacing: 2) {
+                    if newIsRegex {
+                        Text("/").font(.system(.body, design: .monospaced)).foregroundColor(.orange)
+                    }
+                    TextField(newIsRegex ? "regex pattern" : "glob pattern (* = wildcard)", text: $newPattern)
+                        .font(.system(.body, design: .monospaced))
+                        .textFieldStyle(.roundedBorder)
+                    if newIsRegex {
+                        Text("/").font(.system(.body, design: .monospaced)).foregroundColor(.orange)
+                    }
+                }
+
+                Toggle("Regex", isOn: $newIsRegex)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .tint(.orange)
+            }
+
+            HStack(spacing: 8) {
+                // Verdict picker
+                Picker("", selection: $newVerdict) {
+                    Text("Always Block").tag(DecisionVerdict.block)
+                    Text("Always Allow").tag(DecisionVerdict.allow)
+                    Text("Always Ask").tag(DecisionVerdict.prompt)
+                }
+                .pickerStyle(.segmented)
+
+                Button(action: addRule) {
+                    Label("Add Rule", systemImage: "plus.circle")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(verdictColor(newVerdict))
+                .disabled(newPattern.isEmpty)
+            }
+        }
+    }
+
+    private func addRule() {
+        guard !newPattern.isEmpty else { return }
+        let sanitized = ApprovalCoordinator.sanitizeDashes(newPattern)
+        let rule = PersistentRule(
+            toolName: newToolName,
+            pattern: sanitized,
+            isRegex: newIsRegex,
+            verdict: newVerdict
+        )
+        viewModel.addRule(rule)
+        newPattern = ""
+    }
+
+    // MARK: - Import/Export
+
+    private var importExportBar: some View {
+        HStack(spacing: 8) {
+            Button(action: exportRules) {
+                Label("Export", systemImage: "square.and.arrow.up")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+
+            Button(action: importRules) {
+                Label("Import", systemImage: "square.and.arrow.down")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+
+            if let error = importError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.red)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Text("\(viewModel.ruleCount) rules")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private func exportRules() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.nameFieldStringValue = "gavel-rules.json"
+        panel.title = "Export Gavel Rules"
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            try viewModel.exportRules(to: url)
+            importError = nil
+        } catch {
+            importError = "Export failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func importRules() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.json]
+        panel.allowsMultipleSelection = false
+        panel.title = "Import Gavel Rules"
+        panel.message = "Imported rules will be added to your existing rules."
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            let count = try viewModel.importRules(from: url)
+            importError = nil
+            if count == 0 {
+                importError = "No valid rules found in file"
+            }
+        } catch {
+            importError = "Import failed: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Rule Row
 
     private func ruleRow(_ rule: PersistentRule) -> some View {
         HStack(spacing: 6) {
-            Text(rule.verdict == .block ? "DENY" : rule.verdict == .prompt ? "PROMPT" : "ALLOW")
+            Text(verdictLabel(rule.verdict))
                 .font(.caption.bold())
                 .foregroundColor(.white)
                 .padding(.horizontal, 6)
                 .padding(.vertical, 2)
-                .background(rule.verdict == .block ? Color.red : rule.verdict == .prompt ? Color.yellow : Color.green)
+                .background(verdictColor(rule.verdict))
                 .cornerRadius(4)
 
             Text(rule.toolName)
                 .foregroundColor(.orange)
-                .frame(width: 50, alignment: .leading)
+                .frame(width: 60, alignment: .leading)
 
             HStack(spacing: 2) {
                 if rule.isRegex {
-                    Text("/")
-                        .foregroundColor(.orange)
+                    Text("/").foregroundColor(.orange)
                 }
                 Text(rule.pattern)
                     .foregroundColor(.primary)
                     .lineLimit(1)
                 if rule.isRegex {
-                    Text("/")
-                        .foregroundColor(.orange)
+                    Text("/").foregroundColor(.orange)
                 }
             }
 
@@ -230,5 +396,23 @@ struct RulesView: View {
         .padding(.vertical, 4)
         .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
         .cornerRadius(4)
+    }
+
+    // MARK: - Helpers
+
+    private func verdictLabel(_ verdict: DecisionVerdict) -> String {
+        switch verdict {
+        case .block: return "DENY"
+        case .allow: return "ALLOW"
+        case .prompt: return "ASK"
+        }
+    }
+
+    private func verdictColor(_ verdict: DecisionVerdict) -> Color {
+        switch verdict {
+        case .block: return .red
+        case .allow: return .green
+        case .prompt: return .yellow
+        }
     }
 }

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -54,7 +54,7 @@ struct MonitorWindow: View {
             case .rules:
                 RulesView(viewModel: viewModel)
             case .tester:
-                RegexTesterView()
+                RegexTesterView(viewModel: viewModel)
             case .reference:
                 RegexCheatSheetView()
             }
@@ -322,6 +322,8 @@ struct RulesView: View {
         panel.allowedContentTypes = [.json]
         panel.nameFieldStringValue = "gavel-rules.json"
         panel.title = "Export Gavel Rules"
+        panel.canCreateDirectories = true
+        panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
 
         guard panel.runModal() == .OK, let url = panel.url else { return }
 

--- a/Sources/Gavel/Monitor/RegexCheatSheetView.swift
+++ b/Sources/Gavel/Monitor/RegexCheatSheetView.swift
@@ -59,16 +59,16 @@ struct RegexCheatSheetView: View {
                     row("Sources/*", "Matches any path under Sources/")
                 }
 
-                section("Common Gavel Patterns") {
-                    example("Block git push to main",
-                            "git\\s+push\\b.*\\b(main|master)\\b")
-                    example("Allow git but not push",
-                            "git\\s+(?!push)\\w+")
-                    example("Block secrets except --only-names",
-                            "doppler\\s+secrets\\b(?!.*--only-names)")
-                    example("Allow npm/yarn commands",
-                            "(npm|yarn)\\s+\\w+")
-                }
+                Divider()
+
+                bashExamples
+                editExamples
+                writeExamples
+                readExamples
+                globGrepExamples
+                agentExamples
+                mcpExamples
+                wildcardExamples
             }
             .padding(12)
         }
@@ -113,6 +113,118 @@ struct RegexCheatSheetView: View {
                 .padding(.vertical, 2)
                 .background(Color.green.opacity(0.1))
                 .cornerRadius(3)
+        }
+    }
+
+    private func toolNote(_ text: String) -> some View {
+        Text(text)
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .italic()
+    }
+
+    // MARK: - Tool-Specific Example Sections
+
+    private var bashExamples: some View {
+        section("Bash Examples") {
+            example("Block push to main/master",
+                    "git\\s+push\\b.*\\b(main|master)\\b")
+            example("Block force push anywhere",
+                    "git\\s+push\\b.*(-f|--force)\\b")
+            example("Block git reset --hard",
+                    "git\\s+reset\\s+--hard")
+            example("Allow git (except push)",
+                    "git\\s+(?!push)\\w+")
+            example("Allow npm/yarn commands",
+                    "(npm|yarn)\\s+\\w+")
+            example("Allow swift build/test only",
+                    "swift\\s+(build|test)\\b")
+            example("Block rm -rf outside /tmp",
+                    "rm\\s+-\\w*r\\w*\\s+/(?!tmp)")
+            example("Block secrets except safe flags",
+                    "doppler\\s+secrets\\b(?!.*--only-names)")
+            example("Block docker push",
+                    "docker\\s+push\\b")
+        }
+    }
+
+    private var editExamples: some View {
+        section("Edit / MultiEdit Examples") {
+            toolNote("Pattern matches against the file path")
+            example("Allow edits under Sources/",
+                    "Sources/.*")
+            example("Block edits to config files",
+                    "\\.(json|yaml|yml|toml)$")
+            example("Allow edits to Swift files only",
+                    ".*\\.swift$")
+            example("Block edits to dotfiles",
+                    "/Users/.*/\\.\\w+")
+        }
+    }
+
+    private var writeExamples: some View {
+        section("Write Examples") {
+            toolNote("Pattern matches against the file path")
+            example("Allow writes under src/",
+                    "src/.*")
+            example("Block writes to /tmp",
+                    "/tmp/.*")
+            example("Block writes to hidden dirs",
+                    "/Users/.*/\\.\\w+/")
+        }
+    }
+
+    private var readExamples: some View {
+        section("Read Examples") {
+            toolNote("Pattern matches against the file path")
+            example("Allow reading any file",
+                    "*")
+            example("Block reading env files",
+                    "\\.env(\\.local)?$")
+        }
+    }
+
+    private var globGrepExamples: some View {
+        section("Glob / Grep Examples") {
+            toolNote("Pattern matches against the search path or pattern")
+            example("Allow glob in project dirs",
+                    "src/*")
+            example("Allow grep in current project",
+                    "/Users/.*/project/.*")
+        }
+    }
+
+    private var agentExamples: some View {
+        section("Agent Examples") {
+            toolNote("Pattern matches against tool input fields")
+            example("Allow all agent calls",
+                    "*")
+            example("Block agents with worktree type",
+                    ".*worktree.*")
+        }
+    }
+
+    private var mcpExamples: some View {
+        section("MCP Tool Examples") {
+            toolNote("Use tool * with regex, or set tool picker to the full MCP tool name")
+            example("Block all Slack writes",
+                    "mcp__.*[Ss]lack.*(send|update|delete)")
+            example("Allow Slack reads",
+                    "mcp__.*[Ss]lack.*(read|list|search)")
+            example("Block all Jira writes",
+                    "mcp__.*[Jj]ira.*(create|update|delete)")
+            example("Block Playwright navigation",
+                    "mcp__.*[Pp]laywright.*navigate$")
+        }
+    }
+
+    private var wildcardExamples: some View {
+        section("Wildcard (*) Tool Examples") {
+            toolNote("Setting tool to * matches all tool types")
+            example("Block anything touching .env",
+                    "\\.env\\b")
+            example("Ask before any destructive op",
+                    "(rm|delete|drop|truncate)\\b")
         }
     }
 }

--- a/Sources/Gavel/Monitor/RegexCheatSheetView.swift
+++ b/Sources/Gavel/Monitor/RegexCheatSheetView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+/// Static regex quick reference card.
+struct RegexCheatSheetView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                section("Anchors") {
+                    row("^", "Start of string")
+                    row("$", "End of string")
+                    row("\\b", "Word boundary")
+                    row("\\B", "Non-word boundary")
+                }
+
+                section("Character Classes") {
+                    row(".", "Any character (except newline)")
+                    row("\\d", "Digit [0-9]")
+                    row("\\D", "Non-digit")
+                    row("\\w", "Word character [a-zA-Z0-9_]")
+                    row("\\W", "Non-word character")
+                    row("\\s", "Whitespace (space, tab, newline)")
+                    row("\\S", "Non-whitespace")
+                    row("[abc]", "Any of a, b, or c")
+                    row("[^abc]", "Not a, b, or c")
+                    row("[a-z]", "Range: a through z")
+                }
+
+                section("Quantifiers") {
+                    row("*", "0 or more (greedy)")
+                    row("+", "1 or more (greedy)")
+                    row("?", "0 or 1 (optional)")
+                    row("{3}", "Exactly 3")
+                    row("{3,}", "3 or more")
+                    row("{3,5}", "Between 3 and 5")
+                    row("*?", "0 or more (lazy/non-greedy)")
+                    row("+?", "1 or more (lazy/non-greedy)")
+                }
+
+                section("Groups & Lookaround") {
+                    row("(abc)", "Capture group")
+                    row("(?:abc)", "Non-capturing group")
+                    row("a|b", "Alternation (a or b)")
+                    row("(?=abc)", "Positive lookahead")
+                    row("(?!abc)", "Negative lookahead")
+                    row("(?<=abc)", "Positive lookbehind")
+                    row("(?<!abc)", "Negative lookbehind")
+                }
+
+                section("Escaping") {
+                    row("\\", "Escape next character")
+                    row("\\.", "Literal dot")
+                    row("\\(", "Literal parenthesis")
+                    row("\\\\", "Literal backslash")
+                }
+
+                section("Gavel Glob Patterns") {
+                    row("*", "Match any characters (like .*)")
+                    row("swift build*", "Matches 'swift build -c release'")
+                    row("Sources/*", "Matches any path under Sources/")
+                }
+
+                section("Common Gavel Patterns") {
+                    example("Block git push to main",
+                            "git\\s+push\\b.*\\b(main|master)\\b")
+                    example("Allow git but not push",
+                            "git\\s+(?!push)\\w+")
+                    example("Block secrets except --only-names",
+                            "doppler\\s+secrets\\b(?!.*--only-names)")
+                    example("Allow npm/yarn commands",
+                            "(npm|yarn)\\s+\\w+")
+                }
+            }
+            .padding(12)
+        }
+        .font(.system(.caption, design: .monospaced))
+        .background(Color(nsColor: .textBackgroundColor))
+    }
+
+    // MARK: - Helpers
+
+    private func section(_ title: String, @ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.system(.body, design: .default).bold())
+                .foregroundColor(.primary)
+
+            content()
+        }
+    }
+
+    private func row(_ pattern: String, _ description: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Text(pattern)
+                .foregroundColor(.orange)
+                .frame(width: 100, alignment: .leading)
+
+            Text(description)
+                .foregroundColor(.secondary)
+
+            Spacer()
+        }
+    }
+
+    private func example(_ label: String, _ pattern: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .foregroundColor(.secondary)
+                .font(.caption)
+            Text(pattern)
+                .foregroundColor(.green)
+                .textSelection(.enabled)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color.green.opacity(0.1))
+                .cornerRadius(3)
+        }
+    }
+}

--- a/Sources/Gavel/Monitor/RegexTesterView.swift
+++ b/Sources/Gavel/Monitor/RegexTesterView.swift
@@ -1,0 +1,233 @@
+import SwiftUI
+
+/// Interactive regex/glob tester with match highlighting.
+struct RegexTesterView: View {
+    @State private var pattern: String = ""
+    @State private var testString: String = ""
+    @State private var isRegexMode: Bool = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Pattern input
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("Pattern")
+                        .font(.caption.bold())
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Toggle("Regex", isOn: $isRegexMode)
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                        .tint(.orange)
+                }
+
+                HStack(spacing: 2) {
+                    if isRegexMode {
+                        Text("/").font(.system(.body, design: .monospaced)).foregroundColor(.orange)
+                    }
+                    TextField(isRegexMode ? "regex pattern" : "glob pattern (* = wildcard)", text: $pattern)
+                        .font(.system(.body, design: .monospaced))
+                        .textFieldStyle(.roundedBorder)
+                    if isRegexMode {
+                        Text("/i").font(.system(.body, design: .monospaced)).foregroundColor(.orange)
+                    }
+                }
+            }
+
+            // Test string input
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Test String")
+                    .font(.caption.bold())
+                    .foregroundColor(.secondary)
+
+                TextEditor(text: $testString)
+                    .font(.system(.body, design: .monospaced))
+                    .frame(minHeight: 60, maxHeight: 120)
+                    .padding(4)
+                    .background(Color(nsColor: .textBackgroundColor))
+                    .cornerRadius(6)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                    )
+            }
+
+            Divider()
+
+            // Results
+            if !pattern.isEmpty && !testString.isEmpty {
+                matchResults
+            } else {
+                Text("Enter a pattern and test string to see results.")
+                    .foregroundColor(.secondary)
+                    .font(.caption)
+            }
+
+            Spacer()
+        }
+        .padding(12)
+        .background(Color(nsColor: .textBackgroundColor))
+    }
+
+    @ViewBuilder
+    private var matchResults: some View {
+        let compiled = compilePattern()
+
+        switch compiled {
+        case .failure(let error):
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundColor(.red)
+                Text(error)
+                    .foregroundColor(.red)
+                    .font(.body)
+            }
+
+        case .success(let regex):
+            let matches = findMatches(regex: regex, in: testString)
+
+            // Match/No Match badge
+            HStack(spacing: 8) {
+                if matches.isEmpty {
+                    badge(text: "NO MATCH", color: .gray)
+                } else {
+                    badge(text: "\(matches.count) MATCH\(matches.count == 1 ? "" : "ES")", color: .green)
+                }
+
+                if !matches.isEmpty {
+                    Text("Matched ranges shown below")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            // Highlighted test string
+            if !matches.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Highlighted Matches")
+                        .font(.caption.bold())
+                        .foregroundColor(.secondary)
+
+                    highlightedText(testString, matches: matches)
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(nsColor: .controlBackgroundColor))
+                        .cornerRadius(6)
+
+                    // Show matched substrings
+                    ForEach(Array(matches.enumerated()), id: \.offset) { idx, match in
+                        HStack(spacing: 4) {
+                            Text("Match \(idx + 1):")
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundColor(.secondary)
+                            Text(match.value)
+                                .font(.system(.caption, design: .monospaced).bold())
+                                .foregroundColor(.green)
+                                .textSelection(.enabled)
+                            Text("[\(match.range.location)...\(match.range.location + match.range.length)]")
+                                .font(.system(.caption2, design: .monospaced))
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Matching
+
+    private struct MatchResult {
+        let value: String
+        let range: NSRange
+    }
+
+    private enum CompileResult {
+        case success(NSRegularExpression)
+        case failure(String)
+    }
+
+    private func compilePattern() -> CompileResult {
+        if isRegexMode {
+            do {
+                let regex = try NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+                return .success(regex)
+            } catch {
+                return .failure("Invalid regex: \(error.localizedDescription)")
+            }
+        } else {
+            if let regex = PersistentRule.compilePattern(pattern, isRegex: false) {
+                return .success(regex)
+            }
+            return .failure("Invalid glob pattern")
+        }
+    }
+
+    private func findMatches(regex: NSRegularExpression, in string: String) -> [MatchResult] {
+        let nsString = string as NSString
+        let results = regex.matches(in: string, range: NSRange(location: 0, length: nsString.length))
+        return results.map { result in
+            MatchResult(
+                value: nsString.substring(with: result.range),
+                range: result.range
+            )
+        }
+    }
+
+    // MARK: - Highlighted Text
+
+    private func highlightedText(_ string: String, matches: [MatchResult]) -> some View {
+        let attributed = buildAttributedString(string, matches: matches)
+        return Text(attributed)
+            .font(.system(.body, design: .monospaced))
+            .textSelection(.enabled)
+    }
+
+    private func buildAttributedString(_ string: String, matches: [MatchResult]) -> AttributedString {
+        let nsString = string as NSString
+        var result = AttributedString()
+        var lastEnd = 0
+
+        for match in matches {
+            let matchStart = match.range.location
+            let matchEnd = matchStart + match.range.length
+
+            // Plain text before this match
+            if matchStart > lastEnd {
+                let before = nsString.substring(with: NSRange(location: lastEnd, length: matchStart - lastEnd))
+                var part = AttributedString(before)
+                part.font = .system(.body, design: .monospaced)
+                result.append(part)
+            }
+
+            // Highlighted match
+            let matched = nsString.substring(with: match.range)
+            var part = AttributedString(matched)
+            part.font = .system(.body, design: .monospaced).bold()
+            part.foregroundColor = .white
+            part.backgroundColor = .green
+            result.append(part)
+
+            lastEnd = matchEnd
+        }
+
+        // Remaining text
+        if lastEnd < nsString.length {
+            let remainder = nsString.substring(from: lastEnd)
+            var part = AttributedString(remainder)
+            part.font = .system(.body, design: .monospaced)
+            result.append(part)
+        }
+
+        return result
+    }
+
+    private func badge(text: String, color: Color) -> some View {
+        Text(text)
+            .font(.body.bold())
+            .foregroundColor(.white)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(color)
+            .cornerRadius(6)
+    }
+}

--- a/Sources/Gavel/Monitor/RegexTesterView.swift
+++ b/Sources/Gavel/Monitor/RegexTesterView.swift
@@ -2,9 +2,7 @@ import SwiftUI
 
 /// Interactive regex/glob tester with match highlighting.
 struct RegexTesterView: View {
-    @State private var pattern: String = ""
-    @State private var testString: String = ""
-    @State private var isRegexMode: Bool = true
+    @ObservedObject var viewModel: MonitorViewModel
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -15,20 +13,20 @@ struct RegexTesterView: View {
                         .font(.caption.bold())
                         .foregroundColor(.secondary)
                     Spacer()
-                    Toggle("Regex", isOn: $isRegexMode)
+                    Toggle("Regex", isOn: $viewModel.testerIsRegex)
                         .toggleStyle(.switch)
                         .controlSize(.small)
                         .tint(.orange)
                 }
 
                 HStack(spacing: 2) {
-                    if isRegexMode {
+                    if viewModel.testerIsRegex {
                         Text("/").font(.system(.body, design: .monospaced)).foregroundColor(.orange)
                     }
-                    TextField(isRegexMode ? "regex pattern" : "glob pattern (* = wildcard)", text: $pattern)
+                    TextField(viewModel.testerIsRegex ? "regex pattern" : "glob pattern (* = wildcard)", text: $viewModel.testerPattern)
                         .font(.system(.body, design: .monospaced))
                         .textFieldStyle(.roundedBorder)
-                    if isRegexMode {
+                    if viewModel.testerIsRegex {
                         Text("/i").font(.system(.body, design: .monospaced)).foregroundColor(.orange)
                     }
                 }
@@ -40,7 +38,7 @@ struct RegexTesterView: View {
                     .font(.caption.bold())
                     .foregroundColor(.secondary)
 
-                TextEditor(text: $testString)
+                TextEditor(text: $viewModel.testerTestString)
                     .font(.system(.body, design: .monospaced))
                     .frame(minHeight: 60, maxHeight: 120)
                     .padding(4)
@@ -55,7 +53,7 @@ struct RegexTesterView: View {
             Divider()
 
             // Results
-            if !pattern.isEmpty && !testString.isEmpty {
+            if !viewModel.testerPattern.isEmpty && !viewModel.testerTestString.isEmpty {
                 matchResults
             } else {
                 Text("Enter a pattern and test string to see results.")
@@ -84,7 +82,7 @@ struct RegexTesterView: View {
             }
 
         case .success(let regex):
-            let matches = findMatches(regex: regex, in: testString)
+            let matches = findMatches(regex: regex, in: viewModel.testerTestString)
 
             // Match/No Match badge
             HStack(spacing: 8) {
@@ -108,7 +106,7 @@ struct RegexTesterView: View {
                         .font(.caption.bold())
                         .foregroundColor(.secondary)
 
-                    highlightedText(testString, matches: matches)
+                    highlightedText(viewModel.testerTestString, matches: matches)
                         .padding(8)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(Color(nsColor: .controlBackgroundColor))
@@ -147,15 +145,15 @@ struct RegexTesterView: View {
     }
 
     private func compilePattern() -> CompileResult {
-        if isRegexMode {
+        if viewModel.testerIsRegex {
             do {
-                let regex = try NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+                let regex = try NSRegularExpression(pattern: viewModel.testerPattern, options: [.caseInsensitive])
                 return .success(regex)
             } catch {
                 return .failure("Invalid regex: \(error.localizedDescription)")
             }
         } else {
-            if let regex = PersistentRule.compilePattern(pattern, isRegex: false) {
+            if let regex = PersistentRule.compilePattern(viewModel.testerPattern, isRegex: false) {
                 return .success(regex)
             }
             return .failure("Invalid glob pattern")

--- a/Tests/GavelTests/PersistentRuleTests.swift
+++ b/Tests/GavelTests/PersistentRuleTests.swift
@@ -104,4 +104,37 @@ final class PersistentRuleTests: XCTestCase {
         XCTAssertEqual(decision.verdict, .allow)
         XCTAssertNotNil(decision.reason) // non-nil reason = skip dialog in HookRouter
     }
+
+    // MARK: - Wildcard rules match MCP tool names
+
+    func testWildcardRuleMatchesMcpToolName() {
+        var rule = PersistentRule(toolName: "*", pattern: "mcp__LinkedIn__(linkedin_create|linkedin_post)", isRegex: true, verdict: .prompt)
+        // MCP tools have no command/filePath — pattern should match against the tool name
+        XCTAssertTrue(rule.matches(toolName: "mcp__LinkedIn__linkedin_create_post", command: nil, filePath: nil))
+    }
+
+    func testWildcardRuleNoFalsePositiveOnToolName() {
+        var rule = PersistentRule(toolName: "*", pattern: "mcp__LinkedIn__linkedin_create", isRegex: true, verdict: .prompt)
+        // Should not match a different tool
+        XCTAssertFalse(rule.matches(toolName: "mcp__engram__search", command: nil, filePath: nil))
+    }
+
+    func testWildcardPromptRuleForcesDialogInEngine() {
+        let store = RuleStore(configPath: "/dev/null")
+        store.addRule(PersistentRule(toolName: "*", pattern: "mcp__LinkedIn__(linkedin_create|linkedin_post)", isRegex: true, verdict: .prompt))
+
+        let engine = ApprovalEngine(ruleStore: store)
+        let session = Session(pid: 99999)
+        let payload = PreToolUsePayload(toolName: "mcp__LinkedIn__linkedin_create_post", toolInput: [:])
+
+        let decision = engine.evaluate(payload: payload, session: session)
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertTrue(decision.askUser) // askUser = forceDialog in HookRouter
+    }
+
+    func testNonWildcardRuleDoesNotMatchToolName() {
+        // When toolName is specific (not *), it should NOT fall back to tool name matching
+        var rule = PersistentRule(toolName: "Bash", pattern: "mcp__LinkedIn__linkedin_create", isRegex: true, verdict: .prompt)
+        XCTAssertFalse(rule.matches(toolName: "mcp__LinkedIn__linkedin_create_post", command: nil, filePath: nil))
+    }
 }


### PR DESCRIPTION
## Summary
- **Rules tab**: Add-rule form with tool picker, pattern input (glob/regex toggle), verdict selector (Block/Allow/Ask). Import/export rules as JSON for backup and sharing
- **Tester tab**: Interactive regex/glob tester with match highlighting -- enter a pattern and test string, see highlighted matches with ranges
- **Reference tab**: Regex cheat sheet with syntax reference and common gavel pattern examples

## Test plan
- [x] 117 tests pass, clean build
- [ ] Add a deny rule via the form, verify it appears in the list and blocks commands
- [ ] Add an "Always Ask" rule, verify it forces the dialog under auto-approve
- [ ] Export rules to JSON, delete all rules, import the JSON back
- [ ] Test regex patterns in the Tester tab, verify match highlighting
- [ ] Test glob patterns in the Tester tab
- [ ] Verify the Reference tab renders correctly