### PR TITLE
fix: drop component prefix from release tag

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "packages": {


### PR DESCRIPTION
## Summary

release-please was producing tags like \`gavel-v1.1.0\` instead of \`v1.1.0\`. The existing \`release.yml\` workflow only fires on tags matching \`v*\`, so the prefixed tag never triggered the build/sign/notarize pipeline. No tarball asset was ever uploaded, and \`bump-tap.yml\` timed out after 15 minutes waiting for it.

\`include-component-in-tag: false\` drops the \`gavel-\` prefix from the tag. Component name still appears in the release title and changelog — only the tag is changed.

Root-cause run: https://github.com/JaysonRawlins/claude-gavel/actions/runs/24788077393

## After merge

1. Close the stale release-please PR if it reopens with the old branch name — a new PR will appear on the new branch.
2. Manually tag \`v1.1.0\` at \`c5a1b39\` (the merge commit of PR #33) to ship the 1.1.0 release that the prior attempt fumbled:
   \`\`\`
   git tag v1.1.0 c5a1b39
   git push origin v1.1.0
   \`\`\`
   That fires \`release.yml\` → uploads assets → creates GitHub Release → \`bump-tap.yml\` fires → \`homebrew-gavel\` formula updated.