### PR TITLE
Editable MCP fields, sensitive path dialogs, sessions tab

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -9,9 +9,9 @@ import SwiftUI
 final class ApprovalCoordinator: ObservableObject {
 
     enum Action {
-        case allow(context: String?, updatedCommand: String?)
+        case allow(context: String?, updatedCommand: String?, updatedInput: [String: AnyCodable]?)
         case deny(context: String?)
-        case allowPatternForSession(pattern: String, context: String?, updatedCommand: String?)
+        case allowPatternForSession(pattern: String, context: String?, updatedCommand: String?, updatedInput: [String: AnyCodable]?)
         case alwaysDenyPattern(pattern: String, isRegex: Bool, explanation: String?)
         case alwaysAllowPattern(pattern: String, isRegex: Bool)
         case alwaysPromptPattern(pattern: String, isRegex: Bool)
@@ -94,9 +94,9 @@ final class ApprovalCoordinator: ObservableObject {
         let updated: [String: AnyCodable]?
 
         switch action {
-        case .allow(let context, let updatedCommand):
+        case .allow(let context, let updatedCommand, let fieldUpdates):
             ctx = context
-            updated = buildUpdatedInput(updatedCommand)
+            updated = fieldUpdates ?? buildUpdatedInput(updatedCommand)
             current.respond(Decision(verdict: .allow, reason: "User approved", additionalContext: ctx, updatedInput: updated))
         case .deny(let context):
             let reason: String
@@ -107,9 +107,9 @@ final class ApprovalCoordinator: ObservableObject {
             }
             current.respond(Decision(verdict: .block, reason: reason))
             ctx = nil; updated = nil
-        case .allowPatternForSession(let pattern, let context, let updatedCommand):
+        case .allowPatternForSession(let pattern, let context, let updatedCommand, let fieldUpdates):
             ctx = context
-            updated = buildUpdatedInput(updatedCommand)
+            updated = fieldUpdates ?? buildUpdatedInput(updatedCommand)
             let rule = SessionRule(toolName: current.payload.toolName, pattern: pattern)
             current.session.sessionRules.append(rule)
             current.respond(Decision(verdict: .allow, reason: "User approved (\(current.payload.toolName): \(pattern))", additionalContext: ctx, updatedInput: updated))

--- a/Sources/Gavel/Approval/ApprovalEngine.swift
+++ b/Sources/Gavel/Approval/ApprovalEngine.swift
@@ -5,9 +5,11 @@ import Foundation
 /// 1. Hard-blocked dangerous patterns (always block, not overridable)
 /// 2. Persistent DENY rules from RuleStore (block even under auto-approve)
 /// 3. Session pause state
-/// 4. Persistent ALLOW rules from RuleStore
-/// 5. Timed auto-approve
-/// 6. Default: pass through to interactive approval
+/// 4. Persistent PROMPT rules (force dialog even under auto-approve)
+/// 5. Persistent ALLOW rules from RuleStore
+/// 6. Sensitive paths — gavel config, hooks, shell (force dialog)
+/// 7. MCP tool blocking (force dialog, overridable by allow rules)
+/// 8. Default: pass through to interactive approval
 ///
 /// Key invariant: deny rules ALWAYS win over auto-approve.
 final class ApprovalEngine {
@@ -45,7 +47,12 @@ final class ApprovalEngine {
             return decision
         }
 
-        // 6. MCP tool blocking (after allow rules, so users can override)
+        // 6. Sensitive paths — gavel config, hooks, shell config (force dialog)
+        if let reason = patternMatcher.matchSensitivePath(payload: payload) {
+            return Decision(verdict: .block, reason: reason, askUser: true)
+        }
+
+        // 7. MCP tool blocking (after allow rules, so users can override)
         if let reason = patternMatcher.matchMcpDangerous(payload: payload) {
             return Decision(verdict: .block, reason: reason, askUser: true)
         }

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -6,6 +6,7 @@ struct ApprovalPanelView: View {
     @State private var sessionPattern: String = ""
     @State private var noteToClaudeText: String = ""
     @State private var editedCommand: String = ""
+    @State private var editedFields: [String: String] = [:]
     @State private var isRegexMode: Bool = false
 
     var body: some View {
@@ -41,6 +42,7 @@ struct ApprovalPanelView: View {
                 filePath: a.payload.filePath
             )
             editedCommand = ApprovalCoordinator.sanitizeDashes(a.payload.command ?? "")
+            editedFields = [:]
             noteToClaudeText = ""
             isRegexMode = false
         }
@@ -215,12 +217,52 @@ struct ApprovalPanelView: View {
         }
     }
 
+    /// Keys whose values are editable in the approval panel (message content, post text, etc.)
+    private static let editableKeys: Set<String> = [
+        "text", "message", "body", "content", "description", "comment", "prompt", "query"
+    ]
+
     private func genericDetails(_ payload: PreToolUsePayload) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             ForEach(Array(payload.toolInput.keys.sorted()), id: \.self) { key in
                 if let value = payload.toolInput[key]?.stringValue {
-                    labeledField(key, value: value)
+                    if Self.editableKeys.contains(key) {
+                        editableField(key, original: value)
+                    } else {
+                        labeledField(key, value: value)
+                    }
                 }
+            }
+        }
+    }
+
+    private func editableField(_ key: String, original: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("\(key) (editable)")
+                .font(.caption.bold())
+                .foregroundColor(.secondary)
+
+            let binding = Binding<String>(
+                get: { editedFields[key] ?? original },
+                set: { editedFields[key] = $0 }
+            )
+            let isModified = (editedFields[key] ?? original) != original
+
+            TextEditor(text: binding)
+                .font(.system(.body, design: .monospaced))
+                .frame(minHeight: 60, maxHeight: 200)
+                .padding(4)
+                .background(Color.blue.opacity(0.08))
+                .cornerRadius(6)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(isModified ? Color.orange : Color.blue.opacity(0.2), lineWidth: isModified ? 2 : 1)
+                )
+
+            if isModified {
+                Text("Modified — original will be replaced")
+                    .font(.caption2)
+                    .foregroundColor(.orange)
             }
         }
     }
@@ -311,7 +353,8 @@ struct ApprovalPanelView: View {
                     coordinator.handleAction(.allowPatternForSession(
                         pattern: sessionPattern,
                         context: noteToClaudeText.isEmpty ? nil : noteToClaudeText,
-                        updatedCommand: cmdIfModified
+                        updatedCommand: cmdIfModified,
+                        updatedInput: updatedInputIfModified
                     ))
                 }) {
                     Label("Session Allow", systemImage: "checkmark.shield")
@@ -339,7 +382,8 @@ struct ApprovalPanelView: View {
                 Button(action: {
                     coordinator.handleAction(.allow(
                         context: noteToClaudeText.isEmpty ? nil : noteToClaudeText,
-                        updatedCommand: cmdIfModified
+                        updatedCommand: cmdIfModified,
+                        updatedInput: updatedInputIfModified
                     ))
                 }) {
                     Label("Allow Once", systemImage: "checkmark.circle")
@@ -420,6 +464,20 @@ struct ApprovalPanelView: View {
     private var cmdIfModified: String? {
         guard let original = coordinator.currentApproval?.payload.command else { return nil }
         return editedCommand != original ? editedCommand : nil
+    }
+
+    /// Returns updated toolInput if any editable fields were modified.
+    private var updatedInputIfModified: [String: AnyCodable]? {
+        guard let payload = coordinator.currentApproval?.payload else { return nil }
+        let changes = editedFields.filter { key, value in
+            value != (payload.toolInput[key]?.stringValue ?? "")
+        }
+        guard !changes.isEmpty else { return nil }
+        var input = payload.toolInput
+        for (key, value) in changes {
+            input[key] = AnyCodable(value)
+        }
+        return input
     }
 
     // MARK: - Helpers

--- a/Sources/Gavel/Approval/PatternMatcher.swift
+++ b/Sources/Gavel/Approval/PatternMatcher.swift
@@ -10,8 +10,11 @@ struct PatternMatcher {
     /// Pre-compiled dangerous bash command patterns.
     private let bashPatterns: [(regex: NSRegularExpression, reason: String)]
 
-    /// Pre-compiled protected file path patterns (for Write/Edit tools).
+    /// Pre-compiled protected file path patterns — hard block (credentials, persistence).
     private let protectedPaths: [(regex: NSRegularExpression, reason: String)]
+
+    /// Pre-compiled protected file path patterns — force dialog (config, hooks, shell).
+    private let askUserPaths: [(regex: NSRegularExpression, reason: String)]
 
     /// Pre-compiled sensitive read patterns (for Read tool — secrets/keys only).
     private let sensitiveReads: [(regex: NSRegularExpression, reason: String)]
@@ -96,17 +99,12 @@ struct PatternMatcher {
             ("\\bchmod\\b.*\\+x.*/tmp/", "Making temp file executable"),
         ]
 
+        // Hard block — credentials and persistence vectors that should never be written
         let rawPaths: [(pattern: String, reason: String)] = [
             // SSH keys and config
             ("\\.ssh/(id_|authorized_keys|config)", "Protected: SSH keys/config"),
             // GPG keys
             ("\\.gnupg/", "Protected: GPG keys"),
-            // Gavel's own config
-            ("\\.claude/gavel/(rules\\.json|session-defaults\\.json|hooks/|bin/)", "Protected: Gavel config"),
-            // Claude Code hooks and settings
-            ("\\.claude/(settings\\.json|settings\\.local\\.json|hooks/)", "Protected: Claude Code settings/hooks"),
-            // Shell config (persistence vector)
-            ("\\.(bash_profile|bashrc|zshrc|zprofile|profile|zshenv)$", "Protected: Shell config (persistence risk)"),
             // LaunchAgents (persistence vector)
             ("LaunchAgents/", "Protected: LaunchAgent (persistence risk)"),
             ("LaunchDaemons/", "Protected: LaunchDaemon (persistence risk)"),
@@ -117,6 +115,16 @@ struct PatternMatcher {
             ("\\.env$", "Protected: Environment file"),
         ]
 
+        // Ask user — config and tools that may legitimately need editing
+        let rawAskUserPaths: [(pattern: String, reason: String)] = [
+            // Gavel's own config
+            ("\\.claude/gavel/(rules\\.json|session-defaults\\.json|hooks/|bin/)", "Sensitive: Gavel config"),
+            // Claude Code hooks and settings
+            ("\\.claude/(settings\\.json|settings\\.local\\.json|hooks/)", "Sensitive: Claude Code settings/hooks"),
+            // Shell config
+            ("\\.(bash_profile|bashrc|zshrc|zprofile|profile|zshenv)$", "Sensitive: Shell config"),
+        ]
+
         bashPatterns = rawBash.compactMap { entry in
             guard let regex = try? NSRegularExpression(pattern: entry.pattern, options: [.caseInsensitive]) else {
                 return nil
@@ -125,6 +133,13 @@ struct PatternMatcher {
         }
 
         protectedPaths = rawPaths.compactMap { entry in
+            guard let regex = try? NSRegularExpression(pattern: entry.pattern, options: [.caseInsensitive]) else {
+                return nil
+            }
+            return (regex, entry.reason)
+        }
+
+        askUserPaths = rawAskUserPaths.compactMap { entry in
             guard let regex = try? NSRegularExpression(pattern: entry.pattern, options: [.caseInsensitive]) else {
                 return nil
             }
@@ -218,6 +233,21 @@ struct PatternMatcher {
         default:
             return nil
         }
+    }
+
+    /// Check sensitive paths that require user confirmation (gavel config, hooks, shell config).
+    /// Called from ApprovalEngine AFTER allow rules — returns askUser decision.
+    func matchSensitivePath(payload: PreToolUsePayload) -> String? {
+        guard ["Write", "Edit", "MultiEdit"].contains(payload.toolName) else { return nil }
+        guard let path = payload.filePath else { return nil }
+
+        let range = NSRange(path.startIndex..., in: path)
+        for (regex, reason) in askUserPaths {
+            if regex.firstMatch(in: path, range: range) != nil {
+                return reason
+            }
+        }
+        return nil
     }
 
     /// Check MCP tools separately — these are overridable by persistent allow rules.

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -7,7 +7,7 @@ struct MonitorWindow: View {
     @State private var selectedTab: MonitorTab = .feed
 
     enum MonitorTab {
-        case feed, rules, tester, reference
+        case feed, rules, sessions, tester, reference
     }
 
     var body: some View {
@@ -38,6 +38,7 @@ struct MonitorWindow: View {
             Picker("", selection: $selectedTab) {
                 Text("Feed").tag(MonitorTab.feed)
                 Text("Rules (\(viewModel.ruleCount))").tag(MonitorTab.rules)
+                Text("Sessions").tag(MonitorTab.sessions)
                 Text("Tester").tag(MonitorTab.tester)
                 Text("Reference").tag(MonitorTab.reference)
             }
@@ -53,6 +54,8 @@ struct MonitorWindow: View {
                 FeedView(entries: viewModel.feedEntries)
             case .rules:
                 RulesView(viewModel: viewModel)
+            case .sessions:
+                SessionRulesView(viewModel: viewModel)
             case .tester:
                 RegexTesterView(viewModel: viewModel)
             case .reference:
@@ -456,5 +459,149 @@ struct RulesView: View {
         case .allow: return .green
         case .prompt: return .yellow
         }
+    }
+}
+
+// MARK: - Session Rules View
+
+struct SessionRulesView: View {
+    @ObservedObject var viewModel: MonitorViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                let sessions = Array(viewModel.sessionManager.sessions.values)
+                    .sorted { $0.pid < $1.pid }
+
+                if sessions.isEmpty {
+                    Text("No active sessions.")
+                        .foregroundColor(.secondary)
+                        .padding()
+                } else {
+                    ForEach(sessions, id: \.pid) { session in
+                        sessionSection(session)
+                    }
+                }
+            }
+            .padding(8)
+        }
+        .font(.system(.caption, design: .monospaced))
+        .background(Color(nsColor: .textBackgroundColor))
+    }
+
+    private func sessionSection(_ session: Session) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            // Session header
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(session.isAlive ? .green : .gray)
+                    .frame(width: 8, height: 8)
+
+                Text("PID \(session.pid)")
+                    .font(.system(.body, design: .monospaced).bold())
+
+                if let cwd = session.cwd {
+                    Text(cwd.split(separator: "/").suffix(3).joined(separator: "/"))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                HStack(spacing: 4) {
+                    if session.isAutoApproveEnabled {
+                        badge("AUTO", color: .green)
+                    }
+                    if session.isSubAgentInheritEnabled {
+                        badge("SUB", color: .cyan)
+                    }
+                    if session.isPaused {
+                        badge("PAUSED", color: .orange)
+                    }
+                }
+            }
+
+            // Session info
+            HStack(spacing: 16) {
+                Text("Tools: \(session.toolCallCount)")
+                    .foregroundColor(.secondary)
+                Text("Allow: \(session.allowCount)")
+                    .foregroundColor(.green)
+                Text("Block: \(session.blockCount)")
+                    .foregroundColor(.red)
+                Text("Rules: \(session.sessionRules.count)")
+                    .foregroundColor(.purple)
+                Text("Tainted: \(session.taintedPaths.count)")
+                    .foregroundColor(.orange)
+            }
+            .font(.caption2)
+
+            // Session rules
+            if session.sessionRules.isEmpty {
+                Text("No session rules")
+                    .foregroundColor(.secondary)
+                    .font(.caption)
+                    .padding(.leading, 16)
+            } else {
+                ForEach(session.sessionRules) { rule in
+                    HStack(spacing: 6) {
+                        Text("ALLOW")
+                            .font(.caption2.bold())
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Color.purple)
+                            .cornerRadius(3)
+
+                        Text(rule.toolName)
+                            .foregroundColor(.orange)
+
+                        Text(rule.pattern)
+                            .foregroundColor(.primary)
+
+                        Spacer()
+
+                        Button(action: {
+                            session.sessionRules.removeAll { $0.id == rule.id }
+                        }) {
+                            Image(systemName: "trash")
+                                .foregroundColor(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.leading, 16)
+                }
+            }
+
+            // Tainted paths (if any)
+            if !session.taintedPaths.isEmpty {
+                Text("Tainted paths:")
+                    .font(.caption2.bold())
+                    .foregroundColor(.orange)
+                    .padding(.leading, 16)
+                    .padding(.top, 2)
+
+                ForEach(Array(session.taintedPaths.sorted()), id: \.self) { path in
+                    Text(path)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .padding(.leading, 24)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .padding(10)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        .cornerRadius(6)
+    }
+
+    private func badge(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption2.bold())
+            .foregroundColor(.white)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(color)
+            .cornerRadius(3)
     }
 }


### PR DESCRIPTION
## Summary
- **Editable MCP tool fields**: text, message, body, content, query, etc. shown in editable TextEditor. Modified values passed via updatedInput so Claude Code uses the edited version
- **Sensitive paths → Always Ask**: Gavel config, Claude hooks/settings, and shell configs moved from hard block to forced dialog. Enables supervised self-mutation. Credentials (SSH, GPG, AWS, .env, LaunchAgents) remain hard blocked
- **Sessions tab**: Live view of all active sessions showing PID, CWD, AUTO/SUB/PAUSED badges, tool stats, session rules with delete, and tainted paths. Aids debugging session rule persistence
- **Engine priority chain**: New step 6 for sensitive path check (askUser) between allow rules and MCP blocking

## Test plan
- [x] Live tested: editable Slack message field — modified text sent correctly
- [x] Live tested: gavel config/hooks write triggers dialog instead of hard block
- [x] Live tested: SSH keys, AWS credentials still hard blocked
- [x] Live tested: Sessions tab shows active sessions, rules, tainted paths
- [x] Live tested: Session rules visible and deletable from Sessions tab
- [x] Live tested: session rule debugging confirmed rules persist across calls