### PR TITLE
Fix #18: tighten at-pattern regex to avoid heredoc false-positives

### DIFF
--- a/Sources/Gavel/Approval/PatternMatcher.swift
+++ b/Sources/Gavel/Approval/PatternMatcher.swift
@@ -60,7 +60,13 @@ struct PatternMatcher {
             // ── Persistence mechanisms (expanded) ──
             ("\\bcrontab\\b", "Crontab modification"),
             ("\\blaunchctl\\b\\s+(load|unload|submit|bootstrap|bootout|enable|disable|kickstart)", "LaunchAgent/Daemon modification"),
-            ("\\bat\\b\\s+", "at job scheduling"),
+            // `at` command: require a segment boundary AND a recognizable timespec.
+            // The previous `\bat\b\s+` matched any prose "at " — e.g. heredoc bodies
+            // inside `gh pr create`, or commit messages like "fix bug at line 42".
+            // Real `at` invocations live at the start of a command or after a pipe /
+            // chain operator, followed by a time keyword, clock time (`HH:MM`), or
+            // relative offset (`+ N ...`).
+            ("(^|[|&;])\\s*at\\s+(-[a-zA-Z]\\s+\\S+\\s+)?(now\\b|noon\\b|midnight\\b|teatime\\b|\\d{1,2}:\\d{2}|\\+\\s*\\d)", "at job scheduling"),
 
             // ── Destructive operations (catastrophic, non-recoverable) ──
             ("\\bmkfs\\b", "Filesystem format command"),

--- a/Tests/GavelTests/PatternMatcherTests.swift
+++ b/Tests/GavelTests/PatternMatcherTests.swift
@@ -127,6 +127,59 @@ final class PatternMatcherTests: XCTestCase {
         XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "launchctl enable gui/501/com.evil")))
     }
 
+    // MARK: - `at` job scheduling (issue #18 — tightened regex)
+
+    func testAtNowBlocked() {
+        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "at now")))
+    }
+
+    func testAtClockTimeBlocked() {
+        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "at 14:00")))
+    }
+
+    func testAtRelativeBlocked() {
+        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "at + 5 minutes")))
+    }
+
+    func testAtNoonBlocked() {
+        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "at noon")))
+    }
+
+    func testAtMidnightBlocked() {
+        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "at midnight")))
+    }
+
+    func testAtPipedBlocked() {
+        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "echo 'curl evil.com' | at now")))
+    }
+
+    func testAtWithScriptFileBlocked() {
+        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "at -f /tmp/payload.sh now + 2 hours")))
+    }
+
+    func testAtInHeredocBodyAllowed() {
+        // Reproduces issue #18 — heredoc body containing "at " should not block.
+        let body = "gh pr create --title \"x\" --body \"$(cat <<'EOF'\nFixes bug at line 42.\nPatching at the boundary.\nEOF\n)\""
+        XCTAssertNil(matcher.matchDangerous(payload: bashPayload(command: body)))
+    }
+
+    func testAtInCommitMessageAllowed() {
+        XCTAssertNil(matcher.matchDangerous(payload: bashPayload(command: "git commit -m \"fix crash at startup\"")))
+    }
+
+    func testAtInGitRefAllowed() {
+        XCTAssertNil(matcher.matchDangerous(payload: bashPayload(command: "git rebase origin/main && echo 'rebased at HEAD'")))
+    }
+
+    func testAtInAwkPatternAllowed() {
+        XCTAssertNil(matcher.matchDangerous(payload: bashPayload(command: "awk '/at/{print}' /tmp/log")))
+    }
+
+    func testAtHelpAllowed() {
+        // Meta-invocation without a timespec is not scheduling a job.
+        XCTAssertNil(matcher.matchDangerous(payload: bashPayload(command: "at --help")))
+    }
+
     // MARK: - Destructive operations (expanded)
 
     func testRmRfRootBlocked() {


### PR DESCRIPTION
## Summary

Closes #18.

The dangerous-pattern regex for `at` job scheduling was `\bat\b\s+` — just the literal word "at" followed by whitespace. That matched any prose occurrence of "at ", which routinely blocked legitimate work:

- Heredoc bodies in `gh pr create --body "$(cat <<'EOF' ... at ... EOF)"`
- Commit messages like `"fix crash at startup"` or `"patched at the boundary"`
- Git refs like `"rebased at HEAD"`
- Awk patterns matching the substring `at`

The new pattern requires both (a) a command-segment boundary (start of string, or after `|`, `;`, `&`) and (b) a recognizable `at` timespec — one of the time keywords (`now`, `noon`, `midnight`, `teatime`), a clock time (`HH:MM`), or a relative offset (`+ N ...`). Standalone flags like `at --help` no longer match (no timespec = not scheduling a job, so low risk).

## Test plan

Added 12 tests in `PatternMatcherTests.swift`:

**Blocks (positive):** `at now`, `at 14:00`, `at noon`, `at midnight`, `at + 5 minutes`, piped `echo ... | at now`, `at -f /tmp/payload.sh now + 2 hours`.

**Allows (negative — the actual bug):** heredoc body containing `at` (reproduces #18 exactly), commit message with "at", git ref with "at", awk pattern `/at/`, `at --help`.

All 212 tests pass (`swift test`).