### PR TITLE
fix(bump-tap): commit directly instead of fork-and-PR

### DIFF
--- a/.github/workflows/bump-tap.yml
+++ b/.github/workflows/bump-tap.yml
@@ -10,7 +10,6 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     # Only bump the tap once the release.yml workflow has attached the tarball asset.
-    # Otherwise the formula action would fail to fetch the download URL.
     if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Mint app token for tap repo
@@ -28,30 +27,60 @@ jobs:
           TAG: ${{ github.event.release.tag_name }}
         run: |
           # The release.yml workflow runs in parallel and uploads the tarball.
-          # Poll for up to 15 minutes for the asset to appear.
-          ASSET="gavel-${TAG}-macos-arm64.tar.gz"
+          # Poll for up to 15 minutes for both the tarball and its sha256 sidecar.
+          TARBALL="gavel-${TAG}-macos-arm64.tar.gz"
+          SHA_FILE="${TARBALL}.sha256"
           for i in $(seq 1 90); do
-            if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets \
-                 | grep -q "\"name\":\"${ASSET}\""; then
-              echo "Asset ${ASSET} is available."
+            assets=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')
+            if echo "$assets" | grep -qx "$TARBALL" && echo "$assets" | grep -qx "$SHA_FILE"; then
+              echo "Assets available."
               exit 0
             fi
-            echo "Waiting for ${ASSET} ($i/90)…"
+            echo "Waiting for release assets ($i/90)…"
             sleep 10
           done
-          echo "Timed out waiting for ${ASSET}." >&2
+          echo "Timed out waiting for release assets." >&2
           exit 1
 
       - name: Bump formula in JaysonRawlins/homebrew-gavel
-        uses: mislav/bump-homebrew-formula-action@v3
-        with:
-          formula-name: gavel
-          formula-path: Formula/gavel.rb
-          homebrew-tap: ${{ github.repository_owner }}/homebrew-gavel
-          download-url: https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/gavel-${{ github.event.release.tag_name }}-macos-arm64.tar.gz
-          commit-message: |
-            gavel {{version}}
-
-            Created by the gavel-release-bot GitHub App on release of ${{ github.event.release.tag_name }}.
         env:
-          COMMITTER_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ github.event.release.tag_name }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.repository }}
+        # The mislav/bump-homebrew-formula-action and dawidd6/action-homebrew-bump-formula
+        # both default to a fork-and-PR flow. App tokens can't call /user or create forks
+        # (both return 403 "Resource not accessible by integration"), so we commit directly
+        # with plain git. The App is scoped to claude-gavel + homebrew-gavel only, so the
+        # token has write access to the tap.
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          TARBALL="gavel-${TAG}-macos-arm64.tar.gz"
+          DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${TARBALL}"
+
+          # Pull the sha256 from the sidecar asset rather than re-downloading the tarball.
+          SHA=$(gh release download "$TAG" --repo "$REPO" --pattern "${TARBALL}.sha256" -O - | awk '{print $1}')
+          [[ -n "$SHA" ]] || { echo "Empty sha256"; exit 1; }
+
+          TAP_DIR="$RUNNER_TEMP/tap"
+          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/${OWNER}/homebrew-gavel.git" "$TAP_DIR"
+          cd "$TAP_DIR"
+
+          FORMULA=Formula/gavel.rb
+          sed -i -E "s|url \"https://github\.com/[^\"]+\"|url \"${DOWNLOAD_URL}\"|" "$FORMULA"
+          sed -i -E "s|sha256 \"[a-f0-9]+\"|sha256 \"${SHA}\"|" "$FORMULA"
+          sed -i -E "s|version \"[^\"]+\"|version \"${VERSION}\"|" "$FORMULA"
+
+          if git diff --quiet "$FORMULA"; then
+            echo "Formula already at ${VERSION} — nothing to do."
+            exit 0
+          fi
+
+          git config user.email "gavel-release-bot[bot]@users.noreply.github.com"
+          git config user.name  "gavel-release-bot[bot]"
+          git add "$FORMULA"
+          git commit -m "gavel ${VERSION}
+
+          Created by the gavel-release-bot GitHub App on release of ${TAG}."
+          git push


### PR DESCRIPTION
## Summary

`bump-tap.yml` was using `mislav/bump-homebrew-formula-action@v3`, which assumes a fork-based flow: identify the user, fork the tap, push to the fork, open a PR. GitHub App tokens fail both steps:

```
GET /user                            → 403 "Resource not accessible by integration"
POST /repos/…/homebrew-gavel/forks   → 403
```

(See run: https://github.com/JaysonRawlins/claude-gavel/actions/runs/24789249550)

`mislav/bump-homebrew-formula-action` doesn't have a "skip-fork" mode — its `push-to` input is for pointing at an already-existing fork, not for direct pushes. `dawidd6/action-homebrew-bump-formula` does have `no_fork: true`, but adopting a second action felt heavier than warranted for a three-line edit of a known file.

Replaces the action with a plain shell script:

1. Pull the sha256 from the `.sha256` sidecar asset uploaded by `release.yml` (cheaper than re-downloading).
2. Clone the tap using the App token over HTTPS (`https://x-access-token:${TOKEN}@github.com/…`).
3. `sed` the three fields in `Formula/gavel.rb` — `url`, `sha256`, `version`.
4. Commit and push directly to main.

The App is narrowly scoped to `claude-gavel` + `homebrew-gavel` only, so the token genuinely has write access to the tap.

## Why this works where the action didn't

- App tokens authenticate HTTPS git pushes natively when used as the username/password.
- No `/user` call is needed because we never try to discover the "current user."
- No fork creation, which the App can't do.

## Manual bump for v1.1.1

Already applied: [homebrew-gavel@fd0c060](https://github.com/JaysonRawlins/homebrew-gavel/commit/fd0c060). `brew upgrade gavel` should pick up v1.1.1 now, independent of this PR.

## Test plan

Next release (whatever version release-please proposes after this merges) will exercise the new script end-to-end. Expected sequence:

1. Release PR merges → tag `vX.Y.Z` pushed → release.yml runs
2. release.yml uploads tarball + sha256 as release assets
3. release-published event fires → bump-tap.yml runs
4. bump-tap polls for both assets → computes nothing (just reads sidecar) → clones tap → edits formula → commits and pushes to `homebrew-gavel:main`
5. `brew update && brew upgrade gavel` picks up the new version