### PR TITLE
Deny rule explanations and bash editor sizing

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -12,7 +12,7 @@ final class ApprovalCoordinator: ObservableObject {
         case allow(context: String?, updatedCommand: String?)
         case deny(context: String?)
         case allowPatternForSession(pattern: String, context: String?, updatedCommand: String?)
-        case alwaysDenyPattern(pattern: String, isRegex: Bool)
+        case alwaysDenyPattern(pattern: String, isRegex: Bool, explanation: String?)
         case alwaysAllowPattern(pattern: String, isRegex: Bool)
         case alwaysPromptPattern(pattern: String, isRegex: Bool)
     }
@@ -114,12 +114,15 @@ final class ApprovalCoordinator: ObservableObject {
             current.session.sessionRules.append(rule)
             current.respond(Decision(verdict: .allow, reason: "User approved (\(current.payload.toolName): \(pattern))", additionalContext: ctx, updatedInput: updated))
 
-        case .alwaysDenyPattern(let pattern, let isRegex):
+        case .alwaysDenyPattern(let pattern, let isRegex, let explanation):
             ctx = nil; updated = nil
             let sanitized = Self.sanitizeDashes(pattern)
-            let rule = PersistentRule(toolName: current.payload.toolName, pattern: sanitized, isRegex: isRegex, verdict: .block)
+            let explText = (explanation?.isEmpty == false) ? explanation : nil
+            let rule = PersistentRule(toolName: current.payload.toolName, pattern: sanitized, isRegex: isRegex, verdict: .block, explanation: explText)
             ruleStore?.addRule(rule)
-            current.respond(Decision(verdict: .block, reason: "Always deny: \(current.payload.toolName): \(pattern)"))
+            var reason = "Always deny: \(current.payload.toolName): \(pattern)"
+            if let e = explText { reason += " — \(e)" }
+            current.respond(Decision(verdict: .block, reason: reason))
 
         case .alwaysAllowPattern(let pattern, let isRegex):
             ctx = nil; updated = nil

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -279,7 +279,7 @@ struct ApprovalPanelView: View {
             // Persistent + session rules row
             HStack(spacing: 6) {
                 Button(action: {
-                    coordinator.handleAction(.alwaysDenyPattern(pattern: sessionPattern, isRegex: isRegexMode))
+                    coordinator.handleAction(.alwaysDenyPattern(pattern: sessionPattern, isRegex: isRegexMode, explanation: noteToClaudeText.isEmpty ? nil : noteToClaudeText))
                 }) {
                     Label("Always Deny", systemImage: "hand.raised")
                 }

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -24,7 +24,11 @@ final class RuleStore: ObservableObject {
     func evaluateDeny(payload: PreToolUsePayload) -> Decision? {
         for i in rules.indices where rules[i].verdict == .block {
             if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
-                return Decision(verdict: .block, reason: "Always deny: \(rules[i].name)")
+                var reason = "Always deny: \(rules[i].name)"
+                if let explanation = rules[i].explanation, !explanation.isEmpty {
+                    reason += " — \(explanation)"
+                }
+                return Decision(verdict: .block, reason: reason)
             }
         }
         return nil
@@ -103,6 +107,8 @@ struct PersistentRule: Codable, Identifiable {
     let isRegex: Bool
     let verdict: DecisionVerdict
     let createdAt: Date
+    /// Explanation shown to Claude when a deny rule fires (e.g. "use --only-names flag instead").
+    let explanation: String?
 
     /// Pre-compiled regex (rebuilt on first access, not persisted).
     private var _compiledRegex: NSRegularExpression?
@@ -116,10 +122,10 @@ struct PersistentRule: Codable, Identifiable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, toolName, pattern, isRegex, verdict, createdAt
+        case id, name, toolName, pattern, isRegex, verdict, createdAt, explanation
     }
 
-    /// Backward-compatible decoding — isRegex defaults to false for old rules.json.
+    /// Backward-compatible decoding — isRegex and explanation default for old rules.json.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         id = try c.decode(UUID.self, forKey: .id)
@@ -129,13 +135,15 @@ struct PersistentRule: Codable, Identifiable {
         isRegex = try c.decodeIfPresent(Bool.self, forKey: .isRegex) ?? false
         verdict = try c.decode(DecisionVerdict.self, forKey: .verdict)
         createdAt = try c.decode(Date.self, forKey: .createdAt)
+        explanation = try c.decodeIfPresent(String.self, forKey: .explanation)
     }
 
     init(
         toolName: String,
         pattern: String,
         isRegex: Bool = false,
-        verdict: DecisionVerdict
+        verdict: DecisionVerdict,
+        explanation: String? = nil
     ) {
         self.id = UUID()
         self.toolName = toolName
@@ -144,6 +152,7 @@ struct PersistentRule: Codable, Identifiable {
         self.verdict = verdict
         self.createdAt = Date()
         self.name = "\(toolName): \(isRegex ? "/" : "")\(pattern)\(isRegex ? "/" : "")"
+        self.explanation = explanation
         self._compiledRegex = Self.compilePattern(pattern, isRegex: isRegex)
     }
 

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -177,6 +177,7 @@ struct RulesView: View {
     @State private var newToolName: String = "*"
     @State private var newIsRegex: Bool = false
     @State private var newVerdict: DecisionVerdict = .block
+    @State private var newExplanation: String = ""
     @State private var importError: String?
 
     private let toolOptions = ["*", "Bash", "Edit", "MultiEdit", "Write", "Read", "Glob", "Grep", "Agent"]
@@ -257,7 +258,7 @@ struct RulesView: View {
             HStack(spacing: 8) {
                 // Verdict picker
                 Picker("", selection: $newVerdict) {
-                    Text("Always Block").tag(DecisionVerdict.block)
+                    Text("Always Deny").tag(DecisionVerdict.block)
                     Text("Always Allow").tag(DecisionVerdict.allow)
                     Text("Always Ask").tag(DecisionVerdict.prompt)
                 }
@@ -270,20 +271,50 @@ struct RulesView: View {
                 .tint(verdictColor(newVerdict))
                 .disabled(newPattern.isEmpty)
             }
+
+            // Explanation field for deny rules — Claude sees this when blocked
+            if newVerdict == .block {
+                TextEditor(text: $newExplanation)
+                    .font(.system(.caption, design: .monospaced))
+                    .frame(height: 54)
+                    .padding(4)
+                    .background(Color(nsColor: .textBackgroundColor))
+                    .cornerRadius(6)
+                    .overlay(
+                        Group {
+                            if newExplanation.isEmpty {
+                                Text("Explanation for Claude — shown when this rule blocks a tool call")
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(.secondary.opacity(0.5))
+                                    .padding(.leading, 8)
+                                    .padding(.top, 8)
+                                    .allowsHitTesting(false)
+                            }
+                        },
+                        alignment: .topLeading
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                    )
+            }
         }
     }
 
     private func addRule() {
         guard !newPattern.isEmpty else { return }
         let sanitized = ApprovalCoordinator.sanitizeDashes(newPattern)
+        let explText = (newVerdict == .block && !newExplanation.isEmpty) ? newExplanation : nil
         let rule = PersistentRule(
             toolName: newToolName,
             pattern: sanitized,
             isRegex: newIsRegex,
-            verdict: newVerdict
+            verdict: newVerdict,
+            explanation: explText
         )
         viewModel.addRule(rule)
         newPattern = ""
+        newExplanation = ""
     }
 
     // MARK: - Import/Export
@@ -371,15 +402,24 @@ struct RulesView: View {
                 .foregroundColor(.orange)
                 .frame(width: 60, alignment: .leading)
 
-            HStack(spacing: 2) {
-                if rule.isRegex {
-                    Text("/").foregroundColor(.orange)
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(spacing: 2) {
+                    if rule.isRegex {
+                        Text("/").foregroundColor(.orange)
+                    }
+                    Text(rule.pattern)
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+                    if rule.isRegex {
+                        Text("/").foregroundColor(.orange)
+                    }
                 }
-                Text(rule.pattern)
-                    .foregroundColor(.primary)
-                    .lineLimit(1)
-                if rule.isRegex {
-                    Text("/").foregroundColor(.orange)
+
+                if let explanation = rule.explanation, !explanation.isEmpty {
+                    Text(explanation)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
                 }
             }
 


### PR DESCRIPTION
## Summary
- **Deny rule explanations**: PersistentRule gains an optional explanation field. When a deny rule fires, Claude sees the explanation. Settable from both the approval panel (note-to-Claude) and the Rules tab (multi-line TextEditor for deny verdict). Backwards compatible.
- **Bash command editor**: Content-based height sizing with line count and wrap estimation. Editor fills available panel height. Panel resize extends the command area.
- **UI label**: Always Block renamed to Always Deny in the verdict picker

## Test plan
- [x] Live tested: deny rule with explanation shown to Claude in block reason
- [x] Live tested: negative lookahead still works (--only-names passes through)
- [x] Live tested: bash editor sizes to content, panel resizable
- [x] Live tested: explanation field in Rules tab is multi-line and scrollable
- [x] Live tested: rule list shows explanation under pattern
- [x] Backwards compatible: old rules without explanation decode correctly