### PR TITLE
feat(monitor): row redesign with activity flash and recency sort

### DIFF
--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -93,6 +93,20 @@ final class HookRouter {
     ) {
         session.toolCallCount += 1
 
+        // Flash the row in the monitor so the user can see which session is
+        // working without reading PIDs. Auto-clears after 0.6s; SwiftUI animates
+        // the fade. Stamp comparison protects against bursts — only the most
+        // recent activity's clear actually fires.
+        let stamp = Date()
+        DispatchQueue.main.async {
+            session.lastActivityAt = stamp
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            if session.lastActivityAt == stamp {
+                session.lastActivityAt = nil
+            }
+        }
+
         let summary = payload.command ?? payload.filePath ?? ""
         emitFeed(.toolCall(
             tool: payload.toolName,

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -179,7 +179,8 @@ final class SessionManager: ObservableObject {
 
         for snap in snapshots {
             guard isProcessAlive(pid: snap.pid) else { continue }
-            let session = Session(pid: snap.pid, cwd: snap.cwd)
+            let started = ProcessTree.startTime(of: Int32(snap.pid))
+            let session = Session(pid: snap.pid, cwd: snap.cwd, startedAt: started)
             session.sessionId = snap.sessionId
             session.isAutoApproveEnabled = defaultAutoApprove
             session.isSubAgentInheritEnabled = defaultSubAgentInherit
@@ -203,7 +204,8 @@ final class SessionManager: ObservableObject {
         for (pid, cwd) in discovered {
             let pidInt = Int(pid)
             if sessions[pidInt] != nil { continue }
-            let session = Session(pid: pidInt, cwd: cwd)
+            let started = ProcessTree.startTime(of: pid)
+            let session = Session(pid: pidInt, cwd: cwd, startedAt: started)
             session.isAutoApproveEnabled = defaultAutoApprove
             session.isSubAgentInheritEnabled = defaultSubAgentInherit
             session.isPaused = defaultPaused

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -15,6 +15,11 @@ final class Session: ObservableObject, Identifiable {
     @Published var isSubAgentInheritEnabled: Bool = false
     @Published var lastPrompt: String?
 
+    /// Set to the current time on each tool call so the monitor row can flash a
+    /// brief highlight. Cleared back to nil ~600ms later by the daemon so SwiftUI
+    /// can animate the fade. Don't use this for stats — it isn't durable.
+    @Published var lastActivityAt: Date?
+
     // Timed auto-approve
     @Published var autoApproveUntil: Date?
 
@@ -42,9 +47,9 @@ final class Session: ObservableObject, Identifiable {
         return remaining > 0 ? remaining : nil
     }
 
-    init(pid: Int, cwd: String? = nil) {
+    init(pid: Int, cwd: String? = nil, startedAt: Date? = nil) {
         self.pid = pid
-        self.startedAt = Date()
+        self.startedAt = startedAt ?? Date()
         self.cwd = cwd
     }
 

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -76,9 +76,9 @@ struct MonitorWindow: View {
     }
 
     private var sessionControls: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: 2) {
             let sessions = Array(viewModel.sessionManager.sessions.values)
-                .sorted { $0.pid < $1.pid }
+                .sorted { $0.startedAt > $1.startedAt }
 
             if sessions.isEmpty {
                 HStack {
@@ -88,8 +88,13 @@ struct MonitorWindow: View {
                     Spacer()
                 }
             } else {
-                ForEach(sessions, id: \.pid) { session in
-                    sessionRow(session)
+                ForEach(Array(sessions.enumerated()), id: \.element.pid) { index, session in
+                    SessionRow(
+                        session: session,
+                        viewModel: viewModel,
+                        isNewest: index == 0,
+                        alternate: index.isMultiple(of: 2)
+                    )
                 }
             }
 
@@ -178,7 +183,19 @@ struct MonitorWindow: View {
         }
     }
 
-    private func sessionRow(_ session: Session) -> some View {
+}
+
+/// One row in the session-controls strip. Extracted into its own View so it can
+/// observe the Session directly — the function-form predecessor only refreshed
+/// on the 2-second stats timer, which made Pause/Resume label changes feel
+/// laggy and made the per-tool-call flash highlight impossible.
+private struct SessionRow: View {
+    @ObservedObject var session: Session
+    let viewModel: MonitorViewModel
+    let isNewest: Bool
+    let alternate: Bool
+
+    var body: some View {
         HStack(spacing: 8) {
             Circle()
                 .fill(session.isAlive ? .green : .gray)
@@ -196,41 +213,82 @@ struct MonitorWindow: View {
                     .lineLimit(1)
             }
 
-            sessionLabelField(session)
+            SessionLabelField(session: session) { newVal in
+                if let sid = session.sessionId {
+                    viewModel.sessionManager.setLabel(newVal, for: sid)
+                }
+                viewModel.noteInteraction()
+            }
 
             Spacer()
 
-            Toggle(isOn: Binding(
-                get: { session.isSubAgentInheritEnabled },
-                set: { newVal in
-                    session.isSubAgentInheritEnabled = newVal
-                    let allSub = viewModel.sessionManager.sessions.values.allSatisfy { $0.isSubAgentInheritEnabled }
-                    viewModel.sessionManager.defaultSubAgentInherit = allSub
-                    viewModel.sessionManager.saveDefaults()
-                    viewModel.noteInteraction()
-                }
-            )) {
+            actionCluster
+        }
+        .padding(.vertical, 3)
+        .padding(.leading, 8)
+        .padding(.trailing, 6)
+        .background(
+            ZStack {
+                rowBackground
+                Color.yellow.opacity(session.lastActivityAt != nil ? 0.20 : 0)
+            }
+        )
+        .overlay(alignment: .leading) {
+            if isNewest {
+                Rectangle()
+                    .fill(Color.accentColor)
+                    .frame(width: 3)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .animation(.easeOut(duration: 0.45), value: session.lastActivityAt)
+        .help(isNewest ? "Most recently started session" : "")
+    }
+
+    /// Right-side controls in fixed widths so Sub/Auto/Prompt/Pause/Kill line up
+    /// across rows regardless of cwd or label length.
+    @ViewBuilder
+    private var actionCluster: some View {
+        HStack(spacing: 6) {
+            HStack(spacing: 4) {
                 Text("Sub")
                     .font(.caption)
+                    .lineLimit(1)
+                Toggle("", isOn: Binding(
+                    get: { session.isSubAgentInheritEnabled },
+                    set: { newVal in
+                        session.isSubAgentInheritEnabled = newVal
+                        let allSub = viewModel.sessionManager.sessions.values.allSatisfy { $0.isSubAgentInheritEnabled }
+                        viewModel.sessionManager.defaultSubAgentInherit = allSub
+                        viewModel.sessionManager.saveDefaults()
+                        viewModel.noteInteraction()
+                    }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .tint(.cyan)
+                .controlSize(.small)
             }
-            .toggleStyle(.switch)
-            .tint(.cyan)
-            .controlSize(.small)
+            .frame(width: 70, alignment: .leading)
             .help("Auto-approve sub-agent calls (deny rules still block)")
 
-            Toggle(isOn: Binding(
-                get: { session.isAutoApproveEnabled },
-                set: { _ in
-                    viewModel.toggleAutoApprove(for: session)
-                    viewModel.noteInteraction()
-                }
-            )) {
+            HStack(spacing: 4) {
                 Text("Auto")
                     .font(.caption)
+                    .lineLimit(1)
+                Toggle("", isOn: Binding(
+                    get: { session.isAutoApproveEnabled },
+                    set: { _ in
+                        viewModel.toggleAutoApprove(for: session)
+                        viewModel.noteInteraction()
+                    }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .tint(.green)
+                .controlSize(.small)
             }
-            .toggleStyle(.switch)
-            .tint(.green)
-            .controlSize(.small)
+            .frame(width: 76, alignment: .leading)
 
             Button("Prompt") {
                 viewModel.promptSession(session)
@@ -238,6 +296,7 @@ struct MonitorWindow: View {
             .buttonStyle(.bordered)
             .controlSize(.small)
             .tint(.yellow)
+            .frame(width: 70)
             .help("Clear auto + sub-agent inherit + timed auto in one click. Next tool call will prompt.")
 
             Button(session.isPaused ? "Resume" : "Pause") {
@@ -250,6 +309,7 @@ struct MonitorWindow: View {
             .buttonStyle(.bordered)
             .controlSize(.small)
             .tint(session.isPaused ? .green : .orange)
+            .frame(width: 76)
 
             Button("Kill") {
                 kill(Int32(session.pid), SIGINT)
@@ -258,20 +318,14 @@ struct MonitorWindow: View {
             .buttonStyle(.bordered)
             .controlSize(.small)
             .tint(.red)
+            .frame(width: 56)
             .help("Send SIGINT to this session's Claude Code process")
         }
     }
 
-    /// Editable per-session label. Persists to session-defaults.json keyed by Claude
-    /// Code's session UUID, so the name survives daemon restarts.
-    @ViewBuilder
-    private func sessionLabelField(_ session: Session) -> some View {
-        SessionLabelField(session: session) { newVal in
-            if let sid = session.sessionId {
-                viewModel.sessionManager.setLabel(newVal, for: sid)
-            }
-            viewModel.noteInteraction()
-        }
+    private var rowBackground: Color {
+        if isNewest { return Color.accentColor.opacity(0.10) }
+        return alternate ? Color.secondary.opacity(0.06) : Color.clear
     }
 }
 
@@ -812,7 +866,7 @@ struct SessionRulesView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
                 let sessions = Array(viewModel.sessionManager.sessions.values)
-                    .sorted { $0.pid < $1.pid }
+                    .sorted { $0.startedAt > $1.startedAt }
 
                 if sessions.isEmpty {
                     Text("No active sessions.")

--- a/Sources/Gavel/System/ProcessTree.swift
+++ b/Sources/Gavel/System/ProcessTree.swift
@@ -88,6 +88,24 @@ struct ProcessTree {
         return pids
     }
 
+    /// Return the kernel-recorded start time of `pid`. Used to order rehydrated
+    /// or discovered sessions by when their Claude Code process actually started,
+    /// not when gavel happened to notice them.
+    static func startTime(of pid: Int32) -> Date? {
+        var info = proc_bsdinfo()
+        let bytes = proc_pidinfo(
+            pid,
+            PROC_PIDTBSDINFO,
+            0,
+            &info,
+            Int32(MemoryLayout<proc_bsdinfo>.size)
+        )
+        guard bytes > 0 else { return nil }
+        let secs = TimeInterval(info.pbi_start_tvsec)
+        let micros = TimeInterval(info.pbi_start_tvusec) / 1_000_000
+        return Date(timeIntervalSince1970: secs + micros)
+    }
+
     /// Return the current working directory of `pid`, using proc_pidinfo
     /// (the same API `lsof` uses internally for `cwd`). Nil if the process
     /// is gone or we lack permission to inspect it.


### PR DESCRIPTION
## Summary
- Sort the session controls strip by real process start time so newest sessions appear at the top — uses `proc_pidinfo`/`PROC_PIDTBSDINFO` so rehydrated and discovered sessions get their actual kernel start time, not "now."
- Pin the Sub/Auto/Prompt/Pause/Kill cluster to fixed per-control widths and add zebra striping plus a 3px accent leading bar + tinted background on the most recent row.
- Flash a yellow overlay on each `PreToolUse` so you can see at a glance which session is working without comparing PIDs. Stamp auto-clears after 600ms with stamp-equality guarding so bursts don't reset early; SwiftUI animates the fade.
- Extracted `SessionRow` into its own `View` struct with `@ObservedObject var session` (mirrors the existing `SessionLabelField` pattern). Side benefit: Pause/Resume label flips instantly instead of waiting for the 2-second `statsTimer` tick.

## Test plan
- [x] `swift build` clean
- [x] `swift test` — 225/225 pass
- [x] Live-tested via `install.sh` against multiple concurrent Claude Code sessions
- [ ] Confirm the activity flash is visible but not distracting under heavy auto-approve traffic
- [ ] Verify "newest first" survives a daemon restart (rehydrated sessions sort correctly by real process start time, not gavel-discovery time)