### PR TITLE
Homebrew install support, session context, green icon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build release binaries
+        run: swift build -c release
+
+      - name: Import signing certificate
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+
+          echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
+      - name: Sign binaries
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          IDENTITY="Developer ID Application: ($APPLE_TEAM_ID)"
+          codesign --force --options runtime --sign "$IDENTITY" .build/release/gavel
+          codesign --force --options runtime --sign "$IDENTITY" .build/release/gavel-hook
+          codesign --verify --verbose .build/release/gavel
+          codesign --verify --verbose .build/release/gavel-hook
+
+      - name: Package release tarball
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          STAGING="gavel-${VERSION}-macos-arm64"
+          mkdir -p "$STAGING/hooks" "$STAGING/defaults" "$STAGING/scripts"
+          cp .build/release/gavel .build/release/gavel-hook "$STAGING/"
+          cp hooks/*.sh "$STAGING/hooks/"
+          cp defaults/session-context.md "$STAGING/defaults/"
+          cp scripts/gavel-uninstall-hooks "$STAGING/scripts/"
+          tar czf "${STAGING}.tar.gz" "$STAGING"
+          shasum -a 256 "${STAGING}.tar.gz" > "${STAGING}.tar.gz.sha256"
+
+      - name: Notarize binaries
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          STAGING="gavel-${VERSION}-macos-arm64"
+          # Create a zip for notarization (notarytool requires zip or dmg)
+          ditto -c -k --keepParent "$STAGING" "${STAGING}-notarize.zip"
+          xcrun notarytool submit "${STAGING}-notarize.zip" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          rm "${STAGING}-notarize.zip"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          TARBALL="gavel-${VERSION}-macos-arm64.tar.gz"
+          SHA_FILE="${TARBALL}.sha256"
+          SHA=$(cat "$SHA_FILE" | awk '{print $1}')
+
+          gh release create "$VERSION" \
+            --title "Gavel ${VERSION}" \
+            --notes "$(cat <<EOF
+          ## Install
+
+          \`\`\`bash
+          brew tap JaysonRawlins/gavel
+          brew install gavel
+          brew services start gavel
+          \`\`\`
+
+          **SHA256:** \`${SHA}\`
+          EOF
+          )" \
+            "$TARBALL" "$SHA_FILE"
+
+      - name: Cleanup keychain
+        if: always()
+        run: security delete-keychain "$RUNNER_TEMP/signing.keychain-db" 2>/dev/null || true

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -7,7 +7,7 @@ struct MonitorWindow: View {
     @State private var selectedTab: MonitorTab = .feed
 
     enum MonitorTab {
-        case feed, rules, sessions, tester, reference
+        case feed, rules, sessions, context, tester, reference
     }
 
     var body: some View {
@@ -39,6 +39,7 @@ struct MonitorWindow: View {
                 Text("Feed").tag(MonitorTab.feed)
                 Text("Rules (\(viewModel.ruleCount))").tag(MonitorTab.rules)
                 Text("Sessions").tag(MonitorTab.sessions)
+                Text("Context").tag(MonitorTab.context)
                 Text("Tester").tag(MonitorTab.tester)
                 Text("Reference").tag(MonitorTab.reference)
             }
@@ -56,6 +57,8 @@ struct MonitorWindow: View {
                 RulesView(viewModel: viewModel)
             case .sessions:
                 SessionRulesView(viewModel: viewModel)
+            case .context:
+                SessionContextView()
             case .tester:
                 RegexTesterView(viewModel: viewModel)
             case .reference:

--- a/Sources/Gavel/Monitor/SessionContextView.swift
+++ b/Sources/Gavel/Monitor/SessionContextView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// Editor for ~/.claude/gavel/session-context.md — injected into every Claude Code session.
+struct SessionContextView: View {
+    @State private var content: String = ""
+    @State private var savedContent: String = ""
+    @State private var statusMessage: String?
+
+    private static let contextPath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".claude/gavel/session-context.md")
+
+    private var hasChanges: Bool { content != savedContent }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Session Context")
+                        .font(.headline)
+                    Text("Injected into every Claude Code session at startup")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                if let msg = statusMessage {
+                    Text(msg)
+                        .font(.caption)
+                        .foregroundColor(.green)
+                        .transition(.opacity)
+                }
+
+                Button(action: openInEditor) {
+                    Label("Open in Editor", systemImage: "square.and.pencil")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .help("Open in your default .md editor")
+
+                Button(action: save) {
+                    Label("Save", systemImage: "square.and.arrow.down")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(!hasChanges)
+                .keyboardShortcut("s", modifiers: .command)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(Color(nsColor: .controlBackgroundColor))
+
+            Divider()
+
+            TextEditor(text: $content)
+                .font(.system(.body, design: .monospaced))
+                .padding(4)
+        }
+        .onAppear { load() }
+    }
+
+    private func load() {
+        let path = Self.contextPath.path
+        if let data = FileManager.default.contents(atPath: path),
+           let text = String(data: data, encoding: .utf8) {
+            content = text
+            savedContent = text
+        }
+    }
+
+    private func save() {
+        do {
+            try content.write(to: Self.contextPath, atomically: true, encoding: .utf8)
+            savedContent = content
+            statusMessage = "Saved"
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                if statusMessage == "Saved" { statusMessage = nil }
+            }
+        } catch {
+            statusMessage = "Save failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func openInEditor() {
+        if !FileManager.default.fileExists(atPath: Self.contextPath.path) {
+            save()
+        }
+        EditorPreference.open(Self.contextPath)
+    }
+}

--- a/Sources/Gavel/System/EditorPreference.swift
+++ b/Sources/Gavel/System/EditorPreference.swift
@@ -1,0 +1,54 @@
+import AppKit
+import UniformTypeIdentifiers
+
+/// Discovers installed editors and remembers the user's choice.
+enum EditorPreference {
+    private static let key = "preferredEditorBundleID"
+
+    static var preferredBundleID: String? {
+        get { UserDefaults.standard.string(forKey: key) }
+        set { UserDefaults.standard.set(newValue, forKey: key) }
+    }
+
+    /// All apps that can open .md files, sorted with common editors first.
+    static func availableEditors() -> [(name: String, bundleID: String, url: URL)] {
+        let mdType = UTType(filenameExtension: "md") ?? .plainText
+        let appURLs = NSWorkspace.shared.urlsForApplications(toOpen: mdType)
+
+        let priorityBundles = [
+            "dev.zed.Zed",
+            "com.microsoft.VSCode",
+            "com.sublimetext.4",
+            "com.sublimetext.3",
+            "com.jetbrains.intellij",
+            "com.apple.dt.Xcode",
+            "com.apple.TextEdit",
+        ]
+
+        var editors: [(name: String, bundleID: String, url: URL)] = []
+        for url in appURLs {
+            guard let bundle = Bundle(url: url),
+                  let bundleID = bundle.bundleIdentifier else { continue }
+            let name = FileManager.default.displayName(atPath: url.path)
+            editors.append((name: name, bundleID: bundleID, url: url))
+        }
+
+        return editors.sorted { a, b in
+            let ai = priorityBundles.firstIndex(of: a.bundleID) ?? Int.max
+            let bi = priorityBundles.firstIndex(of: b.bundleID) ?? Int.max
+            if ai != bi { return ai < bi }
+            return a.name < b.name
+        }
+    }
+
+    /// Open a file in the user's preferred editor, falling back to system default.
+    static func open(_ url: URL) {
+        if let bundleID = preferredBundleID,
+           let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
+            let config = NSWorkspace.OpenConfiguration()
+            NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: config)
+        } else {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftUI
 
 /// Gavel — Native macOS daemon for Claude Code session monitoring and approval.
@@ -12,6 +13,7 @@ import SwiftUI
 class GavelAppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem!
     private var monitorWindow: NSWindow?
+    private var cancellables = Set<AnyCancellable>()
 
     let sessionManager = SessionManager()
     let approvalEngine = ApprovalEngine()
@@ -41,6 +43,13 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         setupSocketServer()
         setupHookRouter()
         GavelNotifications.requestPermission()
+
+        sessionManager.$defaultAutoApprove
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] autoApprove in
+                self?.updateMenuBarIcon(autoApprove: autoApprove)
+            }
+            .store(in: &cancellables)
 
         NSApp.setActivationPolicy(.accessory) // Menu bar only, no dock icon
     }
@@ -82,13 +91,15 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
     private func setupMenuBar() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         if let button = statusItem.button {
-            button.image = NSImage(systemSymbolName: "gavel.fill", accessibilityDescription: "Gavel")
-                ?? NSImage(systemSymbolName: "shield.checkered", accessibilityDescription: "Gavel")
             button.toolTip = "Gavel — Claude Code Monitor"
         }
+        updateMenuBarIcon(autoApprove: sessionManager.defaultAutoApprove)
 
         let menu = NSMenu()
         menu.addItem(NSMenuItem(title: "Show Monitor", action: #selector(showMonitor), keyEquivalent: ""))
+        let contextItem = NSMenuItem(title: "Edit Session Context", action: nil, keyEquivalent: "")
+        contextItem.submenu = buildEditorSubmenu()
+        menu.addItem(contextItem)
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Pause All Sessions", action: #selector(togglePauseAll), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Clear Session Rules", action: #selector(revokeAll), keyEquivalent: ""))
@@ -96,6 +107,24 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem(title: "Restart Gavel", action: #selector(reloadBinary), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Quit Gavel", action: #selector(quit), keyEquivalent: ""))
         statusItem.menu = menu
+    }
+
+    private func updateMenuBarIcon(autoApprove: Bool) {
+        guard let button = statusItem.button else { return }
+        let symbolName = "gavel.fill"
+        let fallback = "shield.checkered"
+
+        if autoApprove {
+            let config = NSImage.SymbolConfiguration(paletteColors: [.systemGreen])
+            let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: "Gavel — Auto-approve on")
+                ?? NSImage(systemSymbolName: fallback, accessibilityDescription: "Gavel — Auto-approve on")
+            button.image = image?.withSymbolConfiguration(config)
+            button.image?.isTemplate = false
+        } else {
+            let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: "Gavel")
+                ?? NSImage(systemSymbolName: fallback, accessibilityDescription: "Gavel")
+            button.image = image
+        }
     }
 
     @objc private func showMonitor() {
@@ -115,6 +144,77 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         }
         monitorWindow?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func buildEditorSubmenu() -> NSMenu {
+        let submenu = NSMenu()
+        let editors = EditorPreference.availableEditors()
+        let preferred = EditorPreference.preferredBundleID
+
+        for editor in editors {
+            let item = NSMenuItem(title: editor.name, action: #selector(openContextWithEditor(_:)), keyEquivalent: "")
+            item.representedObject = editor.bundleID
+            item.target = self
+            if editor.bundleID == preferred {
+                item.state = .on
+            }
+            submenu.addItem(item)
+        }
+
+        if editors.isEmpty {
+            submenu.addItem(NSMenuItem(title: "No editors found", action: nil, keyEquivalent: ""))
+        }
+
+        return submenu
+    }
+
+    @objc private func openContextWithEditor(_ sender: NSMenuItem) {
+        guard let bundleID = sender.representedObject as? String else { return }
+        EditorPreference.preferredBundleID = bundleID
+
+        // Rebuild submenu to update checkmark
+        if let contextItem = statusItem.menu?.items.first(where: { $0.title == "Edit Session Context" }) {
+            contextItem.submenu = buildEditorSubmenu()
+        }
+
+        let contextPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/gavel/session-context.md")
+        if !FileManager.default.fileExists(atPath: contextPath.path) {
+            seedSessionContext()
+        }
+        EditorPreference.open(contextPath)
+    }
+
+    /// Copy the default session-context.md if none exists.
+    private func seedSessionContext() {
+        let dest = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/gavel/session-context.md")
+        guard !FileManager.default.fileExists(atPath: dest.path) else { return }
+        let fallback = """
+        # Session Context — Gavel Performance Tuning
+
+        These instructions are injected into every Claude Code session at startup.
+        Edit this file to customize how Claude behaves in your projects.
+
+        ## Engineering Principles
+
+        - Orthogonal design: single responsibility per component, changes don't cascade
+        - Fail fast, fail loud: validate early, surface errors immediately, never swallow exceptions
+        - Minimal coupling: depend on interfaces not implementations, composition over inheritance
+
+        ## Code Quality
+
+        - Functions under 30 lines, files under 300: if it's longer, split it
+        - Name things for the reader: variable names explain WHY not WHAT
+        - One level of abstraction per function
+        - Reduce nesting: early returns > deeply nested if/else
+
+        ## Verification
+
+        - A successful build proves syntax, not behavior. Run the actual feature path.
+        - If something fails: read the error and trace it. Don't guess-and-retry.
+        """
+        FileManager.default.createFile(atPath: dest.path, contents: Data(fallback.utf8))
     }
 
     @objc private func togglePauseAll() {

--- a/defaults/session-context.md
+++ b/defaults/session-context.md
@@ -1,0 +1,43 @@
+# Session Context — Gavel Performance Tuning
+
+These instructions are injected into every Claude Code session at startup.
+Edit this file to customize how Claude behaves in your projects.
+
+## Engineering Principles
+
+- Orthogonal design: single responsibility per component, changes don't cascade
+- Fail fast, fail loud: validate early, surface errors immediately, never swallow exceptions
+- Minimal coupling: depend on interfaces not implementations, composition over inheritance
+- Make illegal states unrepresentable: use types and enums to eliminate invalid states at compile time
+
+## Code Quality
+
+- Functions under 30 lines, files under 300: if it's longer, it's doing too much — split it
+- Name things for the reader: variable names should explain WHY not WHAT (userCanEdit > flag)
+- One level of abstraction per function: don't mix high-level flow with low-level details
+- No magic numbers or strings: extract constants with meaningful names
+- Reduce nesting: early returns > deeply nested if/else chains
+
+## Comments
+
+Comments earn their place by doing something the code cannot. Default to fewer comments, not more.
+
+- If a line needs a comment to be understood, first try to rewrite the code: better names, smaller functions, extracted constants
+- Structured doc-comments are fine wherever they feed a documentation pipeline (JSDoc, rustdoc, godoc, etc.)
+- One-line exceptions are fine: flag a non-obvious invariant, a workaround, a known race, or a "must stay in sync with X"
+- Never add comments just to narrate what the next line does
+
+## Verification
+
+- A successful build/compile proves syntax, not behavior. Always run the actual feature path.
+- When adopting a new library or API: write a minimal spike that exercises the specific capability BEFORE building it into the larger feature
+- If something fails unexpectedly: read the actual error and trace it. Don't guess-and-retry.
+
+## Two-Witness Rule
+
+Never conclude something is absent, unsupported, or impossible from a single check.
+
+- 'Not found' after one grep/glob — search with alternate names, casing, or patterns before concluding
+- 'This library doesn't support X' from training knowledge — verify against actual docs or source
+- 'This env/tool isn't installed' from one command — try alternate paths or version managers
+- When only one source was checked, say so: 'I checked X and didn't find it, but I haven't verified via Y.'

--- a/hooks/post_tool_use.sh
+++ b/hooks/post_tool_use.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # Gavel PostToolUse hook — fire-and-forget to daemon.
-GAVEL_HOOK="${GAVEL_HOOK:-$HOME/.claude/gavel/bin/gavel-hook}"
-[[ -x "$GAVEL_HOOK" ]] || GAVEL_HOOK="$(dirname "$0")/../.build/release/gavel-hook"
+# Resolution: $GAVEL_HOOK env → PATH → ~/.claude/gavel/bin/ → dev fallback
+GAVEL_HOOK="${GAVEL_HOOK:-}"
+[[ -z "$GAVEL_HOOK" ]] && GAVEL_HOOK="$(command -v gavel-hook 2>/dev/null || true)"
+[[ -z "$GAVEL_HOOK" || ! -x "$GAVEL_HOOK" ]] && GAVEL_HOOK="$HOME/.claude/gavel/bin/gavel-hook"
+[[ ! -x "$GAVEL_HOOK" ]] && GAVEL_HOOK="$(dirname "$0")/../.build/release/gavel-hook"
 if [[ -x "$GAVEL_HOOK" ]]; then
     CLAUDE_HOOK_TYPE=PostToolUse exec "$GAVEL_HOOK"
 else

--- a/hooks/pre_tool_use.sh
+++ b/hooks/pre_tool_use.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 # Gavel PreToolUse hook — pipes stdin to daemon, prints response.
-# Checks installed path first, falls back to dev .build/ path.
-GAVEL_HOOK="${GAVEL_HOOK:-$HOME/.claude/gavel/bin/gavel-hook}"
-[[ -x "$GAVEL_HOOK" ]] || GAVEL_HOOK="$(dirname "$0")/../.build/release/gavel-hook"
+# Resolution: $GAVEL_HOOK env → PATH → ~/.claude/gavel/bin/ → dev fallback
+GAVEL_HOOK="${GAVEL_HOOK:-}"
+[[ -z "$GAVEL_HOOK" ]] && GAVEL_HOOK="$(command -v gavel-hook 2>/dev/null || true)"
+[[ -z "$GAVEL_HOOK" || ! -x "$GAVEL_HOOK" ]] && GAVEL_HOOK="$HOME/.claude/gavel/bin/gavel-hook"
+[[ ! -x "$GAVEL_HOOK" ]] && GAVEL_HOOK="$(dirname "$0")/../.build/release/gavel-hook"
 if [[ -x "$GAVEL_HOOK" ]]; then
     CLAUDE_HOOK_TYPE=PreToolUse exec "$GAVEL_HOOK"
 else

--- a/hooks/session_start.sh
+++ b/hooks/session_start.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
-# Gavel SessionStart hook — registers session with daemon.
-GAVEL_HOOK="${GAVEL_HOOK:-$HOME/.claude/gavel/bin/gavel-hook}"
-[[ -x "$GAVEL_HOOK" ]] || GAVEL_HOOK="$(dirname "$0")/../.build/release/gavel-hook"
+# Gavel SessionStart hook — injects session context then registers with daemon.
+# Resolution: $GAVEL_HOOK env → PATH → ~/.claude/gavel/bin/ → dev fallback
+CONTEXT_FILE="$HOME/.claude/gavel/session-context.md"
+if [[ -f "$CONTEXT_FILE" ]]; then
+    cat "$CONTEXT_FILE"
+fi
+
+GAVEL_HOOK="${GAVEL_HOOK:-}"
+[[ -z "$GAVEL_HOOK" ]] && GAVEL_HOOK="$(command -v gavel-hook 2>/dev/null || true)"
+[[ -z "$GAVEL_HOOK" || ! -x "$GAVEL_HOOK" ]] && GAVEL_HOOK="$HOME/.claude/gavel/bin/gavel-hook"
+[[ ! -x "$GAVEL_HOOK" ]] && GAVEL_HOOK="$(dirname "$0")/../.build/release/gavel-hook"
 if [[ -x "$GAVEL_HOOK" ]]; then
     CLAUDE_HOOK_TYPE=SessionStart exec "$GAVEL_HOOK"
 else

--- a/hooks/stop.sh
+++ b/hooks/stop.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 # Gavel Stop hook — notifies daemon session is idle.
-# Daemon handles notifications via GavelNotifications.notify().
-GAVEL_HOOK="${GAVEL_HOOK:-$HOME/.claude/gavel/bin/gavel-hook}"
-[[ -x "$GAVEL_HOOK" ]] || GAVEL_HOOK="$(dirname "$0")/../.build/release/gavel-hook"
+# Resolution: $GAVEL_HOOK env → PATH → ~/.claude/gavel/bin/ → dev fallback
+GAVEL_HOOK="${GAVEL_HOOK:-}"
+[[ -z "$GAVEL_HOOK" ]] && GAVEL_HOOK="$(command -v gavel-hook 2>/dev/null || true)"
+[[ -z "$GAVEL_HOOK" || ! -x "$GAVEL_HOOK" ]] && GAVEL_HOOK="$HOME/.claude/gavel/bin/gavel-hook"
+[[ ! -x "$GAVEL_HOOK" ]] && GAVEL_HOOK="$(dirname "$0")/../.build/release/gavel-hook"
 if [[ -x "$GAVEL_HOOK" ]]; then
     CLAUDE_HOOK_TYPE=Stop exec "$GAVEL_HOOK"
 else

--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,14 @@ for f in hooks/*.sh; do
     chmod +x "$HOOKS_DIR/$(basename "$f")"
 done
 
+CONTEXT_FILE="$HOME/.claude/gavel/session-context.md"
+if [[ ! -f "$CONTEXT_FILE" ]]; then
+    echo "Seeding session context with default performance tuning..."
+    cp defaults/session-context.md "$CONTEXT_FILE"
+else
+    echo "Session context already exists, skipping seed (edit via menu bar)"
+fi
+
 echo "Installing LaunchAgent..."
 mkdir -p "$PLIST_DIR"
 cat > "$PLIST" <<PLIST

--- a/scripts/gavel-uninstall-hooks
+++ b/scripts/gavel-uninstall-hooks
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Remove gavel hooks from ~/.claude/settings.json
+# Run this before `brew uninstall gavel`
+set -e
+
+SETTINGS="$HOME/.claude/settings.json"
+if [[ ! -f "$SETTINGS" ]]; then
+    echo "No settings.json found at $SETTINGS"
+    exit 0
+fi
+
+if ! command -v ruby &>/dev/null; then
+    echo "ERROR: ruby not found. Manually remove gavel entries from $SETTINGS"
+    exit 1
+fi
+
+ruby -rjson -e '
+  path = "'"$SETTINGS"'"
+  cfg = JSON.parse(File.read(path))
+  hooks = cfg["hooks"] || {}
+  changed = false
+  hooks.each do |event, entries|
+    original_size = entries.size
+    entries.reject! do |entry|
+      (entry["hooks"] || []).any? { |h| (h["command"] || "").include?("gavel") }
+    end
+    changed = true if entries.size != original_size
+  end
+  hooks.delete_if { |_, v| v.empty? }
+  if changed
+    File.write(path, JSON.pretty_generate(cfg))
+    puts "Removed gavel hooks from settings.json"
+  else
+    puts "No gavel hooks found in settings.json"
+  end
+'
+
+if [[ -d "$HOME/.claude/gavel/hooks" ]]; then
+    rm -rf "$HOME/.claude/gavel/hooks"
+    echo "Removed ~/.claude/gavel/hooks/"
+fi
+
+echo "Done. You can now run: brew uninstall gavel"
+echo "Note: ~/.claude/gavel/ config files (rules.json, session-context.md) are preserved."


### PR DESCRIPTION
## Summary

- Green menu bar icon when default auto-approve is on
- Session context injection system: `~/.claude/gavel/session-context.md` seeded with universal engineering principles, injected on every SessionStart
- Context tab in Monitor window with inline editor (Cmd+S) and "Open in Editor" button
- Editor preference picker — discovers installed editors via UTType, persists choice
- PATH-based hook shim resolution for Homebrew compatibility
- `gavel-uninstall-hooks` helper script for clean removal
- GitHub Actions release workflow: build → codesign → notarize → GitHub Release
- `install.sh` seeds session-context.md on fresh install

## Test plan

- [ ] 200 tests pass (`swift test`)
- [ ] Green icon appears when Default Auto toggled on, reverts when off
- [ ] Edit Session Context submenu shows installed editors with checkmark
- [ ] Context tab loads/saves session-context.md, Open in Editor uses preferred editor
- [ ] New Claude Code session shows injected engineering principles
- [ ] Hook shims resolve gavel-hook via PATH (Homebrew) and fallback (manual install)
- [ ] `gavel-uninstall-hooks` removes entries from settings.json
- [ ] Release workflow triggers on tag push (test after merge)