### PR TITLE
chore: add justfile for common dev tasks

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,36 @@
+# Common dev tasks for gavel. Install just: `brew install just`.
+# `just` (no args) lists targets.
+
+default:
+    @just --list
+
+# Release build of the gavel + gavel-hook binaries
+build:
+    swift build -c release
+
+# Build, then run the local release binary in the foreground
+run-local: build
+    .build/release/gavel
+
+# Run the test suite
+test:
+    swift test
+
+# Run a single test target by name, e.g. `just test-only SocketServerProbeTests`
+test-only TARGET:
+    swift test --filter {{TARGET}}
+
+# Install via install.sh — copies binaries to ~/.claude/gavel/bin and manages com.gavel.daemon LaunchAgent (redundant if you install via brew)
+install: build
+    ./install.sh
+
+# Uninstall the install.sh artifacts (leaves brew-managed gavel alone)
+uninstall:
+    ./install.sh --uninstall
+
+# Tail the daemon log
+log:
+    tail -f ~/.claude/gavel/gavel.log
+
+# Run tests; placeholder for future swiftformat/swiftlint hooks
+check: test


### PR DESCRIPTION
## Summary

Wraps the existing \`swift build\` / \`swift test\` / \`install.sh\` invocations in a \`justfile\` so dev iteration is one command.

\`just\` (no args) lists targets:

\`\`\`
build            # Release build of the gavel + gavel-hook binaries
check            # Run tests; placeholder for future swiftformat/swiftlint hooks
default
install          # Install via install.sh -- copies binaries to ~/.claude/gavel/bin and manages com.gavel.daemon LaunchAgent (redundant if you install via brew)
log              # Tail the daemon log
run-local        # Build, then run the local release binary in the foreground
test             # Run the test suite
test-only TARGET # Run a single test target by name, e.g. \`just test-only SocketServerProbeTests\`
uninstall        # Uninstall the install.sh artifacts (leaves brew-managed gavel alone)
\`\`\`

The targets aren't novel -- they wrap commands you already run. The value is discoverability and a uniform interface that'll work the same on Linux and Windows once those ports land (#46, #47).

## Setup

\`brew install just\` (already on your machine).

## Test plan

- [x] \`just --list\` shows all targets with descriptions
- [x] \`just build\` produces a fresh \`.build/release/gavel\` (verified 1.2.3 binary built clean)
- [x] \`just run-local\` against the live daemon → expect \"another daemon is already running\", exit 1
- [x] \`just test\` runs full suite (248 tests)