### PR TITLE
fix(daemon): bump socket read timeout 2s→30s, fail-closed on empty payload

### DIFF
--- a/Sources/Gavel/Daemon/SocketServer.swift
+++ b/Sources/Gavel/Daemon/SocketServer.swift
@@ -18,6 +18,13 @@ final class SocketServer {
     }
 
     func start() throws {
+        // SO_NOSIGPIPE on the per-connection fd handles the daemon's normal
+        // path, but tests instantiate SocketServer outside the daemon's
+        // signal-handler setup in main.swift. Belt-and-suspenders: ignore
+        // SIGPIPE process-wide so a write to a peer-closed socket can never
+        // crash the host process regardless of context.
+        signal(SIGPIPE, SIG_IGN)
+
         // Single-instance guard: if a live peer is already serving this socket,
         // refuse to take it over. Without this, the second daemon would
         // unlink+bind and silently steal the path while the first daemon's
@@ -167,7 +174,20 @@ final class SocketServer {
             if bytesRead < bufSize { break }
         }
 
-        guard !data.isEmpty else { return }
+        // Empty data means the client connected but never sent anything (or the
+        // read timed out before any bytes arrived). Failing silently here makes
+        // the hook see EOF and emit "daemon returned invalid response", which
+        // Claude Code then treats as a tool error and cancels parallel siblings.
+        // Send an explicit fail-closed JSON instead so the hook surfaces a
+        // diagnosable reason and the cascade has a chance to be debugged.
+        guard !data.isEmpty else {
+            let errMsg = #"{"verdict":"block","reason":"Gavel: empty hook payload (read timeout — daemon worker may be starved under burst load)"}"#
+            let errData = Data(errMsg.utf8)
+            _ = errData.withUnsafeBytes { ptr in
+                write(fd, ptr.baseAddress!, errData.count)
+            }
+            return
+        }
 
         // For PreToolUse hooks, we need to send a response back.
         // The handler determines whether to respond based on hook type.

--- a/Sources/Gavel/System/Constants.swift
+++ b/Sources/Gavel/System/Constants.swift
@@ -15,8 +15,16 @@ enum GavelConstants {
     /// Socket read buffer size (64KB chunks).
     static let socketBufferSize = 64 * 1024
 
-    /// Socket read timeout in seconds.
-    static let socketReadTimeoutSeconds: Int = 2
+    /// Socket read timeout in seconds. Generous because the bound is on each
+    /// `read()` call, not the whole conversation. Under burst load (e.g. five
+    /// parallel `gavel-hook` subprocesses launching at once), an individual
+    /// hook can be descheduled between `connect()` and `write()` for hundreds
+    /// of milliseconds; a 2-second cap was tight enough that one hook in the
+    /// burst would time out, fail closed, and Claude Code would then SIGTERM
+    /// the surviving siblings as parallel-call cancellation. 30 seconds is
+    /// loose enough for any realistic scheduling delay yet still bounded so a
+    /// truly stuck client can't hold a worker thread indefinitely.
+    static let socketReadTimeoutSeconds: Int = 30
 
     /// Stats update interval in seconds.
     static let statsUpdateInterval: TimeInterval = 2.0

--- a/Tests/GavelTests/Phase1RefactorTests.swift
+++ b/Tests/GavelTests/Phase1RefactorTests.swift
@@ -162,7 +162,7 @@ final class Phase1RefactorTests: XCTestCase {
         XCTAssertEqual(GavelConstants.approvalTimeoutSeconds, 86400)
         XCTAssertEqual(GavelConstants.socketListenBacklog, 32)
         XCTAssertEqual(GavelConstants.socketBufferSize, 65536)
-        XCTAssertEqual(GavelConstants.socketReadTimeoutSeconds, 2)
+        XCTAssertEqual(GavelConstants.socketReadTimeoutSeconds, 30)
         XCTAssertEqual(GavelConstants.sessionCleanupInterval, 5.0)
         XCTAssertEqual(GavelConstants.sessionRemovalGraceSeconds, 3.0)
         XCTAssertEqual(GavelConstants.minContentScanLength, 50)


### PR DESCRIPTION
## Symptom

5 parallel prompt-triggering Bash calls would cascade-fail. Exactly one hook prints \`Gavel: daemon returned invalid response\` and exits 2; Claude Code then SIGTERMs the four parallel siblings as cancelled work; the user is left with stale dialogs in the queue that \"click through\" but resolve to dead hook clients (visible as a daemon \"freeze\").

Reproduced this session, twice, with and without the unrelated pin PR — confirms it's pre-existing.

## Root cause

\`SocketServer\` set \`SO_RCVTIMEO = 2s\` on each accepted connection (\`socketReadTimeoutSeconds: Int = 2\`). Under burst load (5 \`gavel-hook\` subprocesses spawning concurrently) one of them gets descheduled between \`connect()\` and \`write()\` for >2s. The daemon's \`read()\` returns -1 with \`EAGAIN\`; the loop exits with empty \`data\`; \`guard !data.isEmpty else { return }\` exits without writing anything; the hook reads EOF and fails closed with the generic \"invalid response\" message.

Once one parallel hook fails, Claude Code cancels the rest as sibling failures, and you have a queue of dialogs whose underlying tool calls are already dead — clicks drain the queue but the tool calls don't resume. That's the \"freeze\" symptom.

## Fix

1. **\`socketReadTimeoutSeconds\` 2 → 30**. Loose enough for any realistic burst scheduling delay; still bounded so a stuck client can't pin a worker forever. The constant has a comment explaining the burst rationale.
2. **Fail-closed on empty payload**. When the read loop exits with no data, the daemon now writes an explicit JSON error (\`{\"verdict\":\"block\",\"reason\":\"Gavel: empty hook payload — daemon worker may be starved under burst load\"}\`) instead of silently closing the fd. The hook surfaces a parseable, diagnosable reason instead of the bland \"invalid response.\"
3. **\`SocketServer.start()\` installs \`signal(SIGPIPE, SIG_IGN)\`** directly. Tests instantiate \`SocketServer\` outside the daemon's signal-handler setup in \`main.swift\`; without this, the new write-to-possibly-closed-socket path would crash the test runner with signal 13.

## Out of scope

This fixes the **cascade trigger**. It does NOT add a UX fix for the broader case of \"5 dialogs queued, user has to click each one.\" That's a separate UX issue (Allow All button, batched approval, or auto-allow-on-pin) worth addressing once this lands.

## Test plan

- [x] \`just build\` clean
- [x] \`just test\` — 248 tests pass (constant-equality assertion updated)
- [ ] After deploy: re-run 5 parallel \`cat ~/.claude/gavel/X\` calls, click through 5 dialogs, all 5 tool calls complete (no cancellation cascade)