### PR TITLE
Add built-in prompt rules for scheduler tools (CronCreate, ScheduleWakeup, CronDelete)

### DIFF
--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -15,7 +15,7 @@ final class RuleStore: ObservableObject {
     private let configPath: String
 
     /// Current seed version — bump when adding new default rules.
-    private static let seedVersion = 6
+    private static let seedVersion = 7
 
     init(configPath: String? = nil) {
         self.configPath = configPath ?? Self.defaultConfigPath
@@ -214,6 +214,36 @@ final class RuleStore: ObservableObject {
             isRegex: true,
             verdict: .prompt,
             explanation: "Push to main/master — verify changes before pushing",
+            builtIn: true
+        ),
+
+        // ── Persistence-creating scheduler tools ──
+        // These plant future execution that fires while the user may not be watching.
+        // Prompt even under auto-approve so the user sees and confirms each one.
+        // Using toolName="*" with an anchored regex pattern gives each rule a
+        // unique pattern string — needed because seed-migration dedupes on pattern.
+        PersistentRule(
+            toolName: "*",
+            pattern: "^CronCreate$",
+            isRegex: true,
+            verdict: .prompt,
+            explanation: "Scheduling a future prompt — plants delayed execution that runs autonomously",
+            builtIn: true
+        ),
+        PersistentRule(
+            toolName: "*",
+            pattern: "^ScheduleWakeup$",
+            isRegex: true,
+            verdict: .prompt,
+            explanation: "Scheduling session re-entry — Claude will resume with this prompt at the given delay",
+            builtIn: true
+        ),
+        PersistentRule(
+            toolName: "*",
+            pattern: "^CronDelete$",
+            isRegex: true,
+            verdict: .prompt,
+            explanation: "Deleting a scheduled job — could remove legitimate user-created schedules",
             builtIn: true
         ),
     ]

--- a/Tests/GavelTests/PersistentRuleTests.swift
+++ b/Tests/GavelTests/PersistentRuleTests.swift
@@ -185,8 +185,9 @@ final class PersistentRuleTests: XCTestCase {
         let store = RuleStore(configPath: "/dev/null")
         let builtInRules = store.rules.filter { $0.builtIn }
         XCTAssertEqual(builtInRules.count, RuleStore.seededDefaults.count)
-        // v6: 5 MCP exfil + 1 self-protection + 1 scripting + 3 sandbox escape + 2 git safety = 12
-        XCTAssertEqual(builtInRules.count, 12)
+        // v7: 5 MCP exfil + 1 self-protection + 1 scripting + 3 sandbox escape
+        //     + 2 git safety + 3 scheduler = 15
+        XCTAssertEqual(builtInRules.count, 15)
     }
 
     func testSeededRulesArePromptVerdict() {
@@ -252,6 +253,63 @@ final class PersistentRuleTests: XCTestCase {
         XCTAssertNil(store.evaluateBuiltInPrompt(payload: payload))
         // evaluateUserPrompt SHOULD match it
         XCTAssertNotNil(store.evaluateUserPrompt(payload: payload))
+    }
+
+    // MARK: - Scheduler tool built-in rules (issue #29)
+
+    func testCronCreatePrompts() {
+        let store = RuleStore(configPath: "/dev/null")
+        let payload = PreToolUsePayload(toolName: "CronCreate", toolInput: [
+            "cron": AnyCodable("0 3 * * 1"),
+            "prompt": AnyCodable("check deploy")
+        ])
+        let decision = store.evaluateBuiltInPrompt(payload: payload)
+        XCTAssertNotNil(decision, "CronCreate should hit the built-in prompt rule")
+        XCTAssertTrue(decision?.askUser ?? false)
+    }
+
+    func testScheduleWakeupPrompts() {
+        let store = RuleStore(configPath: "/dev/null")
+        let payload = PreToolUsePayload(toolName: "ScheduleWakeup", toolInput: [
+            "delaySeconds": AnyCodable(60),
+            "prompt": AnyCodable("resume work")
+        ])
+        let decision = store.evaluateBuiltInPrompt(payload: payload)
+        XCTAssertNotNil(decision, "ScheduleWakeup should hit the built-in prompt rule")
+        XCTAssertTrue(decision?.askUser ?? false)
+    }
+
+    func testCronDeletePrompts() {
+        let store = RuleStore(configPath: "/dev/null")
+        let payload = PreToolUsePayload(toolName: "CronDelete", toolInput: [
+            "id": AnyCodable("abc123")
+        ])
+        let decision = store.evaluateBuiltInPrompt(payload: payload)
+        XCTAssertNotNil(decision, "CronDelete should hit the built-in prompt rule")
+        XCTAssertTrue(decision?.askUser ?? false)
+    }
+
+    func testCronListDoesNotPrompt() {
+        // Read-only — no rule, falls through to normal flow.
+        let store = RuleStore(configPath: "/dev/null")
+        let payload = PreToolUsePayload(toolName: "CronList", toolInput: [:])
+        XCTAssertNil(store.evaluateBuiltInPrompt(payload: payload))
+    }
+
+    func testUserAllowOverridesSchedulerPrompt() {
+        // Stage 6 (user allow) beats Stage 7 (built-in prompt) in ApprovalEngine.
+        // A user who trusts CronCreate should be able to add a matching allow rule.
+        let store = RuleStore(configPath: "/dev/null")
+        store.addRule(PersistentRule(toolName: "CronCreate", pattern: "*", isRegex: false, verdict: .allow))
+        let engine = ApprovalEngine(ruleStore: store)
+        let session = Session(pid: 88888)
+        let payload = PreToolUsePayload(toolName: "CronCreate", toolInput: [
+            "cron": AnyCodable("0 9 * * *"),
+            "prompt": AnyCodable("daily check")
+        ])
+        let decision = engine.evaluate(payload: payload, session: session)
+        // Allow rule wins — no block, no askUser prompt.
+        XCTAssertNotEqual(decision.verdict, .block)
     }
 
     // MARK: - Self-protection built-in rules


### PR DESCRIPTION
## Summary

Closes #29.

Persistence-creating scheduler tools (`CronCreate`, `ScheduleWakeup`, `CronDelete`) were treated the same as routine tool calls under auto-approve. They shouldn't be — a normal call runs now and is visible; a scheduler call plants execution that fires later, potentially while the user isn't watching. Adds seeded `prompt` rules matching the convention gavel already uses for MCP exfil vectors, so these force a dialog even under auto.

## Behavior

| Tool | Under auto-approve, before | Under auto-approve, after |
|---|---|---|
| `CronCreate` | silent allow | dialog |
| `ScheduleWakeup` | silent allow | dialog |
| `CronDelete` | silent allow | dialog |
| `CronList` (read-only) | silent allow | silent allow (no rule added) |

User allow rules on these tool names still override the built-in prompt — Stage 6 (user allow) beats Stage 7 (built-in prompt) in `ApprovalEngine`. A user who trusts `CronCreate` can add a matching allow rule and it works.

## Implementation notes

Rules use `toolName: "*"` with an anchored regex pattern (e.g. `^CronCreate$`) rather than `toolName: "CronCreate"` + `pattern: "*"`. Needed because seed migration dedupes on pattern string — three rules sharing `"*"` would collapse on re-seed. Each regex is unique, so dedupe and delete tracking both work correctly.

Seed version bumped 6 → 7 so existing users get the new defaults on their next daemon start.

## Test plan

5 new tests in `PersistentRuleTests.swift`:

- `testCronCreatePrompts` — built-in rule matches CronCreate payload
- `testScheduleWakeupPrompts` — same for ScheduleWakeup  
- `testCronDeletePrompts` — same for CronDelete
- `testCronListDoesNotPrompt` — read-only list tool is not added
- `testUserAllowOverridesSchedulerPrompt` — user allow rule on CronCreate wins

Updated `testSeededDefaultsArePresent` count (12 → 15).

All 205 tests pass (`swift test`).

## Origin

This issue started as a wrong-framed "hook bypass" report. Root-cause investigation (instrumented hook shim + raw-socket fresh-session test in the dev gavel) confirmed Claude Code does fire `PreToolUse` for all three tools and gavel's hook router handles them correctly. The earlier "silent allow" observations were simply because the session had auto on. See the rewritten issue body for the corrected framing.