### PR TITLE
feat(monitor): discover running Claude Code sessions at startup

### DIFF
--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -37,6 +37,7 @@ final class SessionManager: ObservableObject {
     init() {
         loadDefaults()
         loadActiveSessions()
+        discoverRunningSessions()
         startCleanupTimer()
         startInactivityTimer()
     }
@@ -188,6 +189,30 @@ final class SessionManager: ObservableObject {
             }
             sessions[snap.pid] = session
         }
+    }
+
+    /// Find Claude Code CLI processes running on this machine and add any we
+    /// don't already track. Solves the "started while gavel was down" gap that
+    /// persistence alone can't cover. Discovered sessions get a PID and cwd
+    /// immediately; their sessionId is filled in by the next hook event.
+    @discardableResult
+    func discoverRunningSessions() -> Int {
+        let discovered = ProcessTree.findClaudeCliSessions()
+        var added = 0
+        lock.lock()
+        for (pid, cwd) in discovered {
+            let pidInt = Int(pid)
+            if sessions[pidInt] != nil { continue }
+            let session = Session(pid: pidInt, cwd: cwd)
+            session.isAutoApproveEnabled = defaultAutoApprove
+            session.isSubAgentInheritEnabled = defaultSubAgentInherit
+            session.isPaused = defaultPaused
+            sessions[pidInt] = session
+            added += 1
+        }
+        if added > 0 { saveActiveSessions() }
+        lock.unlock()
+        return added
     }
 
     /// Check if a PID is still alive using kill(0).

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -120,6 +120,14 @@ struct MonitorWindow: View {
                 .tint(.gray)
                 .help("Drop sessions whose Claude Code process has exited.")
 
+                Button("Discover") {
+                    viewModel.sessionManager.discoverRunningSessions()
+                    viewModel.noteInteraction()
+                }
+                .buttonStyle(.bordered)
+                .tint(.blue)
+                .help("Scan for Claude Code CLI processes that haven't fired a hook yet (e.g. started while gavel was down).")
+
                 Spacer()
 
                 inactivityPicker

--- a/Sources/Gavel/System/ProcessTree.swift
+++ b/Sources/Gavel/System/ProcessTree.swift
@@ -57,4 +57,70 @@ struct ProcessTree {
     static func isAlive(pid: Int32) -> Bool {
         kill(pid, 0) == 0 || errno == EPERM
     }
+
+    /// Enumerate every process ID on the system via sysctl(KERN_PROC_ALL).
+    static func enumerateAllPids() -> [Int32] {
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0]
+        var size: size_t = 0
+        guard sysctl(&mib, 4, nil, &size, nil, 0) == 0, size > 0 else { return [] }
+
+        // sysctl can grow between the size query and the data fetch — pad and retry once.
+        var buffer = [UInt8](repeating: 0, count: size + 4096)
+        var actualSize = buffer.count
+        let result = buffer.withUnsafeMutableBufferPointer { ptr in
+            sysctl(&mib, 4, ptr.baseAddress, &actualSize, nil, 0)
+        }
+        guard result == 0 else { return [] }
+
+        let stride = MemoryLayout<kinfo_proc>.stride
+        let count = actualSize / stride
+        var pids: [Int32] = []
+        pids.reserveCapacity(count)
+        buffer.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            for i in 0..<count {
+                let proc = base.advanced(by: i * stride)
+                    .assumingMemoryBound(to: kinfo_proc.self).pointee
+                let pid = proc.kp_proc.p_pid
+                if pid > 0 { pids.append(pid) }
+            }
+        }
+        return pids
+    }
+
+    /// Return the current working directory of `pid`, using proc_pidinfo
+    /// (the same API `lsof` uses internally for `cwd`). Nil if the process
+    /// is gone or we lack permission to inspect it.
+    static func cwd(of pid: Int32) -> String? {
+        var info = proc_vnodepathinfo()
+        let bytes = proc_pidinfo(
+            pid,
+            PROC_PIDVNODEPATHINFO,
+            0,
+            &info,
+            Int32(MemoryLayout<proc_vnodepathinfo>.size)
+        )
+        guard bytes > 0 else { return nil }
+
+        return withUnsafePointer(to: info.pvi_cdir.vip_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: Int(MAXPATHLEN)) { cstr in
+                let s = String(cString: cstr)
+                return s.isEmpty ? nil : s
+            }
+        }
+    }
+
+    /// Discover live Claude Code CLI sessions on the system. Matches on the
+    /// short process name `claude` (the CLI sets p_comm to that), which
+    /// excludes the Electron desktop app helpers — their p_comm is the
+    /// truncated `/Applications/Cl…` binary path.
+    static func findClaudeCliSessions() -> [(pid: Int32, cwd: String)] {
+        var results: [(Int32, String)] = []
+        for pid in enumerateAllPids() {
+            guard let name = processName(pid: pid), name == "claude" else { continue }
+            guard let cwd = cwd(of: pid) else { continue }
+            results.append((pid, cwd))
+        }
+        return results
+    }
 }

--- a/Tests/GavelTests/ProcessTreeTests.swift
+++ b/Tests/GavelTests/ProcessTreeTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+import Darwin
+@testable import Gavel
+
+final class ProcessTreeTests: XCTestCase {
+
+    func testEnumerateAllPidsIncludesSelf() {
+        let pids = ProcessTree.enumerateAllPids()
+        XCTAssertGreaterThan(pids.count, 1)
+        XCTAssertTrue(pids.contains(getpid()))
+    }
+
+    func testCwdOfSelfMatchesFileManager() {
+        guard let cwd = ProcessTree.cwd(of: getpid()) else {
+            XCTFail("cwd lookup failed for our own PID")
+            return
+        }
+        let resolvedActual = (cwd as NSString).resolvingSymlinksInPath
+        let resolvedExpected = (FileManager.default.currentDirectoryPath as NSString).resolvingSymlinksInPath
+        XCTAssertEqual(resolvedActual, resolvedExpected)
+    }
+
+    func testCwdOfNonExistentPidIsNil() {
+        // Pick a PID that's almost certainly not allocated.
+        XCTAssertNil(ProcessTree.cwd(of: 999_999))
+    }
+
+    func testFindClaudeCliSessionsReturnsValidShape() {
+        // Doesn't assume Claude is running — just that the call returns
+        // without crashing and that any results look well-formed.
+        let sessions = ProcessTree.findClaudeCliSessions()
+        for (pid, cwd) in sessions {
+            XCTAssertGreaterThan(pid, 0)
+            XCTAssertFalse(cwd.isEmpty)
+            XCTAssertTrue(cwd.hasPrefix("/"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds active-process discovery so sessions started while gavel was down become visible immediately, rather than waiting for their next hook event.
- Extends `ProcessTree` with native sysctl + `proc_pidinfo` helpers — no shelling out to `ps`/`lsof`.
- New "Discover" footer button in the monitor for manual rescans, plus an automatic scan during daemon startup.

## Why

Persistence (#TBD — the prior PR) keeps known sessions visible across `brew services restart gavel`, but it can't surface a session whose first hook event hasn't arrived yet. Discovery closes that gap. Together with persistence and the per-session label work, the monitor's session list now actually reflects what's running.

## Approach

`p_comm == "claude"` is a clean signal — the CLI sets it that way, and the Electron desktop app's helpers all show `comm` as the truncated `/Applications/Cl…` binary path, so they don't get mistaken for CLI sessions. cwd lookup via `proc_pidinfo(PROC_PIDVNODEPATHINFO)` is the same call `lsof` uses internally for its `cwd` column, ~ms-scale per PID.

Discovered sessions get PID + cwd immediately. `sessionId` arrives via the next hook event, at which point the existing UUID-keyed label persistence kicks in.

## Test plan

- [x] `swift test` — 225 / 225 (was 221, +4 new `ProcessTreeTests`).
- [ ] Smoke: kill daemon, start fresh Claude Code session, restart daemon, confirm session shows up in monitor with correct cwd before any tool call.
- [ ] Smoke: click Discover button while daemon is running and a new Claude session is open — appears in list.
- [ ] Verify Electron Claude desktop helpers don't get added as fake sessions.