### PR TITLE
feat(approval+monitor): note-flow checkbox + 5s activity flash

### DIFF
--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -11,6 +11,23 @@ struct ApprovalPanelView: View {
     @State private var editedFields: [String: String] = [:]
     @State private var isRegexMode: Bool = false
 
+    /// The auto-seeded value of the note field for the current approval. Tracked
+    /// separately so we can render it as a preview (italic + secondary color)
+    /// until the user actually edits it. Once edited, the user's text becomes
+    /// authoritative and renders normally.
+    @State private var seededNoteText: String = ""
+
+    /// Becomes true on the user's first edit of the note field. Drives both the
+    /// preview/normal styling and the auto-tick of `sendNoteToClaude`.
+    @State private var noteHasBeenEdited: Bool = false
+
+    /// Gates whether the note flows to Claude as `additionalContext` on Allow.
+    /// Off by default so the seeded "User approved this via Gavel — …" preview
+    /// doesn't spam Claude's context for normal approvals. Auto-ticks when the
+    /// user edits the note. Deny paths are NOT gated by this — denies always
+    /// include the typed note as the deny reason.
+    @State private var sendNoteToClaude: Bool = false
+
     var body: some View {
         VStack(spacing: 0) {
             if let approval = sessionPanel.currentApproval {
@@ -48,16 +65,28 @@ struct ApprovalPanelView: View {
             )
             editedCommand = ApprovalCoordinator.sanitizeDashes(a.payload.command ?? "")
             editedFields = [:]
-            // Pre-populate the note field for forced dialogs so a default
-            // "approved via Gavel" trail flows back to Claude even if the user
-            // just clicks Allow without typing. Empty for default-tier prompts.
+            // Seed the note field as a *preview* of what would flow to Claude
+            // if the user opts in. Not actually sent unless the checkbox is
+            // ticked (or the user edits the field, which auto-ticks).
             if let reason = a.triggerReason, !reason.isEmpty {
-                noteToClaudeText = "User approved this via Gavel — \(reason)"
+                let seeded = "User approved this via Gavel — \(reason)"
+                noteToClaudeText = seeded
+                seededNoteText = seeded
             } else {
                 noteToClaudeText = ""
+                seededNoteText = ""
             }
+            noteHasBeenEdited = false
+            sendNoteToClaude = false
             isRegexMode = false
         }
+    }
+
+    /// True when the field still shows the auto-seeded preview (i.e. user hasn't
+    /// edited). Used to render the text in italic + secondary so it's visually
+    /// obvious it's a preview, not a value-in-flight.
+    private var notePreviewActive: Bool {
+        !noteHasBeenEdited && !seededNoteText.isEmpty && noteToClaudeText == seededNoteText
     }
 
     // MARK: - Header
@@ -311,24 +340,53 @@ struct ApprovalPanelView: View {
             Image(systemName: "bubble.left")
                 .foregroundColor(.secondary)
                 .padding(.top, 4)
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Note to Claude (optional — Claude sees this as context)")
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Note to Claude")
                     .font(.caption)
                     .foregroundColor(.secondary)
                 TextEditor(text: $noteToClaudeText)
-                    .font(.system(.body, design: .monospaced))
+                    .font(notePreviewActive
+                          ? .system(.body, design: .monospaced).italic()
+                          : .system(.body, design: .monospaced))
+                    .foregroundColor(notePreviewActive ? .secondary : .primary)
                     .frame(minHeight: 36, maxHeight: 120)
                     .padding(4)
                     .background(Color(nsColor: .textBackgroundColor))
                     .cornerRadius(6)
                     .overlay(
                         RoundedRectangle(cornerRadius: 6)
-                            .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                            .stroke(sendNoteToClaude ? Color.green.opacity(0.6) : Color.secondary.opacity(0.3),
+                                    lineWidth: sendNoteToClaude ? 1.5 : 1)
                     )
+                    .onChange(of: noteToClaudeText) { newValue in
+                        // First user edit auto-ticks the send-checkbox so a
+                        // typed note doesn't get silently dropped. The check
+                        // against seededNoteText prevents the resetFields()
+                        // assignment from also tripping this.
+                        if !noteHasBeenEdited && newValue != seededNoteText {
+                            noteHasBeenEdited = true
+                            sendNoteToClaude = true
+                        }
+                    }
+                Toggle(isOn: $sendNoteToClaude) {
+                    Text("Send note to Claude (off by default — used for testing / explicit context)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .toggleStyle(.checkbox)
+                .help("When checked, the note above is sent to Claude as additionalContext on Allow. Denies always include the note as the deny reason regardless of this checkbox.")
             }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
+    }
+
+    /// The note value to send as additionalContext on Allow paths. Returns nil
+    /// when the checkbox is off (or text is empty), suppressing the seeded
+    /// preview from leaking into Claude's context.
+    private var noteForAllowContext: String? {
+        guard sendNoteToClaude, !noteToClaudeText.isEmpty else { return nil }
+        return noteToClaudeText
     }
 
     // MARK: - Action Bar
@@ -429,7 +487,7 @@ struct ApprovalPanelView: View {
                 Button(action: {
                     coordinator.handleAction(.allowPatternForSession(
                         pattern: sessionPattern,
-                        context: noteToClaudeText.isEmpty ? nil : noteToClaudeText,
+                        context: noteForAllowContext,
                         updatedCommand: cmdIfModified,
                         updatedInput: updatedInputIfModified
                     ), on: sessionPanel)
@@ -472,7 +530,7 @@ struct ApprovalPanelView: View {
 
                 Button(action: {
                     coordinator.handleAction(.allow(
-                        context: noteToClaudeText.isEmpty ? nil : noteToClaudeText,
+                        context: noteForAllowContext,
                         updatedCommand: cmdIfModified,
                         updatedInput: updatedInputIfModified
                     ), on: sessionPanel)

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -1,32 +1,76 @@
 import SwiftUI
 
+/// All state for the note-to-Claude field, hoisted into an ObservableObject so
+/// the field's sub-view can observe it independently of the parent panel.
+/// Rationale: when the user clicks the in-field checkbox, only `NoteField`
+/// needs to re-render — the action buttons (Allow/Deny) live in the parent
+/// body and shouldn't get torn down by an unrelated state change. An earlier
+/// `@State`-on-parent design wedged the daemon when the user toggled the
+/// checkbox and then clicked Deny: the parent body re-rendered, the
+/// floating-panel checkbox lost / shuffled key-responder status, and the
+/// subsequent Deny click never reached `coordinator.handleAction`. Isolating
+/// the state plus replacing `Toggle.checkbox` with a `Button`-styled checkbox
+/// (which doesn't carry the same NSButton focus quirks in utility panels)
+/// removes both vectors.
+final class NoteFieldState: ObservableObject {
+    @Published var text: String = ""
+    @Published var sendToClaude: Bool = false
+    @Published var hasBeenEdited: Bool = false
+    var seeded: String = ""
+
+    /// True when the field still shows the auto-seeded preview (i.e. user
+    /// hasn't edited). Drives italic + secondary text styling.
+    var notePreviewActive: Bool {
+        !hasBeenEdited && !seeded.isEmpty && text == seeded
+    }
+
+    /// Note value to send as `additionalContext` on Allow paths. nil unless
+    /// the user explicitly opted in (checkbox or edit-auto-tick) AND there's
+    /// non-empty text.
+    var noteForAllowContext: String? {
+        guard sendToClaude, !text.isEmpty else { return nil }
+        return text
+    }
+
+    /// Note value to send as the deny reason. Gated on `hasBeenEdited` rather
+    /// than the checkbox: a typed deny reason is always high-signal, but the
+    /// auto-seeded preview ("User approved this via Gavel") is nonsensical
+    /// as a deny reason and must not flow on a no-edit deny.
+    var noteForDenyContext: String? {
+        guard hasBeenEdited, !text.isEmpty else { return nil }
+        return text
+    }
+
+    func reset(seededText: String) {
+        text = seededText
+        seeded = seededText
+        hasBeenEdited = false
+        sendToClaude = false
+    }
+
+    /// Called from the field's `onChange`. Promotes the first text mutation
+    /// to "user has edited" + auto-ticks the send checkbox.
+    func userEditedIfNeeded() {
+        if !hasBeenEdited && text != seeded {
+            hasBeenEdited = true
+            sendToClaude = true
+        }
+    }
+}
+
 /// The interactive approval dialog shown for each PreToolUse event.
 /// Each session gets its own panel via SessionPanel.
 struct ApprovalPanelView: View {
     @ObservedObject var coordinator: ApprovalCoordinator
     @ObservedObject var sessionPanel: ApprovalCoordinator.SessionPanel
     @State private var sessionPattern: String = ""
-    @State private var noteToClaudeText: String = ""
     @State private var editedCommand: String = ""
     @State private var editedFields: [String: String] = [:]
     @State private var isRegexMode: Bool = false
 
-    /// The auto-seeded value of the note field for the current approval. Tracked
-    /// separately so we can render it as a preview (italic + secondary color)
-    /// until the user actually edits it. Once edited, the user's text becomes
-    /// authoritative and renders normally.
-    @State private var seededNoteText: String = ""
-
-    /// Becomes true on the user's first edit of the note field. Drives both the
-    /// preview/normal styling and the auto-tick of `sendNoteToClaude`.
-    @State private var noteHasBeenEdited: Bool = false
-
-    /// Gates whether the note flows to Claude as `additionalContext` on Allow.
-    /// Off by default so the seeded "User approved this via Gavel — …" preview
-    /// doesn't spam Claude's context for normal approvals. Auto-ticks when the
-    /// user edits the note. Deny paths are NOT gated by this — denies always
-    /// include the typed note as the deny reason.
-    @State private var sendNoteToClaude: Bool = false
+    /// All note-field state lives here. See `NoteFieldState` for the
+    /// architectural rationale (re-render isolation + bug fix).
+    @StateObject private var noteState = NoteFieldState()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -66,31 +110,17 @@ struct ApprovalPanelView: View {
             editedCommand = ApprovalCoordinator.sanitizeDashes(a.payload.command ?? "")
             editedFields = [:]
             // Seed the note field as a *preview* of what would flow to Claude
-            // if the user opts in. Not actually sent unless the checkbox is
-            // ticked (or the user edits the field, which auto-ticks).
-            // Default-tier prompts (no rule fired) get a generic canned line so
-            // the opt-in path is consistent — useful when the user runs with
-            // auto off and wants a quick "user explicitly approved" trail
-            // without typing each time.
+            // if the user opts in. Default-tier prompts (no rule fired) get a
+            // generic canned line so the opt-in path is consistent.
             let seeded: String
             if let reason = a.triggerReason, !reason.isEmpty {
                 seeded = "User approved this via Gavel — \(reason)"
             } else {
                 seeded = "User approved this via Gavel"
             }
-            noteToClaudeText = seeded
-            seededNoteText = seeded
-            noteHasBeenEdited = false
-            sendNoteToClaude = false
+            noteState.reset(seededText: seeded)
             isRegexMode = false
         }
-    }
-
-    /// True when the field still shows the auto-seeded preview (i.e. user hasn't
-    /// edited). Used to render the text in italic + secondary so it's visually
-    /// obvious it's a preview, not a value-in-flight.
-    private var notePreviewActive: Bool {
-        !noteHasBeenEdited && !seededNoteText.isEmpty && noteToClaudeText == seededNoteText
     }
 
     // MARK: - Header
@@ -344,63 +374,10 @@ struct ApprovalPanelView: View {
             Image(systemName: "bubble.left")
                 .foregroundColor(.secondary)
                 .padding(.top, 4)
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Note to Claude")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                TextEditor(text: $noteToClaudeText)
-                    .font(notePreviewActive
-                          ? .system(.body, design: .monospaced).italic()
-                          : .system(.body, design: .monospaced))
-                    .foregroundColor(notePreviewActive ? .secondary : .primary)
-                    .frame(minHeight: 36, maxHeight: 120)
-                    .padding(4)
-                    .background(Color(nsColor: .textBackgroundColor))
-                    .cornerRadius(6)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 6)
-                            .stroke(sendNoteToClaude ? Color.green.opacity(0.6) : Color.secondary.opacity(0.3),
-                                    lineWidth: sendNoteToClaude ? 1.5 : 1)
-                    )
-                    .onChange(of: noteToClaudeText) { newValue in
-                        // First user edit auto-ticks the send-checkbox so a
-                        // typed note doesn't get silently dropped. The check
-                        // against seededNoteText prevents the resetFields()
-                        // assignment from also tripping this.
-                        if !noteHasBeenEdited && newValue != seededNoteText {
-                            noteHasBeenEdited = true
-                            sendNoteToClaude = true
-                        }
-                    }
-                Toggle(isOn: $sendNoteToClaude) {
-                    Text("Send note to Claude (off by default — used for testing / explicit context)")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                .toggleStyle(.checkbox)
-                .help("When checked, the note above is sent to Claude as additionalContext on Allow. Denies always include the note as the deny reason regardless of this checkbox.")
-            }
+            NoteField(state: noteState)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
-    }
-
-    /// The note value to send as additionalContext on Allow paths. Returns nil
-    /// when the checkbox is off (or text is empty), suppressing the seeded
-    /// preview from leaking into Claude's context.
-    private var noteForAllowContext: String? {
-        guard sendNoteToClaude, !noteToClaudeText.isEmpty else { return nil }
-        return noteToClaudeText
-    }
-
-    /// The note value to send on Deny paths. Gated on `noteHasBeenEdited`
-    /// rather than the checkbox: a typed deny reason is always high-signal
-    /// for Claude's replan, but the auto-seeded preview ("User approved this
-    /// via Gavel") is nonsense as a deny reason and must not flow if the
-    /// user just hit Deny without typing.
-    private var noteForDenyContext: String? {
-        guard noteHasBeenEdited, !noteToClaudeText.isEmpty else { return nil }
-        return noteToClaudeText
     }
 
     // MARK: - Action Bar
@@ -458,7 +435,7 @@ struct ApprovalPanelView: View {
             // Persistent + session rules row
             HStack(spacing: 6) {
                 Button(action: {
-                    coordinator.handleAction(.alwaysDenyPattern(pattern: sessionPattern, isRegex: isRegexMode, explanation: noteForDenyContext), on: sessionPanel)
+                    coordinator.handleAction(.alwaysDenyPattern(pattern: sessionPattern, isRegex: isRegexMode, explanation: noteState.noteForDenyContext), on: sessionPanel)
                 }) {
                     Label("Always Deny", systemImage: "hand.raised")
                 }
@@ -489,7 +466,7 @@ struct ApprovalPanelView: View {
                 Button(action: {
                     coordinator.handleAction(.denyPatternForSession(
                         pattern: sessionPattern,
-                        explanation: noteForDenyContext
+                        explanation: noteState.noteForDenyContext
                     ), on: sessionPanel)
                 }) {
                     Label("Session Deny", systemImage: "shield.slash")
@@ -501,7 +478,7 @@ struct ApprovalPanelView: View {
                 Button(action: {
                     coordinator.handleAction(.allowPatternForSession(
                         pattern: sessionPattern,
-                        context: noteForAllowContext,
+                        context: noteState.noteForAllowContext,
                         updatedCommand: cmdIfModified,
                         updatedInput: updatedInputIfModified
                     ), on: sessionPanel)
@@ -518,7 +495,7 @@ struct ApprovalPanelView: View {
             HStack {
                 Button(action: {
                     coordinator.handleAction(.deny(
-                        context: noteForDenyContext
+                        context: noteState.noteForDenyContext
                     ), on: sessionPanel)
                     coordinator.sessionManager?.noteInteraction()
                 }) {
@@ -544,7 +521,7 @@ struct ApprovalPanelView: View {
 
                 Button(action: {
                     coordinator.handleAction(.allow(
-                        context: noteForAllowContext,
+                        context: noteState.noteForAllowContext,
                         updatedCommand: cmdIfModified,
                         updatedInput: updatedInputIfModified
                     ), on: sessionPanel)
@@ -694,6 +671,56 @@ struct ApprovalPanelView: View {
         case "Read", "Glob", "Grep": return .gray
         case "Agent": return .purple
         default: return .primary
+        }
+    }
+}
+
+// MARK: - NoteField sub-view
+
+/// The note-to-Claude field, isolated into its own view so checkbox toggles
+/// only re-render this slice — keeping the parent panel's action buttons
+/// (Allow/Deny) stable. The checkbox is implemented as a `Button` styled with
+/// SF Symbol icons rather than a `Toggle.checkbox`, because the latter's
+/// underlying NSButton in floating utility panels can lose / shuffle key
+/// responder status, eating the user's subsequent click on Deny. This combo
+/// (state isolation + button-as-checkbox) fixes the wedge reproduced in the
+/// pentest test case "tick checkbox then click Deny without typing".
+private struct NoteField: View {
+    @ObservedObject var state: NoteFieldState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Note to Claude")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            TextEditor(text: $state.text)
+                .font(state.notePreviewActive
+                      ? .system(.body, design: .monospaced).italic()
+                      : .system(.body, design: .monospaced))
+                .foregroundColor(state.notePreviewActive ? .secondary : .primary)
+                .frame(minHeight: 36, maxHeight: 120)
+                .padding(4)
+                .background(Color(nsColor: .textBackgroundColor))
+                .cornerRadius(6)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(state.sendToClaude ? Color.green.opacity(0.6) : Color.secondary.opacity(0.3),
+                                lineWidth: state.sendToClaude ? 1.5 : 1)
+                )
+                .onChange(of: state.text) { _ in
+                    state.userEditedIfNeeded()
+                }
+            Button(action: { state.sendToClaude.toggle() }) {
+                HStack(spacing: 6) {
+                    Image(systemName: state.sendToClaude ? "checkmark.square.fill" : "square")
+                        .foregroundColor(state.sendToClaude ? .accentColor : .secondary)
+                    Text("Send note to Claude (off by default — used for testing / explicit context)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+            .help("When checked, the note above is sent to Claude as additionalContext on Allow. Denies always include the typed note as the deny reason regardless of this checkbox.")
         }
     }
 }

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -393,6 +393,16 @@ struct ApprovalPanelView: View {
         return noteToClaudeText
     }
 
+    /// The note value to send on Deny paths. Gated on `noteHasBeenEdited`
+    /// rather than the checkbox: a typed deny reason is always high-signal
+    /// for Claude's replan, but the auto-seeded preview ("User approved this
+    /// via Gavel") is nonsense as a deny reason and must not flow if the
+    /// user just hit Deny without typing.
+    private var noteForDenyContext: String? {
+        guard noteHasBeenEdited, !noteToClaudeText.isEmpty else { return nil }
+        return noteToClaudeText
+    }
+
     // MARK: - Action Bar
 
     @ViewBuilder
@@ -448,7 +458,7 @@ struct ApprovalPanelView: View {
             // Persistent + session rules row
             HStack(spacing: 6) {
                 Button(action: {
-                    coordinator.handleAction(.alwaysDenyPattern(pattern: sessionPattern, isRegex: isRegexMode, explanation: noteToClaudeText.isEmpty ? nil : noteToClaudeText), on: sessionPanel)
+                    coordinator.handleAction(.alwaysDenyPattern(pattern: sessionPattern, isRegex: isRegexMode, explanation: noteForDenyContext), on: sessionPanel)
                 }) {
                     Label("Always Deny", systemImage: "hand.raised")
                 }
@@ -479,7 +489,7 @@ struct ApprovalPanelView: View {
                 Button(action: {
                     coordinator.handleAction(.denyPatternForSession(
                         pattern: sessionPattern,
-                        explanation: noteToClaudeText.isEmpty ? nil : noteToClaudeText
+                        explanation: noteForDenyContext
                     ), on: sessionPanel)
                 }) {
                     Label("Session Deny", systemImage: "shield.slash")
@@ -508,7 +518,7 @@ struct ApprovalPanelView: View {
             HStack {
                 Button(action: {
                     coordinator.handleAction(.deny(
-                        context: noteToClaudeText.isEmpty ? nil : noteToClaudeText
+                        context: noteForDenyContext
                     ), on: sessionPanel)
                     coordinator.sessionManager?.noteInteraction()
                 }) {

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -68,14 +68,18 @@ struct ApprovalPanelView: View {
             // Seed the note field as a *preview* of what would flow to Claude
             // if the user opts in. Not actually sent unless the checkbox is
             // ticked (or the user edits the field, which auto-ticks).
+            // Default-tier prompts (no rule fired) get a generic canned line so
+            // the opt-in path is consistent — useful when the user runs with
+            // auto off and wants a quick "user explicitly approved" trail
+            // without typing each time.
+            let seeded: String
             if let reason = a.triggerReason, !reason.isEmpty {
-                let seeded = "User approved this via Gavel — \(reason)"
-                noteToClaudeText = seeded
-                seededNoteText = seeded
+                seeded = "User approved this via Gavel — \(reason)"
             } else {
-                noteToClaudeText = ""
-                seededNoteText = ""
+                seeded = "User approved this via Gavel"
             }
+            noteToClaudeText = seeded
+            seededNoteText = seeded
             noteHasBeenEdited = false
             sendNoteToClaude = false
             isRegexMode = false

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -94,14 +94,17 @@ final class HookRouter {
         session.toolCallCount += 1
 
         // Flash the row in the monitor so the user can see which session is
-        // working without reading PIDs. Auto-clears after 0.6s; SwiftUI animates
+        // working without reading PIDs. Auto-clears after 5s; SwiftUI animates
         // the fade. Stamp comparison protects against bursts — only the most
-        // recent activity's clear actually fires.
+        // recent activity's clear actually fires (so a burst extends the visible
+        // window rather than truncating it). 5s is the sweet spot at ~12+
+        // sessions: long enough that human glance-and-find can't miss it, short
+        // enough that it doesn't pile up across rows during normal traffic.
         let stamp = Date()
         DispatchQueue.main.async {
             session.lastActivityAt = stamp
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
             if session.lastActivityAt == stamp {
                 session.lastActivityAt = nil
             }


### PR DESCRIPTION
## Why

Auto-seeding \"User approved this via Gavel — <reason>\" as \`additionalContext\` on every Allow turned out to be mostly noise:

- Claude already knows the call was approved (the tool succeeded).
- The rule reason is internal book-keeping that doesn't change Claude's behavior.
- Each seeded line costs ~15-30 tokens of attention dilution. Over 50 prompts/session that's 750-1500 tokens of boilerplate Claude has to look past to find the actual signal.

The audit trail lives in gavel's monitor / decision feed — that's the right place for it. Claude's transcript shouldn't be a duplicate audit log.

## New behavior

- Note field still pre-populates with seeded text when an ask-user rule fires, but renders **italic + secondary** as a *preview*, not a value-in-flight.
- New **\"Send note to Claude\"** checkbox below the field, **off by default**.
- Editing the note **auto-ticks** the checkbox so a typed note never gets silently dropped.
- Field border turns **green** when the checkbox is on — \"this WILL be sent\" is visually obvious.
- Tooltip documents the deny asymmetry: deny paths always send the note as the deny reason regardless of the checkbox (deny notes are high-signal context for Claude's replan).
- Per-dialog reset (checkbox state, edit-tracking flag, seeded-text snapshot all clear on each new approval — no leakage across queued dialogs).

## Tradeoffs

Loses persistent transcript-side audit (\`grep \"User approved this via Gavel\"\` in old transcripts). The gavel monitor's decision feed is the right place for that audit anyway, and it's already there.

The visible dialog banner (orange \"Triggered by Gavel rule: …\") stays unchanged — that's user-facing visibility and costs Claude nothing.

## Test plan

- [x] \`just build\` clean
- [x] \`just test\` — 248 tests pass (UI behavior; no test additions)
- [ ] Manual: trigger a built-in prompt rule (e.g. \`cat ~/.claude/gavel/rules.json\`). Note field shows seeded text in italic/grey. Checkbox is off. Click Allow → no additionalContext flows.
- [ ] Manual: same scenario, tick the checkbox. Note field's border turns green. Click Allow → seeded text flows as additionalContext.
- [ ] Manual: same scenario, edit the note (type anything). Checkbox auto-ticks; styling switches to normal/primary; border green. Click Allow → typed text flows.
- [ ] Manual: trigger any approval, click Deny with a typed reason. Verify the typed reason still flows as the deny context regardless of checkbox state.