### PR TITLE
Fix session rules bypassed by askUser forced dialogs

### DIFF
--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -120,6 +120,19 @@ final class HookRouter {
         let engineDecision = approvalEngine.evaluate(payload: payload, session: session)
         if engineDecision.verdict == .block {
             if engineDecision.askUser {
+                // Before forcing dialog, check if a session rule already covers this.
+                // Session Allow from a previous dialog should skip re-prompting.
+                if let rule = session.matchesSessionRule(
+                    toolName: payload.toolName,
+                    command: payload.command,
+                    filePath: payload.filePath
+                ) {
+                    session.allowCount += 1
+                    emitFeed(.decision(badge: .allow, reason: "Session rule: \(rule.toolName): \(rule.pattern)", pid: session.pid, at: timestamp))
+                    sendResponse(Decision(verdict: .allow, reason: "Session rule: \(rule.pattern)"), respond: respond)
+                    return
+                }
+
                 // MCP-style block: jump straight to interactive dialog
                 emitFeed(.decision(badge: .block, reason: "Needs approval: \(engineDecision.reason ?? "")", pid: session.pid, at: timestamp))
 


### PR DESCRIPTION
## Summary
Session Allow from the approval dialog creates a session rule, but MCP blocks and prompt rules short-circuited to forceDialog before session rules were checked. Now HookRouter checks session rules before showing the forced dialog, so Session Allow works for MCP tools and prompt rules on subsequent calls.

## Test plan
- [x] Live tested: Playwright navigate prompts on first call, Session Allow works on subsequent calls
- [x] Hardcoded dangerous patterns (reverse shells etc) still hard-block regardless of session rules
- [x] Persistent deny rules still take priority over session rules