### PR TITLE
fix(cli): handle --version/--help, reject unknown args before daemon launch

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -8,7 +8,13 @@
   "packages": {
     ".": {
       "package-name": "gavel",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "Sources/Gavel/Version.swift"
+        }
+      ]
     }
   }
 }

--- a/Sources/Gavel/Version.swift
+++ b/Sources/Gavel/Version.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Release version of the gavel binary. Bumped by release-please via the
+/// `x-release-please-version` marker — see `.release-please-config.json`'s
+/// `extra-files` entry.
+let GAVEL_VERSION = "1.2.1" // x-release-please-version

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -314,6 +314,12 @@ NSSetUncaughtExceptionHandler { exception in
     gavelLog("STACK: \(exception.callStackSymbols.prefix(10).joined(separator: "\n  "))")
 }
 
+// Argv handling — runs BEFORE any daemon setup. Without this, an unknown
+// arg like `gavel --version` falls through to NSApplication.run() and
+// silently launches a second daemon that fights the real one for the socket
+// (split-brain). Diagnostic invocations should never bind the socket.
+parseArgsOrExit(Array(CommandLine.arguments.dropFirst()))
+
 // Ignore SIGPIPE — clients disconnect, we don't want to die
 signal(SIGPIPE, SIG_IGN)
 
@@ -331,3 +337,36 @@ let app = NSApplication.shared
 let delegate = GavelAppDelegate()
 app.delegate = delegate
 app.run()
+
+// MARK: - Argv parsing
+
+/// Returns normally only when the binary should proceed to daemon launch.
+/// Calls `exit()` for `--version`/`--help` and any unknown argument, so the
+/// process never reaches `NSApplication.run()` and never binds the socket.
+func parseArgsOrExit(_ args: [String]) {
+    if args.isEmpty { return }
+    if args.count > 1 {
+        FileHandle.standardError.write(Data("gavel: too many arguments (expected 0 or 1)\n".utf8))
+        FileHandle.standardError.write(Data("Try 'gavel --help' for usage.\n".utf8))
+        exit(2)
+    }
+    switch args[0] {
+    case "--version", "-v":
+        print("gavel \(GAVEL_VERSION)")
+        exit(0)
+    case "--help", "-h":
+        print("""
+        gavel — Claude Code session monitor and approval daemon
+
+        Usage:
+          gavel              Run as menu bar daemon (managed by LaunchAgent)
+          gavel --version    Print version and exit
+          gavel --help       Print this help and exit
+        """)
+        exit(0)
+    default:
+        FileHandle.standardError.write(Data("gavel: unknown argument: \(args[0])\n".utf8))
+        FileHandle.standardError.write(Data("Try 'gavel --help' for usage.\n".utf8))
+        exit(2)
+    }
+}


### PR DESCRIPTION
## Summary

Any non-empty argv to the \`gavel\` binary used to fall through to \`NSApplication.run()\`, silently binding \`gavel.sock\`. A second daemon would then fight the real LaunchAgent-spawned daemon for hook connections — a split-brain that surfaces as intermittent "daemon returned invalid response" errors and ask-user prompts where loaded rules don't apply.

Reproed when running \`gavel --version\` for diagnostics during the visibility-feature debugging session — the diagnostic command itself broke the running daemon.

## Changes

- **\`Sources/Gavel/Version.swift\`** (new): \`GAVEL_VERSION\` constant marked with \`// x-release-please-version\` so future releases auto-bump it.
- **\`Sources/Gavel/main.swift\`**: \`parseArgsOrExit()\` runs BEFORE any daemon setup. \`--version\`/\`-v\` and \`--help\`/\`-h\` print and exit(0); unknown args / extra args print to stderr and exit(2). Only empty argv reaches \`NSApplication.run()\`.
- **\`.release-please-config.json\`**: \`extra-files\` entry for \`Version.swift\` so the constant tracks the tag.

## Test plan

Smoke tests on the local debug build, all completed with no daemon spawn:

| Command | Output | Exit |
|---|---|---|
| \`gavel --version\` | \`gavel 1.2.1\` | 0 |
| \`gavel -v\` | \`gavel 1.2.1\` | 0 |
| \`gavel --help\` | usage text | 0 |
| \`gavel --bogus\` | \`unknown argument: --bogus\` (stderr) | 2 |
| \`gavel -v --help\` | \`too many arguments\` (stderr) | 2 |
| \`gavel\` | daemon launches | (long-running, unchanged) |

Full test suite: 243 tests pass.

## Future-proofing

When release-please cuts the next release, it'll find the \`x-release-please-version\` marker in \`Version.swift\` and bump the string in lock-step with the tag — no manual sync required.