### PR TITLE
fix(daemon): single-instance guard via connect-probe before bind

### DIFF
--- a/Sources/Gavel/Daemon/SocketServer.swift
+++ b/Sources/Gavel/Daemon/SocketServer.swift
@@ -18,6 +18,15 @@ final class SocketServer {
     }
 
     func start() throws {
+        // Single-instance guard: if a live peer is already serving this socket,
+        // refuse to take it over. Without this, the second daemon would
+        // unlink+bind and silently steal the path while the first daemon's
+        // listening fd survives — split-brain. Hook connections then land on
+        // whichever bound last, with whichever rule set that process loaded.
+        if Self.probeAlive(socketPath: socketPath) {
+            throw GavelError.daemonAlreadyRunning(path: socketPath)
+        }
+
         // Clean up stale socket
         unlink(socketPath)
 
@@ -96,6 +105,43 @@ final class SocketServer {
         }
     }
 
+    /// Returns true iff a peer is currently `accept()`-ing on `socketPath`.
+    ///
+    /// Classification (kept narrow on purpose):
+    /// - `connect()` succeeds → live daemon → true.
+    /// - `ENOENT` → no socket file → false.
+    /// - `ECONNREFUSED` → stale socket file with no listener → false.
+    /// - Any other errno → conservative *true* so we fail closed and don't
+    ///   accidentally clobber a running daemon over an EPERM/EACCES quirk.
+    static func probeAlive(socketPath: String) -> Bool {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = socketPath.utf8CString
+        guard pathBytes.count <= MemoryLayout.size(ofValue: addr.sun_path) else {
+            return false
+        }
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: pathBytes.count) { dest in
+                for (i, byte) in pathBytes.enumerated() { dest[i] = byte }
+            }
+        }
+
+        let result = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        if result == 0 { return true }
+        switch errno {
+        case ENOENT, ECONNREFUSED: return false
+        default: return true
+        }
+    }
+
     private func handleConnection(fd: Int32) {
         defer { close(fd) }
 
@@ -138,6 +184,7 @@ enum GavelError: Error, LocalizedError {
     case socketPathTooLong
     case bindFailed(errno: Int32)
     case listenFailed(errno: Int32)
+    case daemonAlreadyRunning(path: String)
 
     var errorDescription: String? {
         switch self {
@@ -145,6 +192,7 @@ enum GavelError: Error, LocalizedError {
         case .socketPathTooLong: return "Socket path exceeds maximum length"
         case .bindFailed(let e): return "Failed to bind socket: \(String(cString: strerror(e)))"
         case .listenFailed(let e): return "Failed to listen on socket: \(String(cString: strerror(e)))"
+        case .daemonAlreadyRunning(let path): return "Another gavel daemon is already serving \(path)"
         }
     }
 }

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -270,6 +270,12 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         do {
             try socketServer?.start()
             print("Gavel listening on \(socketPath)")
+        } catch GavelError.daemonAlreadyRunning(let path) {
+            // TOCTOU: a peer daemon came up between our top-level probe and
+            // this bind. Refuse to clobber it.
+            gavelLog("Refusing to start: another gavel daemon is already serving \(path) (TOCTOU)")
+            FileHandle.standardError.write(Data("gavel: another daemon is already running on \(path)\n".utf8))
+            exit(1)
         } catch {
             print("Failed to start socket server: \(error)")
         }
@@ -332,6 +338,19 @@ for sig: Int32 in [SIGABRT, SIGSEGV, SIGBUS, SIGILL, SIGFPE] {
 }
 
 gavelLog("Gavel starting")
+
+// Single-instance guard: probe the socket BEFORE NSApplication.run() so a
+// duplicate launch never shows a menu bar icon and never registers as a
+// running daemon. SocketServer.start() also enforces this, but probing
+// here keeps the foot-gun symptoms (split-brain, ghost menu bar) off the
+// screen entirely.
+let socketPath = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".claude/gavel/gavel.sock").path
+if SocketServer.probeAlive(socketPath: socketPath) {
+    gavelLog("Refusing to start: another gavel daemon is already serving \(socketPath)")
+    FileHandle.standardError.write(Data("gavel: another daemon is already running on \(socketPath)\n".utf8))
+    exit(1)
+}
 
 let app = NSApplication.shared
 let delegate = GavelAppDelegate()

--- a/Tests/GavelTests/SocketServerProbeTests.swift
+++ b/Tests/GavelTests/SocketServerProbeTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+import Darwin
+@testable import Gavel
+
+final class SocketServerProbeTests: XCTestCase {
+
+    private func tempSocketPath() -> String {
+        let dir = NSTemporaryDirectory()
+        let name = "gavel-probe-\(UUID().uuidString.prefix(8)).sock"
+        return (dir as NSString).appendingPathComponent(name)
+    }
+
+    func testProbeFalseWhenNoSocketFile() {
+        let path = tempSocketPath()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: path))
+        XCTAssertFalse(SocketServer.probeAlive(socketPath: path))
+    }
+
+    func testProbeTrueWhileServerListening() throws {
+        let path = tempSocketPath()
+        defer { unlink(path) }
+
+        let server = SocketServer(socketPath: path)
+        try server.start()
+        defer { server.stop() }
+
+        XCTAssertTrue(SocketServer.probeAlive(socketPath: path))
+    }
+
+    func testProbeFalseAfterServerStops() throws {
+        let path = tempSocketPath()
+        defer { unlink(path) }
+
+        let server = SocketServer(socketPath: path)
+        try server.start()
+        XCTAssertTrue(SocketServer.probeAlive(socketPath: path))
+
+        server.stop()
+        XCTAssertFalse(SocketServer.probeAlive(socketPath: path))
+    }
+
+    func testProbeFalseOnStaleSocketFile() throws {
+        // Simulate the case where a daemon crashed: socket file lingers, but
+        // no listener is bound. probeAlive should return false (ECONNREFUSED).
+        let path = tempSocketPath()
+        defer { unlink(path) }
+
+        // Create a socket file via bind, then close the fd without listening.
+        // Connect attempts to this path will fail with ECONNREFUSED.
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(fd, 0)
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = path.utf8CString
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: pathBytes.count) { dest in
+                for (i, byte) in pathBytes.enumerated() { dest[i] = byte }
+            }
+        }
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.bind(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        XCTAssertEqual(bindResult, 0)
+        close(fd) // No listen() call → file exists but no listener.
+
+        XCTAssertFalse(SocketServer.probeAlive(socketPath: path))
+    }
+
+    func testStartRefusesWhenPeerAlive() throws {
+        let path = tempSocketPath()
+        defer { unlink(path) }
+
+        let serverA = SocketServer(socketPath: path)
+        try serverA.start()
+        defer { serverA.stop() }
+
+        let serverB = SocketServer(socketPath: path)
+        XCTAssertThrowsError(try serverB.start()) { error in
+            guard case GavelError.daemonAlreadyRunning(let p) = error else {
+                XCTFail("Expected daemonAlreadyRunning, got \(error)")
+                return
+            }
+            XCTAssertEqual(p, path)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two \`gavel\` invocations used to both \`unlink + bind\` the same socket path. The kernel lets the second succeed; the first daemon's listening fd survives but new hook connections land on whichever bound last -- **split-brain**. Hooks then hit a daemon with the wrong rule set, manifesting as intermittent \"daemon returned invalid response\" errors and ask-user prompts that don't apply your loaded rules.

Reproed in the wild this session: a single user machine with two LaunchAgents -- the manual \`com.gavel.daemon.plist\` and \`homebrew.mxcl.gavel.plist\` -- both spawning their own daemon copies for ~10 minutes before discovery.

## Probe classification (intentionally narrow)

| \`connect()\` result | Decision |
|---|---|
| Returns 0 (success) | Live peer -- refuse to start |
| \`ENOENT\` | No socket file -- safe to bind |
| \`ECONNREFUSED\` | Stale socket file, no listener -- safe to bind |
| Any other errno | Conservative \`true\` (fail closed; don't clobber on EPERM/EACCES quirks) |

## Two probe sites (defense in depth)

1. **\`main.swift\` before \`NSApplication.run()\`** -- duplicate launches never show a menu bar icon and never log \"Gavel starting\" past the refusal line.
2. **\`SocketServer.start()\`** -- guards the TOCTOU window between the top-level probe and the bind. Triggers a clean \`exit(1)\` with the same message.

## Test plan

- [x] 5 new unit tests in \`SocketServerProbeTests.swift\`: missing socket file, live server, post-stop, stale socket file (bind without listen), start-refusal path
- [x] Full suite: 248 tests pass
- [x] Smoke-tested locally against the live daemon -- \`.build/debug/gavel\` correctly refused with \"another daemon is already running\" + exit 1, without disturbing the running LaunchAgent process

## Caller-side note

After this lands, anyone with the dual-LaunchAgent setup should pick one path (the brew install is the canonical one going forward) and remove the other. Without that cleanup, the losing LaunchAgent will respawn-and-fail in a loop, filling \`gavel.log\` with refusal messages every few seconds (KeepAlive backoff caps it but doesn't stop it).