### PR TITLE
feat(monitor): click row to pin highlight, drop first-row default

### DIFF
--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -16,6 +16,12 @@ final class MonitorViewModel: ObservableObject {
     @Published var testerTestString: String = ""
     @Published var testerIsRegex: Bool = true
 
+    /// User-pinned session PID. Click any row to pin (highlight); click the
+    /// pinned row again to unpin. In-memory only — fresh on app restart.
+    /// Lingers if the pinned session ends; the UI just renders no highlight
+    /// until the user pins something else.
+    @Published var pinnedSessionPid: Int?
+
     let approvalCoordinator: ApprovalCoordinator
     let sessionManager: SessionManager
     private let maxFeedEntries = GavelConstants.maxFeedEntries
@@ -42,6 +48,15 @@ final class MonitorViewModel: ObservableObject {
     }
 
     // MARK: - Controls
+
+    func togglePin(for session: Session) {
+        if pinnedSessionPid == session.pid {
+            pinnedSessionPid = nil
+        } else {
+            pinnedSessionPid = session.pid
+        }
+        noteInteraction()
+    }
 
     func toggleAutoApprove(for session: Session) {
         if session.isAutoApproveEnabled {

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -92,7 +92,7 @@ struct MonitorWindow: View {
                     SessionRow(
                         session: session,
                         viewModel: viewModel,
-                        isNewest: index == 0,
+                        isPinned: viewModel.pinnedSessionPid == session.pid,
                         alternate: index.isMultiple(of: 2)
                     )
                 }
@@ -192,7 +192,7 @@ struct MonitorWindow: View {
 private struct SessionRow: View {
     @ObservedObject var session: Session
     let viewModel: MonitorViewModel
-    let isNewest: Bool
+    let isPinned: Bool
     let alternate: Bool
 
     var body: some View {
@@ -234,15 +234,22 @@ private struct SessionRow: View {
             }
         )
         .overlay(alignment: .leading) {
-            if isNewest {
+            if isPinned {
                 Rectangle()
                     .fill(Color.accentColor)
                     .frame(width: 3)
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 4))
+        // Hit-test the entire row, including padding/Spacer gaps. Buttons and
+        // toggles still consume their own taps (SwiftUI default), so only the
+        // identity area (status dot, PID, cwd, label gap) triggers the pin.
+        .contentShape(Rectangle())
+        .onTapGesture {
+            viewModel.togglePin(for: session)
+        }
         .animation(.easeOut(duration: 0.45), value: session.lastActivityAt)
-        .help(isNewest ? "Most recently started session" : "")
+        .help(isPinned ? "Pinned — click again to unpin" : "Click to pin this row")
     }
 
     /// Right-side controls in fixed widths so Sub/Auto/Prompt/Pause/Kill line up
@@ -324,7 +331,7 @@ private struct SessionRow: View {
     }
 
     private var rowBackground: Color {
-        if isNewest { return Color.accentColor.opacity(0.10) }
+        if isPinned { return Color.accentColor.opacity(0.10) }
         return alternate ? Color.secondary.opacity(0.06) : Color.clear
     }
 }


### PR DESCRIPTION
## Summary

The first-row highlight was useful when sessions weren't recency-sorted, but the recency sort already makes \"newest\" obvious. The visual real estate is more valuable for **the row the user is working with right now** — a single session pinned so their eyes have a stable landing target while glancing between gavel and a terminal (e.g. matching the gavel row label to a Ghostty tab title set via \`claude --name <pid>\`).

## Behavior

- Click any row → pinned (left accent bar + 10% accent background, same visual that used to mark the newest row).
- Click the pinned row again → unpinned.
- At most one row is pinned at any time.
- No row is highlighted by default — the recency sort makes the newest row obvious enough.
- Pin is in-memory only. Fresh on app restart.
- If the pinned session ends, the row disappears normally and the next pin click overwrites the lingering PID.

## Implementation

- \`MonitorViewModel.pinnedSessionPid: Int?\` (\`@Published\`).
- \`togglePin(for:)\` — flips the pin.
- \`SessionRow.isNewest\` → \`isPinned\` rename (same visual treatment, different driver).
- \`.contentShape(Rectangle()) + .onTapGesture\` on the row HStack. Buttons and toggles still consume their own taps via SwiftUI defaults, so only the identity area (status dot, PID, cwd, label gap, padding) triggers pin — no gesture conflicts with the existing controls.

## Test plan

- [x] \`just build\` clean
- [x] \`just test\` — 248 tests pass (no test additions; behavior is purely view-layer interaction)
- [x] Manual: open monitor with multiple sessions, click a row → pinned. Click again → unpinned. Click a different row → previous unpins, new pins.
- [x] Manual: click a Toggle/Button on a row → control fires, row does NOT get pinned.
- [x] Manual: click the label field → label enters edit mode, row does NOT get pinned.
- [x] Manual: pin a row, end that session → row disappears, no orphan highlight.