### PR TITLE
Per-PID panels, cloud CLI askUser, rm/read promotions

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -3,9 +3,9 @@ import SwiftUI
 
 /// Coordinates interactive approval dialogs for PreToolUse events.
 ///
-/// When auto-approve is off, queues incoming requests and shows a floating
-/// panel for each one. The socket handler blocks (via semaphore) until
-/// the user responds.
+/// Each session (PID) gets its own floating panel so approvals from
+/// different projects don't block each other. The socket handler blocks
+/// (via semaphore) until the user responds on that session's panel.
 final class ApprovalCoordinator: ObservableObject {
 
     enum Action {
@@ -28,15 +28,33 @@ final class ApprovalCoordinator: ObservableObject {
         let respond: (Decision) -> Void
     }
 
-    @Published var currentApproval: PendingApproval?
-    @Published var queueCount: Int = 0
+    /// Per-session approval state. Each session gets its own panel and queue.
+    final class SessionPanel: ObservableObject {
+        let pid: Int
+        @Published var currentApproval: PendingApproval?
+        @Published var queueCount: Int = 0
+        var pendingQueue: [PendingApproval] = []
+        var panel: NSPanel?
 
-    private var pendingQueue: [PendingApproval] = []
-    private var panel: NSPanel?
+        init(pid: Int) { self.pid = pid }
+    }
+
+    /// Active session panels, keyed by PID.
+    private var sessionPanels: [Int: SessionPanel] = [:]
+
+    /// Currently focused session panel (for compatibility with single-panel callers).
+    @Published var activeSessionPanel: SessionPanel?
+
+    /// Get or create a SessionPanel for a PID.
+    private func sessionPanel(for pid: Int) -> SessionPanel {
+        if let existing = sessionPanels[pid] { return existing }
+        let sp = SessionPanel(pid: pid)
+        sessionPanels[pid] = sp
+        return sp
+    }
 
     /// Request approval for a tool use. Blocks the calling thread until the user decides.
     /// Called from socket handler (background thread).
-    /// Set `forceDialog` to true to show the dialog even under auto-approve (used for MCP writes).
     func requestApproval(
         payload: PreToolUsePayload,
         session: Session,
@@ -61,26 +79,28 @@ final class ApprovalCoordinator: ObservableObject {
         }
 
         DispatchQueue.main.async {
-            if self.currentApproval == nil {
-                self.showApproval(pending)
+            let sp = self.sessionPanel(for: session.pid)
+            if sp.currentApproval == nil {
+                self.showApproval(pending, on: sp)
             } else {
-                self.pendingQueue.append(pending)
-                self.queueCount = self.pendingQueue.count
+                sp.pendingQueue.append(pending)
+                sp.queueCount = sp.pendingQueue.count
             }
         }
 
         let waitResult = semaphore.wait(timeout: .now() + GavelConstants.approvalTimeoutSeconds)
         if waitResult == .timedOut {
             DispatchQueue.main.async {
-                self.dismissCurrent()
+                let sp = self.sessionPanel(for: session.pid)
+                self.dismissCurrent(on: sp)
             }
         }
         return result
     }
 
     /// Handle the user's decision from the approval panel.
-    func handleAction(_ action: Action) {
-        guard let current = currentApproval else { return }
+    func handleAction(_ action: Action, on sessionPanel: SessionPanel) {
+        guard let current = sessionPanel.currentApproval else { return }
 
         // Build updatedInput if user modified the command
         func buildUpdatedInput(_ updatedCommand: String?) -> [String: AnyCodable]? {
@@ -136,37 +156,44 @@ final class ApprovalCoordinator: ObservableObject {
             let sanitized = Self.sanitizeDashes(pattern)
             let rule = PersistentRule(toolName: current.payload.toolName, pattern: sanitized, isRegex: isRegex, verdict: .prompt)
             ruleStore?.addRule(rule)
-            // For this invocation, still need user to decide — show as allow (they already saw the dialog)
             current.respond(Decision(verdict: .allow, reason: "Always prompt rule saved: \(current.payload.toolName): \(pattern)"))
         }
 
-        advanceQueue()
+        advanceQueue(on: sessionPanel)
+    }
+
+    /// Backward-compatible handleAction for callers that don't specify a session panel.
+    func handleAction(_ action: Action) {
+        guard let sp = activeSessionPanel else { return }
+        handleAction(action, on: sp)
     }
 
     /// Enable auto-approve for a session and flush its pending approvals.
-    /// Forced dialogs (from prompt rules / MCP blocks) are NOT flushed — they require explicit action.
+    /// Forced dialogs (from prompt rules / MCP blocks) are NOT flushed.
     func enableAutoApprove(for session: Session) {
         session.isAutoApproveEnabled = true
 
-        // Flush current if it belongs to this session — but not if forced
-        if let current = currentApproval, current.session.pid == session.pid, !current.forceDialog {
+        guard let sp = sessionPanels[session.pid] else { return }
+
+        // Flush current if not forced
+        if let current = sp.currentApproval, !current.forceDialog {
             current.respond(Decision(verdict: .allow, reason: "Auto-approved"))
-            currentApproval = nil
+            sp.currentApproval = nil
         }
-        // Flush queued items for this session — but not forced ones
-        let (forSession, remaining) = pendingQueue.partitioned { $0.session.pid == session.pid && !$0.forceDialog }
-        for pending in forSession {
+        // Flush queued items — but not forced ones
+        let (flushable, remaining) = sp.pendingQueue.partitioned { !$0.forceDialog }
+        for pending in flushable {
             pending.respond(Decision(verdict: .allow, reason: "Auto-approved"))
         }
-        pendingQueue = remaining
-        queueCount = pendingQueue.count
+        sp.pendingQueue = remaining
+        sp.queueCount = sp.pendingQueue.count
 
-        if currentApproval == nil {
-            if pendingQueue.isEmpty {
-                closePanel()
+        if sp.currentApproval == nil {
+            if sp.pendingQueue.isEmpty {
+                closePanel(on: sp)
             } else {
-                showApproval(pendingQueue.removeFirst())
-                queueCount = pendingQueue.count
+                showApproval(sp.pendingQueue.removeFirst(), on: sp)
+                sp.queueCount = sp.pendingQueue.count
             }
         }
     }
@@ -175,44 +202,50 @@ final class ApprovalCoordinator: ObservableObject {
         session.isAutoApproveEnabled = false
     }
 
-    // MARK: - Panel Management
+    // MARK: - Per-Session Panel Management
 
-    private func showApproval(_ approval: PendingApproval) {
-        currentApproval = approval
+    private func showApproval(_ approval: PendingApproval, on sp: SessionPanel) {
+        sp.currentApproval = approval
+        activeSessionPanel = sp
 
-        if panel == nil {
-            createPanel()
+        if sp.panel == nil {
+            createPanel(for: sp)
         }
 
-        panel?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        // Update title with project context
+        let cwdSuffix = approval.session.cwd.map { cwd in
+            let parts = cwd.split(separator: "/").suffix(2).joined(separator: "/")
+            return " — \(parts)"
+        } ?? ""
+        sp.panel?.title = "Gavel — PID \(sp.pid)\(cwdSuffix)"
 
-        // Play a sound to get attention
+        sp.panel?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
         NSSound(named: "Tink")?.play()
     }
 
-    private func advanceQueue() {
-        currentApproval = nil
-        if pendingQueue.isEmpty {
-            closePanel()
+    private func advanceQueue(on sp: SessionPanel) {
+        sp.currentApproval = nil
+        if sp.pendingQueue.isEmpty {
+            closePanel(on: sp)
         } else {
-            let next = pendingQueue.removeFirst()
-            queueCount = pendingQueue.count
-            showApproval(next)
+            let next = sp.pendingQueue.removeFirst()
+            sp.queueCount = sp.pendingQueue.count
+            showApproval(next, on: sp)
         }
     }
 
-    private func dismissCurrent() {
-        currentApproval = nil
-        if pendingQueue.isEmpty {
-            closePanel()
+    private func dismissCurrent(on sp: SessionPanel) {
+        sp.currentApproval = nil
+        if sp.pendingQueue.isEmpty {
+            closePanel(on: sp)
         } else {
-            advanceQueue()
+            advanceQueue(on: sp)
         }
     }
 
-    private func createPanel() {
-        let contentView = ApprovalPanelView(coordinator: self)
+    private func createPanel(for sp: SessionPanel) {
+        let contentView = ApprovalPanelView(coordinator: self, sessionPanel: sp)
         let hostingView = NSHostingView(rootView: contentView)
 
         let p = NSPanel(
@@ -221,16 +254,25 @@ final class ApprovalCoordinator: ObservableObject {
             backing: .buffered,
             defer: false
         )
-        p.title = "Gavel — Approve Tool Use"
+        p.title = "Gavel — PID \(sp.pid)"
         p.contentView = hostingView
         p.center()
         p.isFloatingPanel = true
         p.level = .floating
         p.isReleasedWhenClosed = false
         p.hidesOnDeactivate = false
-        // Allow text editing operations (paste, cut, copy, select all)
         p.acceptsMouseMovedEvents = true
-        panel = p
+
+        // Offset each session's panel so they don't stack on top of each other
+        let offset = CGFloat(sessionPanels.count - 1) * 30
+        if let frame = p.screen?.visibleFrame {
+            p.setFrameOrigin(NSPoint(
+                x: frame.midX - GavelConstants.panelWidth / 2 + offset,
+                y: frame.midY - GavelConstants.panelHeight / 2 - offset
+            ))
+        }
+
+        sp.panel = p
     }
 
     /// Replace typographic dashes (macOS smart dashes) with ASCII hyphens.
@@ -240,8 +282,8 @@ final class ApprovalCoordinator: ObservableObject {
              .replacingOccurrences(of: "\u{2012}", with: "-")  // figure dash
     }
 
-    private func closePanel() {
-        panel?.orderOut(nil)
+    private func closePanel(on sp: SessionPanel) {
+        sp.panel?.orderOut(nil)
     }
 }
 

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -1,8 +1,10 @@
 import SwiftUI
 
 /// The interactive approval dialog shown for each PreToolUse event.
+/// Each session gets its own panel via SessionPanel.
 struct ApprovalPanelView: View {
     @ObservedObject var coordinator: ApprovalCoordinator
+    @ObservedObject var sessionPanel: ApprovalCoordinator.SessionPanel
     @State private var sessionPattern: String = ""
     @State private var noteToClaudeText: String = ""
     @State private var editedCommand: String = ""
@@ -11,7 +13,7 @@ struct ApprovalPanelView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if let approval = coordinator.currentApproval {
+            if let approval = sessionPanel.currentApproval {
                 toolHeader(approval)
                 Divider()
                 toolDetails(approval)
@@ -26,7 +28,7 @@ struct ApprovalPanelView: View {
             }
         }
         .frame(minWidth: 560, minHeight: 300)
-        .onChange(of: coordinator.currentApproval?.timestamp) { _ in
+        .onChange(of: sessionPanel.currentApproval?.timestamp) { _ in
             resetFields()
         }
         .onAppear {
@@ -35,7 +37,7 @@ struct ApprovalPanelView: View {
     }
 
     private func resetFields() {
-        if let a = coordinator.currentApproval {
+        if let a = sessionPanel.currentApproval {
             sessionPattern = SessionRule.suggestPattern(
                 toolName: a.payload.toolName,
                 command: a.payload.command,
@@ -63,8 +65,8 @@ struct ApprovalPanelView: View {
 
             Spacer()
 
-            if coordinator.queueCount > 0 {
-                Text("+\(coordinator.queueCount) queued")
+            if sessionPanel.queueCount > 0 {
+                Text("+\(sessionPanel.queueCount) queued")
                     .font(.caption)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
@@ -290,29 +292,42 @@ struct ApprovalPanelView: View {
     private func actionBar(_ approval: ApprovalCoordinator.PendingApproval) -> some View {
         VStack(spacing: 6) {
             // Pattern field with regex toggle
-            HStack(spacing: 4) {
-                Text("\(approval.payload.toolName):")
-                    .font(.system(.body, design: .monospaced).bold())
-                    .foregroundColor(colorForTool(approval.payload.toolName))
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 4) {
+                    Text("\(approval.payload.toolName):")
+                        .font(.system(.body, design: .monospaced).bold())
+                        .foregroundColor(colorForTool(approval.payload.toolName))
 
-                if isRegexMode {
-                    Text("/")
-                        .font(.system(.body, design: .monospaced))
-                        .foregroundColor(.orange)
-                }
-                TextField(isRegexMode ? "regex pattern" : "glob pattern (* = wildcard)", text: $sessionPattern)
-                    .font(.system(.body, design: .monospaced))
-                    .textFieldStyle(.roundedBorder)
-                if isRegexMode {
-                    Text("/")
-                        .font(.system(.body, design: .monospaced))
-                        .foregroundColor(.orange)
-                }
+                    if isRegexMode {
+                        Text("/")
+                            .font(.system(.body, design: .monospaced))
+                            .foregroundColor(.orange)
+                    }
 
-                Toggle("Regex", isOn: $isRegexMode)
-                    .toggleStyle(.switch)
-                    .controlSize(.small)
+                    Spacer()
+
+                    if isRegexMode {
+                        Text("/")
+                            .font(.system(.body, design: .monospaced))
+                            .foregroundColor(.orange)
+                    }
+
+                    Toggle("Regex", isOn: $isRegexMode)
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
                     .tint(.orange)
+                }
+
+                TextEditor(text: $sessionPattern)
+                    .font(.system(.caption, design: .monospaced))
+                    .frame(height: 54)
+                    .padding(4)
+                    .background(Color(nsColor: .textBackgroundColor))
+                    .cornerRadius(6)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                    )
             }
 
             // Live pattern tester
@@ -321,7 +336,7 @@ struct ApprovalPanelView: View {
             // Persistent + session rules row
             HStack(spacing: 6) {
                 Button(action: {
-                    coordinator.handleAction(.alwaysDenyPattern(pattern: sessionPattern, isRegex: isRegexMode, explanation: noteToClaudeText.isEmpty ? nil : noteToClaudeText))
+                    coordinator.handleAction(.alwaysDenyPattern(pattern: sessionPattern, isRegex: isRegexMode, explanation: noteToClaudeText.isEmpty ? nil : noteToClaudeText), on: sessionPanel)
                 }) {
                     Label("Always Deny", systemImage: "hand.raised")
                 }
@@ -330,7 +345,7 @@ struct ApprovalPanelView: View {
                 .keyboardShortcut("d", modifiers: [.command, .shift])
 
                 Button(action: {
-                    coordinator.handleAction(.alwaysAllowPattern(pattern: sessionPattern, isRegex: isRegexMode))
+                    coordinator.handleAction(.alwaysAllowPattern(pattern: sessionPattern, isRegex: isRegexMode), on: sessionPanel)
                 }) {
                     Label("Always Allow", systemImage: "shield.checkered")
                 }
@@ -339,7 +354,7 @@ struct ApprovalPanelView: View {
                 .keyboardShortcut("a", modifiers: [.command, .shift])
 
                 Button(action: {
-                    coordinator.handleAction(.alwaysPromptPattern(pattern: sessionPattern, isRegex: isRegexMode))
+                    coordinator.handleAction(.alwaysPromptPattern(pattern: sessionPattern, isRegex: isRegexMode), on: sessionPanel)
                 }) {
                     Label("Always Prompt", systemImage: "bell.badge")
                 }
@@ -355,7 +370,7 @@ struct ApprovalPanelView: View {
                         context: noteToClaudeText.isEmpty ? nil : noteToClaudeText,
                         updatedCommand: cmdIfModified,
                         updatedInput: updatedInputIfModified
-                    ))
+                    ), on: sessionPanel)
                 }) {
                     Label("Session Allow", systemImage: "checkmark.shield")
                 }
@@ -369,7 +384,7 @@ struct ApprovalPanelView: View {
                 Button(action: {
                     coordinator.handleAction(.deny(
                         context: noteToClaudeText.isEmpty ? nil : noteToClaudeText
-                    ))
+                    ), on: sessionPanel)
                 }) {
                     Label("Deny", systemImage: "xmark.circle")
                 }
@@ -384,7 +399,7 @@ struct ApprovalPanelView: View {
                         context: noteToClaudeText.isEmpty ? nil : noteToClaudeText,
                         updatedCommand: cmdIfModified,
                         updatedInput: updatedInputIfModified
-                    ))
+                    ), on: sessionPanel)
                 }) {
                     Label("Allow Once", systemImage: "checkmark.circle")
                 }
@@ -462,13 +477,13 @@ struct ApprovalPanelView: View {
 
     /// Returns the edited command only if it differs from the original.
     private var cmdIfModified: String? {
-        guard let original = coordinator.currentApproval?.payload.command else { return nil }
+        guard let original = sessionPanel.currentApproval?.payload.command else { return nil }
         return editedCommand != original ? editedCommand : nil
     }
 
     /// Returns updated toolInput if any editable fields were modified.
     private var updatedInputIfModified: [String: AnyCodable]? {
-        guard let payload = coordinator.currentApproval?.payload else { return nil }
+        guard let payload = sessionPanel.currentApproval?.payload else { return nil }
         let changes = editedFields.filter { key, value in
             value != (payload.toolInput[key]?.stringValue ?? "")
         }

--- a/Sources/Gavel/Approval/PatternMatcher.swift
+++ b/Sources/Gavel/Approval/PatternMatcher.swift
@@ -7,8 +7,11 @@ import Foundation
 /// 2. **Protected path patterns** — block Write/Edit to sensitive file paths
 struct PatternMatcher {
 
-    /// Pre-compiled dangerous bash command patterns.
+    /// Pre-compiled dangerous bash command patterns — hard block.
     private let bashPatterns: [(regex: NSRegularExpression, reason: String)]
+
+    /// Pre-compiled bash patterns that force dialog — destructive but sometimes legitimate.
+    private let askUserBashPatterns: [(regex: NSRegularExpression, reason: String)]
 
     /// Pre-compiled protected file path patterns — hard block (credentials, persistence).
     private let protectedPaths: [(regex: NSRegularExpression, reason: String)]
@@ -16,8 +19,11 @@ struct PatternMatcher {
     /// Pre-compiled protected file path patterns — force dialog (config, hooks, shell).
     private let askUserPaths: [(regex: NSRegularExpression, reason: String)]
 
-    /// Pre-compiled sensitive read patterns (for Read tool — secrets/keys only).
+    /// Pre-compiled sensitive read patterns — hard block (actual secrets).
     private let sensitiveReads: [(regex: NSRegularExpression, reason: String)]
+
+    /// Pre-compiled sensitive read patterns — force dialog (configuration).
+    private let askUserReads: [(regex: NSRegularExpression, reason: String)]
 
     init() {
         let rawBash: [(pattern: String, reason: String)] = [
@@ -56,11 +62,7 @@ struct PatternMatcher {
             ("\\blaunchctl\\b\\s+(load|unload|submit|bootstrap|bootout|enable|disable|kickstart)", "LaunchAgent/Daemon modification"),
             ("\\bat\\b\\s+", "at job scheduling"),
 
-            // ── Destructive operations (expanded) ──
-            ("\\brm\\s+-\\w*[rR]\\w*\\s+/(?!tmp\\b)", "Recursive delete from root"),
-            ("\\brm\\s+-\\w*[rR]\\w*\\s+\\./", "Recursive delete from current directory"),
-            ("\\brm\\s+-\\w*[rR]\\w*\\s+\\.\\./", "Recursive delete from parent directory"),
-            ("\\brm\\s+--recursive", "Recursive delete (long flag)"),
+            // ── Destructive operations (catastrophic, non-recoverable) ──
             ("\\bmkfs\\b", "Filesystem format command"),
             ("\\bdd\\b\\s+.*of=/dev/", "Direct disk write"),
 
@@ -99,6 +101,19 @@ struct PatternMatcher {
             ("\\bchmod\\b.*\\+x.*/tmp/", "Making temp file executable"),
         ]
 
+        // Destructive/sensitive bash commands — force dialog instead of hard block
+        let rawAskUserBash: [(pattern: String, reason: String)] = [
+            // Recursive delete
+            ("\\brm\\s+-\\w*[rR]\\w*\\s+/(?!tmp\\b)", "Recursive delete from root path"),
+            ("\\brm\\s+-\\w*[rR]\\w*\\s+\\./", "Recursive delete from current directory"),
+            ("\\brm\\s+-\\w*[rR]\\w*\\s+\\.\\./", "Recursive delete from parent directory"),
+            ("\\brm\\s+--recursive", "Recursive delete (long flag)"),
+            // Cloud CLI write operations
+            ("\\baz\\s+.*\\b(update|create|delete|set|add|remove|start|stop|restart)\\b", "Azure CLI write operation"),
+            ("\\baws\\s+.*\\b(create|delete|update|put|remove|terminate|stop|start|modify|run)\\b(?!.*--dry-run)", "AWS CLI write operation"),
+            ("\\bgcloud\\s+.*\\b(create|delete|update|add|remove|start|stop|deploy)\\b", "GCloud CLI write operation"),
+        ]
+
         // Hard block — credentials and persistence vectors that should never be written
         let rawPaths: [(pattern: String, reason: String)] = [
             // SSH keys and config
@@ -132,6 +147,13 @@ struct PatternMatcher {
             return (regex, entry.reason)
         }
 
+        askUserBashPatterns = rawAskUserBash.compactMap { entry in
+            guard let regex = try? NSRegularExpression(pattern: entry.pattern, options: [.caseInsensitive]) else {
+                return nil
+            }
+            return (regex, entry.reason)
+        }
+
         protectedPaths = rawPaths.compactMap { entry in
             guard let regex = try? NSRegularExpression(pattern: entry.pattern, options: [.caseInsensitive]) else {
                 return nil
@@ -146,6 +168,7 @@ struct PatternMatcher {
             return (regex, entry.reason)
         }
 
+        // Hard block — actual secrets that should never be read
         let rawSensitiveReads: [(pattern: String, reason: String)] = [
             // SSH private keys
             ("\\.ssh/(id_|id_rsa|id_ed25519|id_ecdsa)", "Blocked: SSH private key read"),
@@ -158,8 +181,6 @@ struct PatternMatcher {
             // Environment files with secrets
             ("\\.env$", "Blocked: Environment file read"),
             ("\\.env\\.local$", "Blocked: Local environment file read"),
-            // Gavel rules (prevent reading to reverse-engineer deny patterns)
-            ("\\.claude/gavel/rules\\.json", "Blocked: Gavel rules read"),
             // Keychain
             ("Keychains/", "Blocked: Keychain access"),
             // Token/credential files
@@ -170,7 +191,20 @@ struct PatternMatcher {
             ("\\.netrc$", "Blocked: netrc credentials"),
         ]
 
+        // Ask user — configuration that may need reading for self-mutation
+        let rawAskUserReads: [(pattern: String, reason: String)] = [
+            ("\\.claude/gavel/rules\\.json", "Sensitive: Gavel rules read"),
+            ("\\.claude/gavel/session-defaults\\.json", "Sensitive: Gavel defaults read"),
+        ]
+
         sensitiveReads = rawSensitiveReads.compactMap { entry in
+            guard let regex = try? NSRegularExpression(pattern: entry.pattern, options: [.caseInsensitive]) else {
+                return nil
+            }
+            return (regex, entry.reason)
+        }
+
+        askUserReads = rawAskUserReads.compactMap { entry in
             guard let regex = try? NSRegularExpression(pattern: entry.pattern, options: [.caseInsensitive]) else {
                 return nil
             }
@@ -238,15 +272,38 @@ struct PatternMatcher {
     /// Check sensitive paths that require user confirmation (gavel config, hooks, shell config).
     /// Called from ApprovalEngine AFTER allow rules — returns askUser decision.
     func matchSensitivePath(payload: PreToolUsePayload) -> String? {
-        guard ["Write", "Edit", "MultiEdit"].contains(payload.toolName) else { return nil }
-        guard let path = payload.filePath else { return nil }
-
-        let range = NSRange(path.startIndex..., in: path)
-        for (regex, reason) in askUserPaths {
-            if regex.firstMatch(in: path, range: range) != nil {
-                return reason
+        // Bash: check askUser destructive patterns (rm -rf etc.)
+        if payload.toolName == "Bash", let command = payload.command {
+            let stripped = Self.stripQuotedContent(command)
+            let range = NSRange(stripped.startIndex..., in: stripped)
+            for (regex, reason) in askUserBashPatterns {
+                if regex.firstMatch(in: stripped, range: range) != nil {
+                    return reason
+                }
             }
         }
+
+        guard let path = payload.filePath else { return nil }
+        let range = NSRange(path.startIndex..., in: path)
+
+        // Write/Edit: check askUser write paths
+        if ["Write", "Edit", "MultiEdit"].contains(payload.toolName) {
+            for (regex, reason) in askUserPaths {
+                if regex.firstMatch(in: path, range: range) != nil {
+                    return reason
+                }
+            }
+        }
+
+        // Read: check askUser read paths (config files needed for self-mutation)
+        if payload.toolName == "Read" {
+            for (regex, reason) in askUserReads {
+                if regex.firstMatch(in: path, range: range) != nil {
+                    return reason
+                }
+            }
+        }
+
         return nil
     }
 

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -145,12 +145,9 @@ struct SessionRule: Identifiable {
         switch toolName {
         case "Bash":
             guard let cmd = command, !cmd.isEmpty else { return "*" }
-            let parts = cmd.split(separator: " ", maxSplits: 2)
-            if parts.count >= 2 {
-                // "swift build -c release" → "swift build*"
-                return "\(parts[0]) \(parts[1])*"
-            }
-            return "\(parts[0]) *"
+            // Use the full command so Session Allow matches exactly this command.
+            // User can edit the pattern to broaden it (e.g. add * wildcard).
+            return cmd
 
         case "Edit", "MultiEdit", "Write":
             guard let path = filePath else { return "*" }


### PR DESCRIPTION
## Summary
- **Per-PID approval panels**: Each Claude Code session gets its own floating window with project CWD in title. Panels offset so they don't stack. Independent queues -- approvals across projects don't block each other
- **Cloud CLI write ops**: az/aws/gcloud update/create/delete/modify etc. now force approval dialog via hardcoded askUser bash patterns. AWS --dry-run exempted
- **rm -rf → Always Ask**: Moved from hard block to forced dialog. User sees full path before approving
- **rules.json read → Always Ask**: Enables supervised self-mutation. SSH keys, AWS creds, .env etc. remain hard blocked
- **Full command in pattern field**: Bash pattern shows entire command instead of truncated first-two-words. 3-line scrollable TextEditor

## Test plan
- [x] Live tested: per-PID panels with 3 simultaneous projects
- [x] Live tested: az network vnet update triggers dialog
- [x] Live tested: rm -rf triggers dialog instead of hard block
- [x] Live tested: rules.json read triggers dialog instead of hard block
- [x] Live tested: session hook self-mutation via Always Ask
- [x] Live tested: full command displayed in pattern field