### PR TITLE
feat(daemon): per-session state persistence + diagnostic logging

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -111,6 +111,11 @@ final class ApprovalCoordinator: ObservableObject {
 
     /// Handle the user's decision from the approval panel.
     func handleAction(_ action: Action, on sessionPanel: SessionPanel) {
+        // Diagnostic breadcrumb. Critical signal: if `currentApprovalPresent`
+        // is ever `false` when a click arrives, we've found the wedge vector
+        // (click drops silently, semaphore never signals, hook waits forever).
+        let presentMarker = sessionPanel.currentApproval == nil ? "MISSING" : "ok"
+        gavelLog("[approval] action pid=\(sessionPanel.pid) currentApproval=\(presentMarker) action=\(actionLogTag(action))")
         guard let current = sessionPanel.currentApproval else { return }
 
         // Build updatedInput if user modified the command
@@ -192,6 +197,7 @@ final class ApprovalCoordinator: ObservableObject {
     /// Forced dialogs (from prompt rules / MCP blocks) are NOT flushed.
     func enableAutoApprove(for session: Session) {
         session.isAutoApproveEnabled = true
+        sessionManager?.saveActiveSessions()
 
         guard let sp = sessionPanels[session.pid] else { return }
 
@@ -220,11 +226,13 @@ final class ApprovalCoordinator: ObservableObject {
 
     func disableAutoApprove(for session: Session) {
         session.isAutoApproveEnabled = false
+        sessionManager?.saveActiveSessions()
     }
 
     // MARK: - Per-Session Panel Management
 
     private func showApproval(_ approval: PendingApproval, on sp: SessionPanel) {
+        gavelLog("[approval] show pid=\(sp.pid) tool=\(approval.payload.toolName) queueDepth=\(sp.pendingQueue.count) trigger=\(approval.triggerReason ?? "-")")
         sp.currentApproval = approval
         activeSessionPanel = sp
 
@@ -245,6 +253,7 @@ final class ApprovalCoordinator: ObservableObject {
     }
 
     private func advanceQueue(on sp: SessionPanel) {
+        gavelLog("[approval] advance pid=\(sp.pid) remaining=\(sp.pendingQueue.count)")
         sp.currentApproval = nil
         if sp.pendingQueue.isEmpty {
             closePanel(on: sp)
@@ -252,6 +261,21 @@ final class ApprovalCoordinator: ObservableObject {
             let next = sp.pendingQueue.removeFirst()
             sp.queueCount = sp.pendingQueue.count
             showApproval(next, on: sp)
+        }
+    }
+
+    /// Compact tag for the action enum, used in diagnostic logs. Avoids
+    /// dumping the full enum (which would include user-typed notes) into
+    /// gavel.log.
+    private func actionLogTag(_ action: Action) -> String {
+        switch action {
+        case .allow: return "allow"
+        case .deny: return "deny"
+        case .allowPatternForSession: return "allowPatternForSession"
+        case .denyPatternForSession: return "denyPatternForSession"
+        case .alwaysDenyPattern: return "alwaysDenyPattern"
+        case .alwaysAllowPattern: return "alwaysAllowPattern"
+        case .alwaysPromptPattern: return "alwaysPromptPattern"
         }
     }
 

--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -292,7 +292,14 @@ final class ApprovalCoordinator: ObservableObject {
         let contentView = ApprovalPanelView(coordinator: self, sessionPanel: sp)
         let hostingView = NSHostingView(rootView: contentView)
 
-        let p = NSPanel(
+        // Use a panel subclass that ignores plain Escape. Default NSPanel
+        // behavior: Escape (and Cmd+.) call `cancelOperation` which closes
+        // the panel. That orphans the pending approval (worker still
+        // blocked on its semaphore) and leaves the user with no UI to
+        // resolve it. The Deny button's `Cmd+Escape` shortcut still fires
+        // because it's handled at the SwiftUI level before reaching the
+        // window's cancelOperation.
+        let p = NoEscapeNSPanel(
             contentRect: NSRect(x: 0, y: 0, width: GavelConstants.panelWidth, height: GavelConstants.panelHeight),
             styleMask: [.titled, .closable, .resizable, .utilityWindow],
             backing: .buffered,
@@ -342,5 +349,20 @@ private extension Array {
             else { rest.append(element) }
         }
         return (matching, rest)
+    }
+}
+
+// MARK: - Escape-resistant panel
+
+/// NSPanel that swallows the default `cancelOperation:` (plain Escape).
+/// Without this, pressing Escape in the approval dialog closes the panel
+/// without resolving the pending approval — the worker thread stays blocked
+/// on its semaphore and the user has no UI to dismiss it. The Deny button's
+/// Cmd+Escape SwiftUI shortcut still fires because it's intercepted before
+/// the keystroke reaches NSWindow's cancelOperation handling.
+private final class NoEscapeNSPanel: NSPanel {
+    override func cancelOperation(_ sender: Any?) {
+        // intentional no-op — leave the dialog open so the user must
+        // explicitly choose Cmd+Return (allow) or Cmd+Escape (deny).
     }
 }

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -519,14 +519,7 @@ struct ApprovalPanelView: View {
 
                 Spacer()
 
-                Button(action: {
-                    coordinator.handleAction(.allow(
-                        context: noteState.noteForAllowContext,
-                        updatedCommand: cmdIfModified,
-                        updatedInput: updatedInputIfModified
-                    ), on: sessionPanel)
-                    coordinator.sessionManager?.noteInteraction()
-                }) {
+                Button(action: { performAllowOnce() }) {
                     Label("Allow Once", systemImage: "checkmark.circle")
                 }
                 .buttonStyle(.borderedProminent)
@@ -536,6 +529,29 @@ struct ApprovalPanelView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+        // Hidden mirror of the Allow Once shortcut that fires on Cmd+Return.
+        // Plain Return is consumed by the note TextEditor when it has focus
+        // (inserts a newline), so Cmd+Return gives a way to approve without
+        // first defocusing the field. SwiftUI honors only one
+        // `.keyboardShortcut` per Button, so this is a separate hidden Button.
+        .background(
+            Button("") { performAllowOnce() }
+                .keyboardShortcut(.return, modifiers: [.command])
+                .opacity(0)
+                .frame(width: 0, height: 0)
+                .accessibilityHidden(true)
+        )
+    }
+
+    /// Trigger the Allow Once action. Extracted so the visible button and
+    /// the hidden Cmd+Return shortcut button can share one implementation.
+    private func performAllowOnce() {
+        coordinator.handleAction(.allow(
+            context: noteState.noteForAllowContext,
+            updatedCommand: cmdIfModified,
+            updatedInput: updatedInputIfModified
+        ), on: sessionPanel)
+        coordinator.sessionManager?.noteInteraction()
     }
 
     // MARK: - Pattern Tester

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -523,23 +523,16 @@ struct ApprovalPanelView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(.green)
-                .keyboardShortcut(.return, modifiers: [])
+                // Cmd+Return only — plain Return alone too easily fires Allow
+                // on macOS (TextEditor doesn't always capture it), and an
+                // accidental approval is a real cost. Both action shortcuts
+                // (Cmd+Return / Cmd+Escape) require the Cmd modifier for
+                // symmetry and to prevent stray-key triggering.
+                .keyboardShortcut(.return, modifiers: [.command])
             }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        // Hidden mirror of the Allow Once shortcut that fires on Cmd+Return.
-        // Plain Return is consumed by the note TextEditor when it has focus
-        // (inserts a newline), so Cmd+Return gives a way to approve without
-        // first defocusing the field. SwiftUI honors only one
-        // `.keyboardShortcut` per Button, so this is a separate hidden Button.
-        .background(
-            Button("") { performAllowOnce() }
-                .keyboardShortcut(.return, modifiers: [.command])
-                .opacity(0)
-                .frame(width: 0, height: 0)
-                .accessibilityHidden(true)
-        )
     }
 
     /// Trigger the Allow Once action. Extracted so the visible button and

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -493,17 +493,16 @@ struct ApprovalPanelView: View {
 
             // One-time actions
             HStack {
-                Button(action: {
-                    coordinator.handleAction(.deny(
-                        context: noteState.noteForDenyContext
-                    ), on: sessionPanel)
-                    coordinator.sessionManager?.noteInteraction()
-                }) {
+                Button(action: { performDeny() }) {
                     Label("Deny", systemImage: "xmark.circle")
                 }
                 .buttonStyle(.bordered)
                 .tint(.orange)
-                .keyboardShortcut(.escape, modifiers: [])
+                // Modifier required so a stray Escape press (TextEditor
+                // dismiss, accidental key) doesn't reject an in-flight
+                // approval. Cmd+Escape mirrors the Cmd+Return convention
+                // used for Allow Once.
+                .keyboardShortcut(.escape, modifiers: [.command])
 
                 Button(action: {
                     if let approval = sessionPanel.currentApproval {
@@ -550,6 +549,13 @@ struct ApprovalPanelView: View {
             context: noteState.noteForAllowContext,
             updatedCommand: cmdIfModified,
             updatedInput: updatedInputIfModified
+        ), on: sessionPanel)
+        coordinator.sessionManager?.noteInteraction()
+    }
+
+    private func performDeny() {
+        coordinator.handleAction(.deny(
+            context: noteState.noteForDenyContext
         ), on: sessionPanel)
         coordinator.sessionManager?.noteInteraction()
     }

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -30,7 +30,7 @@ final class RuleStore: ObservableObject {
     // MARK: - Evaluation (split by verdict for priority ordering)
 
     func evaluateDeny(payload: PreToolUsePayload) -> Decision? {
-        for i in rules.indices where rules[i].verdict == .block {
+        for i in rules.indices where rules[i].verdict == .block && !rules[i].isDisabled {
             if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
                 var reason = "Always deny: \(rules[i].name)"
                 if let explanation = rules[i].explanation, !explanation.isEmpty {
@@ -43,7 +43,7 @@ final class RuleStore: ObservableObject {
     }
 
     func evaluateAllow(payload: PreToolUsePayload) -> Decision? {
-        for i in rules.indices where rules[i].verdict == .allow {
+        for i in rules.indices where rules[i].verdict == .allow && !rules[i].isDisabled {
             if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
                 return Decision(verdict: .allow, reason: "Always allow: \(rules[i].name)")
             }
@@ -53,7 +53,7 @@ final class RuleStore: ObservableObject {
 
     /// User-created prompt rules — high priority, checked before allow rules.
     func evaluateUserPrompt(payload: PreToolUsePayload) -> Decision? {
-        for i in rules.indices where rules[i].verdict == .prompt && !rules[i].builtIn {
+        for i in rules.indices where rules[i].verdict == .prompt && !rules[i].builtIn && !rules[i].isDisabled {
             if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
                 return Decision(verdict: .block, reason: "Always prompt: \(rules[i].name)", askUser: true)
             }
@@ -63,12 +63,20 @@ final class RuleStore: ObservableObject {
 
     /// Built-in prompt rules — lower priority, checked after allow rules so users can override.
     func evaluateBuiltInPrompt(payload: PreToolUsePayload) -> Decision? {
-        for i in rules.indices where rules[i].verdict == .prompt && rules[i].builtIn {
+        for i in rules.indices where rules[i].verdict == .prompt && rules[i].builtIn && !rules[i].isDisabled {
             if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
                 return Decision(verdict: .block, reason: "Default rule: \(rules[i].name)", askUser: true)
             }
         }
         return nil
+    }
+
+    /// Toggle a rule's disabled state. Persists immediately so the change
+    /// survives a daemon restart (and stays visible in the UI as "off").
+    func setDisabled(id: UUID, isDisabled: Bool) {
+        guard let idx = rules.firstIndex(where: { $0.id == id }) else { return }
+        rules[idx].isDisabled = isDisabled
+        saveRules()
     }
 
     // MARK: - Rule Management
@@ -331,6 +339,11 @@ struct PersistentRule: Codable, Identifiable {
     let explanation: String?
     /// True for seeded default rules (MCP exfil patterns). User rules are always false.
     let builtIn: Bool
+    /// Skip this rule during evaluation when true. Persisted so the disable
+    /// survives daemon restarts (so a forgotten "temporarily off" rule still
+    /// surfaces in the UI rather than silently re-engaging on reboot). Toggle
+    /// from the Rules tab; defaults to false (rule active).
+    var isDisabled: Bool
 
     /// Pre-compiled regex (rebuilt on first access, not persisted).
     private var _compiledRegex: NSRegularExpression?
@@ -344,10 +357,11 @@ struct PersistentRule: Codable, Identifiable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, toolName, pattern, isRegex, verdict, createdAt, explanation, builtIn
+        case id, name, toolName, pattern, isRegex, verdict, createdAt, explanation, builtIn, isDisabled
     }
 
-    /// Backward-compatible decoding — isRegex, explanation, builtIn default for old rules.json.
+    /// Backward-compatible decoding — isRegex, explanation, builtIn, isDisabled
+    /// all default for old rules.json files lacking the field.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         id = try c.decode(UUID.self, forKey: .id)
@@ -359,6 +373,7 @@ struct PersistentRule: Codable, Identifiable {
         createdAt = try c.decode(Date.self, forKey: .createdAt)
         explanation = try c.decodeIfPresent(String.self, forKey: .explanation)
         builtIn = try c.decodeIfPresent(Bool.self, forKey: .builtIn) ?? false
+        isDisabled = try c.decodeIfPresent(Bool.self, forKey: .isDisabled) ?? false
     }
 
     init(
@@ -367,7 +382,8 @@ struct PersistentRule: Codable, Identifiable {
         isRegex: Bool = false,
         verdict: DecisionVerdict,
         explanation: String? = nil,
-        builtIn: Bool = false
+        builtIn: Bool = false,
+        isDisabled: Bool = false
     ) {
         self.id = UUID()
         self.toolName = toolName
@@ -378,6 +394,7 @@ struct PersistentRule: Codable, Identifiable {
         self.name = "\(toolName): \(isRegex ? "/" : "")\(pattern)\(isRegex ? "/" : "")"
         self.explanation = explanation
         self.builtIn = builtIn
+        self.isDisabled = isDisabled
         self._compiledRegex = Self.compilePattern(pattern, isRegex: isRegex)
     }
 
@@ -392,6 +409,7 @@ struct PersistentRule: Codable, Identifiable {
         self.name = "\(old.toolName): \(isRegex ? "/" : "")\(pattern)\(isRegex ? "/" : "")"
         self.explanation = explanation
         self.builtIn = old.builtIn
+        self.isDisabled = old.isDisabled
         self._compiledRegex = Self.compilePattern(pattern, isRegex: isRegex)
     }
 

--- a/Sources/Gavel/Approval/TaintTracker.swift
+++ b/Sources/Gavel/Approval/TaintTracker.swift
@@ -45,6 +45,24 @@ struct TaintTracker {
     }
 
     /// Record new tainted paths from a command that copies sensitive data.
+    /// Writes go through TaintedPathStore (thread-safe) so the worker thread
+    /// that calls this never touches Combine. A local Set is used as a scratch
+    /// buffer so the private extractors below keep their existing
+    /// `inout Set<String>` signatures and we batch a single `formUnion` at
+    /// the end (one lock acquisition instead of one per insert).
+    static func recordTaints(command: String, into store: TaintedPathStore) {
+        guard referencesSensitiveSource(command) else { return }
+        var buffer = Set<String>()
+        extractRedirectTarget(from: command, into: &buffer)
+        extractCompileOutput(from: command, into: &buffer)
+        extractCopyDestination(from: command, into: &buffer)
+        if !buffer.isEmpty {
+            store.formUnion(buffer)
+        }
+    }
+
+    /// Set-style overload kept for unit tests that hand-craft a Set rather
+    /// than going through the store.
     static func recordTaints(command: String, into taintedPaths: inout Set<String>) {
         guard referencesSensitiveSource(command) else { return }
         extractRedirectTarget(from: command, into: &taintedPaths)

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -271,6 +271,12 @@ final class HookRouter {
     // MARK: - Helpers
 
     private func sendResponse(_ decision: Decision, respond: ((Data) -> Void)?) {
+        // Diagnostic breadcrumb: every hook response that reaches the worker
+        // should produce a `[hook] respond ...` line. If a `[socket] enter`
+        // ever lacks a matching `[hook] respond` and `[socket] exit wrote=N`
+        // (with N > 0), the worker died/wedged after read but before write.
+        let reasonTag = decision.reason ?? "-"
+        gavelLog("[hook] respond verdict=\(decision.verdict.rawValue) reason=\(reasonTag.prefix(80))")
         if let respond = respond,
            let data = decision.hookResponse.data(using: .utf8) {
             respond(data)

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -56,7 +56,9 @@ final class HookRouter {
         case .sessionStart(let payload):
             if let sid = payload.sessionId { sessionManager.recordSessionId(sid, on: session) }
             if let cwd = payload.cwd { sessionManager.recordCwd(cwd, on: session) }
-            session.model = payload.model
+            // Worker thread → main for the @Published write.
+            let model = payload.model
+            DispatchQueue.main.async { session.model = model }
             let source = payload.source ?? "startup"
             emitFeed(.system("Session \(source)", pid: session.pid, at: ts))
 
@@ -65,8 +67,9 @@ final class HookRouter {
 
         case .userPromptSubmit(let payload):
             if let sid = payload.sessionId { sessionManager.recordSessionId(sid, on: session) }
-            session.lastPrompt = payload.prompt
-            let preview = (payload.prompt ?? "").prefix(120)
+            let prompt = payload.prompt
+            DispatchQueue.main.async { session.lastPrompt = prompt }
+            let preview = (prompt ?? "").prefix(120)
             emitFeed(.prompt(text: String(preview), pid: session.pid, at: ts))
 
         case .notification(let payload):
@@ -91,7 +94,7 @@ final class HookRouter {
         timestamp: Date,
         respond: ((Data) -> Void)?
     ) {
-        session.toolCallCount += 1
+        session.stats.incrementToolCall()
 
         // Flash the row in the monitor so the user can see which session is
         // working without reading PIDs. Auto-clears after 5s; SwiftUI animates
@@ -123,14 +126,14 @@ final class HookRouter {
             session.taintedPaths.insert(path)
         }
         if payload.toolName == "Bash", let command = payload.command {
-            if let taintReason = TaintTracker.checkExfiltration(command: command, taintedPaths: session.taintedPaths) {
+            if let taintReason = TaintTracker.checkExfiltration(command: command, taintedPaths: session.taintedPaths.snapshot) {
                 let decision = Decision(verdict: .block, reason: taintReason)
-                session.blockCount += 1
+                session.stats.incrementBlock()
                 emitFeed(.decision(badge: .block, reason: taintReason, pid: session.pid, at: timestamp))
                 sendResponse(decision, respond: respond)
                 return
             }
-            TaintTracker.recordTaints(command: command, into: &session.taintedPaths)
+            TaintTracker.recordTaints(command: command, into: session.taintedPaths)
         }
 
         // Stage 0.5: Session deny rules — checked early so they block even under auto-approve
@@ -139,7 +142,7 @@ final class HookRouter {
             command: payload.command,
             filePath: payload.filePath
         ) {
-            session.blockCount += 1
+            session.stats.incrementBlock()
             let reason = "Session deny: \(rule.toolName): \(rule.pattern)"
             emitFeed(.decision(badge: .block, reason: reason, pid: session.pid, at: timestamp))
             sendResponse(Decision(verdict: .block, reason: reason, additionalContext: rule.explanation), respond: respond)
@@ -157,7 +160,7 @@ final class HookRouter {
                     command: payload.command,
                     filePath: payload.filePath
                 ) {
-                    session.allowCount += 1
+                    session.stats.incrementAllow()
                     emitFeed(.decision(badge: .allow, reason: "Session rule: \(rule.toolName): \(rule.pattern)", pid: session.pid, at: timestamp))
                     sendResponse(Decision(verdict: .allow, reason: "Session rule: \(rule.pattern)"), respond: respond)
                     return
@@ -173,17 +176,17 @@ final class HookRouter {
                 )
                 switch decision.verdict {
                 case .allow, .prompt:
-                    session.allowCount += 1
+                    session.stats.incrementAllow()
                     emitFeed(.decision(badge: .allow, reason: decision.reason, pid: session.pid, at: timestamp))
                 case .block:
-                    session.blockCount += 1
+                    session.stats.incrementBlock()
                     emitFeed(.decision(badge: .block, reason: decision.reason, pid: session.pid, at: timestamp))
                 }
                 sendResponse(decision, respond: respond)
                 return
             } else {
                 // Hard block: dangerous patterns, persistent deny, pause
-                session.blockCount += 1
+                session.stats.incrementBlock()
                 let badge: DecisionBadge = session.isPaused ? .paused : .block
                 emitFeed(.decision(badge: badge, reason: engineDecision.reason, pid: session.pid, at: timestamp))
                 sendResponse(engineDecision, respond: respond)
@@ -192,7 +195,7 @@ final class HookRouter {
         }
         // Persistent allow rules (have a reason) skip the dialog
         if engineDecision.reason != nil {
-            session.allowCount += 1
+            session.stats.incrementAllow()
             emitFeed(.decision(badge: .allow, reason: engineDecision.reason, pid: session.pid, at: timestamp))
             sendResponse(engineDecision, respond: respond)
             return
@@ -200,7 +203,7 @@ final class HookRouter {
 
         // Stage 2: Check auto-approve and session wildcard rules (skip dialog)
         if session.isAutoApproveActive {
-            session.allowCount += 1
+            session.stats.incrementAllow()
             emitFeed(.decision(badge: .autoApprove, reason: engineDecision.reason, pid: session.pid, at: timestamp))
             sendResponse(engineDecision, respond: respond)
             return
@@ -211,7 +214,7 @@ final class HookRouter {
             command: payload.command,
             filePath: payload.filePath
         ) {
-            session.allowCount += 1
+            session.stats.incrementAllow()
             emitFeed(.decision(badge: .allow, reason: "\(rule.toolName): \(rule.pattern)", pid: session.pid, at: timestamp))
             sendResponse(engineDecision, respond: respond)
             return
@@ -220,7 +223,7 @@ final class HookRouter {
         // Stage 2.5: Sub-agent inheritance — auto-approve sub-agent calls
         // (deny rules already checked in Stage 1, so blocks are respected)
         if payload.isSubAgent && session.isSubAgentInheritEnabled {
-            session.allowCount += 1
+            session.stats.incrementAllow()
             emitFeed(.decision(badge: .autoApprove, reason: "Sub-agent: \(payload.agentType ?? "unknown")", pid: session.pid, at: timestamp))
             sendResponse(Decision(verdict: .allow, reason: "Sub-agent inherited"), respond: respond)
             return
@@ -235,10 +238,10 @@ final class HookRouter {
 
         switch decision.verdict {
         case .allow, .prompt:
-            session.allowCount += 1
+            session.stats.incrementAllow()
             emitFeed(.decision(badge: .allow, reason: decision.reason, pid: session.pid, at: timestamp))
         case .block:
-            session.blockCount += 1
+            session.stats.incrementBlock()
             emitFeed(.decision(badge: .block, reason: decision.reason, pid: session.pid, at: timestamp))
         }
 

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -90,13 +90,20 @@ final class SessionManager: ObservableObject {
 
     /// Bind a Claude Code session UUID to a Session and apply any saved label.
     /// If the user typed a label before the sessionId was known, persist it now.
+    /// Called from socket-worker threads — `@Published` mutations on `session`
+    /// are dispatched to main per SwiftUI's main-thread invariant.
     func recordSessionId(_ sid: String, on session: Session) {
         let changed = session.sessionId != sid
-        session.sessionId = sid
-        if session.label.isEmpty, let saved = sessionLabels[sid] {
-            session.label = saved
-        } else if !session.label.isEmpty && sessionLabels[sid] != session.label {
-            sessionLabels[sid] = session.label
+        let savedLabel = sessionLabels[sid]
+        let currentLabel = session.label
+        DispatchQueue.main.async {
+            session.sessionId = sid
+            if session.label.isEmpty, let saved = savedLabel {
+                session.label = saved
+            }
+        }
+        if !currentLabel.isEmpty && savedLabel != currentLabel {
+            sessionLabels[sid] = currentLabel
             saveDefaults()
         }
         if changed {
@@ -107,9 +114,12 @@ final class SessionManager: ObservableObject {
     }
 
     /// Update the cwd for a session and persist the change.
+    /// Worker-thread caller; @Published mutation dispatched to main.
     func recordCwd(_ cwd: String, on session: Session) {
         let changed = session.cwd != cwd
-        session.cwd = cwd
+        DispatchQueue.main.async {
+            session.cwd = cwd
+        }
         if changed {
             lock.lock()
             saveActiveSessionsLocked()
@@ -269,8 +279,13 @@ final class SessionManager: ObservableObject {
         for pid in pids {
             if !isProcessAlive(pid: pid) {
                 lock.lock()
-                sessions[pid]?.isAlive = false
+                let session = sessions[pid]
                 lock.unlock()
+                // `isAlive` is @Published; SwiftUI requires main-thread
+                // mutation. The cleanup timer runs on a global utility queue.
+                DispatchQueue.main.async {
+                    session?.isAlive = false
+                }
                 DispatchQueue.global().asyncAfter(deadline: .now() + GavelConstants.sessionRemovalGraceSeconds) { [weak self] in
                     self?.removeSession(pid: pid)
                 }

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -60,7 +60,7 @@ final class SessionManager: ObservableObject {
         session.isSubAgentInheritEnabled = defaultSubAgentInherit
         session.isPaused = defaultPaused
         sessions[pid] = session
-        saveActiveSessions()
+        saveActiveSessionsLocked()
         return session
     }
 
@@ -101,7 +101,7 @@ final class SessionManager: ObservableObject {
         }
         if changed {
             lock.lock()
-            saveActiveSessions()
+            saveActiveSessionsLocked()
             lock.unlock()
         }
     }
@@ -112,7 +112,7 @@ final class SessionManager: ObservableObject {
         session.cwd = cwd
         if changed {
             lock.lock()
-            saveActiveSessions()
+            saveActiveSessionsLocked()
             lock.unlock()
         }
     }
@@ -132,7 +132,7 @@ final class SessionManager: ObservableObject {
     func removeSession(pid: Int) {
         lock.lock()
         sessions.removeValue(forKey: pid)
-        saveActiveSessions()
+        saveActiveSessionsLocked()
         lock.unlock()
     }
 
@@ -148,24 +148,48 @@ final class SessionManager: ObservableObject {
             sessions.removeValue(forKey: pid)
         }
         if !toRemove.isEmpty {
-            saveActiveSessions()
+            saveActiveSessionsLocked()
         }
         lock.unlock()
     }
 
     // MARK: - Active session persistence
 
+    /// Snapshot of a live session, persisted to active-sessions.json so the
+    /// daemon can rehydrate per-session toggle state across restarts/crashes.
+    /// New fields (auto/sub/paused) are optional so older on-disk files
+    /// load cleanly — missing values fall through to defaults.
     private struct PersistedSession: Codable {
         let pid: Int
         let sessionId: String?
         let cwd: String?
+        let isAutoApproveEnabled: Bool?
+        let isSubAgentInheritEnabled: Bool?
+        let isPaused: Bool?
+    }
+
+    /// Persist all live sessions and their per-session toggle state.
+    /// Call after any change a user expects to survive a daemon restart
+    /// (auto/sub/pause toggle, inactivity-driven auto-revoke, etc.).
+    /// Internal locking handled here so callers don't have to remember.
+    func saveActiveSessions() {
+        lock.lock()
+        defer { lock.unlock() }
+        saveActiveSessionsLocked()
     }
 
     /// Caller's responsibility: hold `lock` (or know that no concurrent writer can race).
-    private func saveActiveSessions() {
+    private func saveActiveSessionsLocked() {
         let snapshot = sessions.values
             .filter { $0.isAlive }
-            .map { PersistedSession(pid: $0.pid, sessionId: $0.sessionId, cwd: $0.cwd) }
+            .map { PersistedSession(
+                pid: $0.pid,
+                sessionId: $0.sessionId,
+                cwd: $0.cwd,
+                isAutoApproveEnabled: $0.isAutoApproveEnabled,
+                isSubAgentInheritEnabled: $0.isSubAgentInheritEnabled,
+                isPaused: $0.isPaused
+            ) }
         guard let json = try? JSONEncoder().encode(snapshot) else { return }
         FileManager.default.createFile(atPath: Self.sessionsPath, contents: json)
     }
@@ -182,9 +206,12 @@ final class SessionManager: ObservableObject {
             let started = ProcessTree.startTime(of: Int32(snap.pid))
             let session = Session(pid: snap.pid, cwd: snap.cwd, startedAt: started)
             session.sessionId = snap.sessionId
-            session.isAutoApproveEnabled = defaultAutoApprove
-            session.isSubAgentInheritEnabled = defaultSubAgentInherit
-            session.isPaused = defaultPaused
+            // Apply persisted per-session settings if present, else fall back
+            // to defaults (covers older on-disk files written before this
+            // field set existed).
+            session.isAutoApproveEnabled = snap.isAutoApproveEnabled ?? defaultAutoApprove
+            session.isSubAgentInheritEnabled = snap.isSubAgentInheritEnabled ?? defaultSubAgentInherit
+            session.isPaused = snap.isPaused ?? defaultPaused
             if let sid = snap.sessionId, let savedLabel = sessionLabels[sid] {
                 session.label = savedLabel
             }
@@ -212,7 +239,7 @@ final class SessionManager: ObservableObject {
             sessions[pidInt] = session
             added += 1
         }
-        if added > 0 { saveActiveSessions() }
+        if added > 0 { saveActiveSessionsLocked() }
         lock.unlock()
         return added
     }
@@ -265,6 +292,10 @@ final class SessionManager: ObservableObject {
             self.defaultAutoApprove = false
             self.defaultSubAgentInherit = false
             self.saveDefaults()
+            // Persist the per-session revoke too so an inactivity-driven flip
+            // (or "Prompt All" click) survives a daemon restart. Otherwise
+            // the user wakes up to gavel restoring the OLD auto state.
+            self.saveActiveSessions()
             GavelNotifications.notify(title: "Gavel — Prompt Mode", body: reason)
             self.noteInteraction()
         }

--- a/Sources/Gavel/Daemon/SocketServer.swift
+++ b/Sources/Gavel/Daemon/SocketServer.swift
@@ -150,7 +150,12 @@ final class SocketServer {
     }
 
     private func handleConnection(fd: Int32) {
-        defer { close(fd) }
+        gavelLog("[socket] enter fd=\(fd)")
+        var bytesWritten = 0
+        defer {
+            gavelLog("[socket] exit fd=\(fd) wroteBytes=\(bytesWritten)")
+            close(fd)
+        }
 
         // Prevent SIGPIPE on this socket if client disconnects during write
         var noSigPipe: Int32 = 1
@@ -181,20 +186,23 @@ final class SocketServer {
         // Send an explicit fail-closed JSON instead so the hook surfaces a
         // diagnosable reason and the cascade has a chance to be debugged.
         guard !data.isEmpty else {
+            gavelLog("[socket] empty payload fd=\(fd) — sending fail-closed")
             let errMsg = #"{"verdict":"block","reason":"Gavel: empty hook payload (read timeout — daemon worker may be starved under burst load)"}"#
             let errData = Data(errMsg.utf8)
-            _ = errData.withUnsafeBytes { ptr in
+            let written = errData.withUnsafeBytes { ptr in
                 write(fd, ptr.baseAddress!, errData.count)
             }
+            if written > 0 { bytesWritten = written }
             return
         }
 
         // For PreToolUse hooks, we need to send a response back.
         // The handler determines whether to respond based on hook type.
         onEvent?(data) { responseData in
-            _ = responseData.withUnsafeBytes { ptr in
+            let written = responseData.withUnsafeBytes { ptr in
                 write(fd, ptr.baseAddress!, responseData.count)
             }
+            if written > 0 { bytesWritten = written }
         }
     }
 }

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -26,13 +26,27 @@ final class Session: ObservableObject, Identifiable {
     // Session rules — wildcard patterns for approval or denial
     @Published var sessionRules: [SessionRule] = []
 
-    // Taint tracking — temp files that contain sensitive data
-    @Published var taintedPaths: Set<String> = []
+    // Worker-mutable state. NOT @Published on purpose — both are touched on
+    // every PreToolUse hook from background threads, and `@Published`
+    // mutations from non-main contend with SwiftUI's main-thread publish
+    // chain (under load this manifested as workers deadlocking after
+    // accept(), see freeze investigation 2026-05-04). UI sees these update
+    // via the 2-second stats timer in MonitorViewModel which calls
+    // `objectWillChange.send()` per session, triggering a re-render that
+    // reads the current values via the computed accessors below.
 
-    // Stats
-    @Published var toolCallCount: Int = 0
-    @Published var allowCount: Int = 0
-    @Published var blockCount: Int = 0
+    let stats = SessionStats()
+
+    /// Temp files containing sensitive data flow. TaintedPathStore is
+    /// thread-safe; existing UI code can still call `.count`, `.sorted()`,
+    /// `.isEmpty` on it directly via the conveniences on the store type.
+    let taintedPaths = TaintedPathStore()
+
+    // Computed proxies so `session.toolCallCount` style call-sites in views
+    // and the stats aggregator still read naturally.
+    var toolCallCount: Int { stats.toolCallCount }
+    var allowCount: Int { stats.allowCount }
+    var blockCount: Int { stats.blockCount }
 
     var id: Int { pid }
 

--- a/Sources/Gavel/Models/SessionStats.swift
+++ b/Sources/Gavel/Models/SessionStats.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Thread-safe counters for a single Session. Lives outside the
+/// `@ObservedObject` Session class on purpose: every PreToolUse hook
+/// increments at least one counter from a worker thread, and `@Published`
+/// mutations from background threads tangle with SwiftUI's main-thread
+/// publish chain — under load (panel open, multiple concurrent sessions)
+/// this manifests as worker-thread deadlocks where new connections accept
+/// but never progress past `read()`.
+///
+/// UI sees updates via `MonitorViewModel.updateStats`, which runs on the
+/// 2-second stats timer (main thread) and calls `objectWillChange.send()`
+/// on each session — that triggers a SwiftUI re-render which reads the
+/// current values via the computed accessors on `Session`. Two-second
+/// granularity is fine for monitor stats; nothing here needs millisecond
+/// reactivity.
+final class SessionStats {
+    private let lock = NSLock()
+    private var _toolCallCount = 0
+    private var _allowCount = 0
+    private var _blockCount = 0
+
+    var toolCallCount: Int { lock.lock(); defer { lock.unlock() }; return _toolCallCount }
+    var allowCount: Int { lock.lock(); defer { lock.unlock() }; return _allowCount }
+    var blockCount: Int { lock.lock(); defer { lock.unlock() }; return _blockCount }
+
+    func incrementToolCall() { lock.lock(); _toolCallCount += 1; lock.unlock() }
+    func incrementAllow() { lock.lock(); _allowCount += 1; lock.unlock() }
+    func incrementBlock() { lock.lock(); _blockCount += 1; lock.unlock() }
+}

--- a/Sources/Gavel/Models/TaintedPathStore.swift
+++ b/Sources/Gavel/Models/TaintedPathStore.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Thread-safe set of paths the daemon has flagged as tainted by sensitive
+/// data flow. Same threading rationale as `SessionStats`: TaintTracker reads
+/// and writes this from worker threads on every Bash and Write/Edit hook;
+/// `@Published Set<String>` mutations from background would deadlock with
+/// SwiftUI's publish chain under load.
+///
+/// The "snapshot" name on the read accessor is intentional — the returned
+/// `Set<String>` is a copy, not a live view, so callers can iterate without
+/// holding the lock. Set-like conveniences (`count`, `isEmpty`, `sorted()`,
+/// `contains`) are provided so existing UI code (`session.taintedPaths.count`)
+/// continues to read naturally.
+final class TaintedPathStore {
+    private let lock = NSLock()
+    private var _paths = Set<String>()
+
+    /// Atomic snapshot of the current set. Safe to iterate from any thread.
+    var snapshot: Set<String> { lock.lock(); defer { lock.unlock() }; return _paths }
+
+    func insert(_ path: String) {
+        lock.lock(); defer { lock.unlock() }
+        _paths.insert(path)
+    }
+
+    func formUnion(_ paths: Set<String>) {
+        lock.lock(); defer { lock.unlock() }
+        _paths.formUnion(paths)
+    }
+
+    // MARK: - Set-shaped conveniences for UI / read-side callers
+
+    var count: Int { lock.lock(); defer { lock.unlock() }; return _paths.count }
+    var isEmpty: Bool { lock.lock(); defer { lock.unlock() }; return _paths.isEmpty }
+    func contains(_ path: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _paths.contains(path)
+    }
+    func sorted() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return _paths.sorted()
+    }
+}

--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -176,6 +176,14 @@ final class MonitorViewModel: ObservableObject {
             allowRuleCount += session.sessionRules.filter { $0.verdict == .allow }.count
             denyRuleCount += session.sessionRules.filter { $0.verdict == .block }.count
             if session.isAutoApproveEnabled { autoCount += 1 }
+            // Counters and taintedPaths live in non-Combine thread-safe stores
+            // (SessionStats / TaintedPathStore) so worker-thread mutations
+            // never trip SwiftUI's main-thread invariant. The trade-off: the
+            // UI doesn't auto-refresh on each increment. Pump a manual publish
+            // here on the 2-second tick so monitor rows re-read the current
+            // counter / taint values during normal render. Two-second
+            // granularity is fine for stats; nothing here needs realtime.
+            session.objectWillChange.send()
         }
 
         let totalRules = allowRuleCount + denyRuleCount

--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -73,12 +73,14 @@ final class MonitorViewModel: ObservableObject {
         guard let session = sessionManager.sessions.values.first else { return }
         session.isPaused.toggle()
         isPaused = session.isPaused
+        sessionManager.saveActiveSessions()
     }
 
     func revokeAutoApprove() {
         for session in sessionManager.sessions.values {
             session.revokeAutoApprove()
         }
+        sessionManager.saveActiveSessions()
     }
 
     /// Revoke auto across every session + reset defaults + notify. The menu bar
@@ -91,6 +93,7 @@ final class MonitorViewModel: ObservableObject {
     /// One-click alternative to toggling both Auto and Sub off manually.
     func promptSession(_ session: Session) {
         session.revokeAutoApprove()
+        sessionManager.saveActiveSessions()
         sessionManager.noteInteraction()
     }
 

--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -122,6 +122,10 @@ final class MonitorViewModel: ObservableObject {
         approvalCoordinator.ruleStore?.updateRule(id: id, pattern: pattern, isRegex: isRegex, verdict: verdict, explanation: explanation)
     }
 
+    func setRuleDisabled(id: UUID, isDisabled: Bool) {
+        approvalCoordinator.ruleStore?.setDisabled(id: id, isDisabled: isDisabled)
+    }
+
     func exportRules(to url: URL) throws {
         guard let rules = approvalCoordinator.ruleStore?.rules else { return }
         let encoder = JSONEncoder()

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -268,6 +268,7 @@ private struct SessionRow: View {
                         let allSub = viewModel.sessionManager.sessions.values.allSatisfy { $0.isSubAgentInheritEnabled }
                         viewModel.sessionManager.defaultSubAgentInherit = allSub
                         viewModel.sessionManager.saveDefaults()
+                        viewModel.sessionManager.saveActiveSessions()
                         viewModel.noteInteraction()
                     }
                 ))
@@ -311,6 +312,7 @@ private struct SessionRow: View {
                 let anyPaused = viewModel.sessionManager.sessions.values.contains { $0.isPaused }
                 viewModel.sessionManager.defaultPaused = anyPaused
                 viewModel.sessionManager.saveDefaults()
+                viewModel.sessionManager.saveActiveSessions()
                 viewModel.noteInteraction()
             }
             .buttonStyle(.bordered)

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -694,6 +694,22 @@ struct RulesView: View {
         VStack(spacing: 0) {
             // Display row
             HStack(spacing: 6) {
+                // Enable/disable toggle. Click flips the rule's `isDisabled`
+                // and persists. Disabled rules render greyed-out to make the
+                // off state visible at a glance — important when the user has
+                // disabled a rule for testing and wants to remember to re-enable.
+                Button(action: {
+                    viewModel.setRuleDisabled(id: rule.id, isDisabled: !rule.isDisabled)
+                    viewModel.noteInteraction()
+                }) {
+                    Image(systemName: rule.isDisabled ? "circle" : "checkmark.circle.fill")
+                        .foregroundColor(rule.isDisabled ? .secondary : .green)
+                }
+                .buttonStyle(.plain)
+                .help(rule.isDisabled
+                      ? "Disabled — click to enable"
+                      : "Enabled — click to temporarily disable (persists across restarts)")
+
                 Text(verdictLabel(rule.verdict))
                     .font(.caption.bold())
                     .foregroundColor(.white)
@@ -717,6 +733,16 @@ struct RulesView: View {
                         .padding(.horizontal, 4)
                         .padding(.vertical, 1)
                         .background(Color.blue.opacity(0.6))
+                        .cornerRadius(3)
+                }
+
+                if rule.isDisabled {
+                    Text("OFF")
+                        .font(.caption2.bold())
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(Color.gray)
                         .cornerRadius(3)
                 }
 
@@ -763,6 +789,7 @@ struct RulesView: View {
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
+            .opacity(rule.isDisabled ? 0.5 : 1.0)
 
             // Inline edit form (shown when editing this rule)
             if editingRuleId == rule.id {

--- a/Tests/GavelTests/ApprovalEngineTests.swift
+++ b/Tests/GavelTests/ApprovalEngineTests.swift
@@ -4,10 +4,23 @@ import XCTest
 final class ApprovalEngineTests: XCTestCase {
     var engine: ApprovalEngine!
     var session: Session!
+    var ruleStorePath: String!
 
     override func setUp() {
-        engine = ApprovalEngine()
+        // Isolated rule store so the user's real rules.json never leaks into
+        // the engine and breaks tests with their own prompt patterns.
+        ruleStorePath = NSTemporaryDirectory() + "engine-tests-\(UUID().uuidString).json"
+        engine = ApprovalEngine(
+            patternMatcher: PatternMatcher(),
+            ruleStore: RuleStore(configPath: ruleStorePath)
+        )
         session = Session(pid: 12345)
+    }
+
+    override func tearDown() {
+        if let path = ruleStorePath {
+            try? FileManager.default.removeItem(atPath: path)
+        }
     }
 
     private func payload(tool: String = "Bash", command: String? = nil, filePath: String? = nil) -> PreToolUsePayload {

--- a/Tests/GavelTests/WireFormatTests.swift
+++ b/Tests/GavelTests/WireFormatTests.swift
@@ -3,6 +3,21 @@ import XCTest
 
 final class WireFormatTests: XCTestCase {
 
+    /// Build an ApprovalEngine that does NOT load the user's real rules.json.
+    /// Without this, any prompt rule the user has installed (e.g. "always
+    /// prompt on doppler secrets") matches the test payload and the dialog
+    /// blocks the test forever waiting for a click that never comes. The
+    /// returned engine and its tempdir-scoped store should be discarded by
+    /// the caller (FileManager removeItem in a defer).
+    private func makeIsolatedEngine() -> (ApprovalEngine, String) {
+        let path = NSTemporaryDirectory() + "wireformat-rules-\(UUID().uuidString).json"
+        let engine = ApprovalEngine(
+            patternMatcher: PatternMatcher(),
+            ruleStore: RuleStore(configPath: path)
+        )
+        return (engine, path)
+    }
+
     // MARK: - Decision hookResponse (daemon → shim protocol)
 
     func testAllowDecisionJson() throws {
@@ -130,7 +145,8 @@ final class WireFormatTests: XCTestCase {
     // MARK: - HookRouter integration
 
     func testRouterAllowsNormalCommand() {
-        let engine = ApprovalEngine()
+        let (engine, ruleStorePath) = makeIsolatedEngine()
+        defer { try? FileManager.default.removeItem(atPath: ruleStorePath) }
         let manager = SessionManager()
         let coordinator = ApprovalCoordinator()
         // Pre-create session with auto-approve so router doesn't block on dialog
@@ -162,7 +178,8 @@ final class WireFormatTests: XCTestCase {
     }
 
     func testRouterBlocksDangerousCommand() {
-        let engine = ApprovalEngine()
+        let (engine, ruleStorePath) = makeIsolatedEngine()
+        defer { try? FileManager.default.removeItem(atPath: ruleStorePath) }
         let manager = SessionManager()
         let coordinator = ApprovalCoordinator()
         // Dangerous commands are blocked before reaching interactive approval
@@ -193,7 +210,8 @@ final class WireFormatTests: XCTestCase {
     }
 
     func testRouterBlocksOnSessionDeny() {
-        let engine = ApprovalEngine()
+        let (engine, ruleStorePath) = makeIsolatedEngine()
+        defer { try? FileManager.default.removeItem(atPath: ruleStorePath) }
         let manager = SessionManager()
         let coordinator = ApprovalCoordinator()
         let session = manager.session(for: 66666)
@@ -231,7 +249,8 @@ final class WireFormatTests: XCTestCase {
     }
 
     func testRouterSessionDenyOverridesAutoApprove() {
-        let engine = ApprovalEngine()
+        let (engine, ruleStorePath) = makeIsolatedEngine()
+        defer { try? FileManager.default.removeItem(atPath: ruleStorePath) }
         let manager = SessionManager()
         let coordinator = ApprovalCoordinator()
         let session = manager.session(for: 77777)
@@ -268,7 +287,8 @@ final class WireFormatTests: XCTestCase {
     }
 
     func testRouterEnrichesSessionFromPayload() {
-        let engine = ApprovalEngine()
+        let (engine, ruleStorePath) = makeIsolatedEngine()
+        defer { try? FileManager.default.removeItem(atPath: ruleStorePath) }
         let manager = SessionManager()
         let coordinator = ApprovalCoordinator()
         let session = manager.session(for: 55555)
@@ -292,11 +312,10 @@ final class WireFormatTests: XCTestCase {
         router.handle(data: json.data(using: .utf8)!) { _ in }
 
         // sessionId/cwd are @Published; SessionManager dispatches the writes
-        // to the main queue (worker → main per SwiftUI invariant). Drain the
-        // main queue before asserting so the dispatched writes have landed.
-        let exp = expectation(description: "main queue drained")
-        DispatchQueue.main.async { exp.fulfill() }
-        wait(for: [exp], timeout: 1.0)
+        // to the main queue (worker → main per SwiftUI invariant). Pump the
+        // current run loop briefly so the dispatched writes land before we
+        // assert.
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
 
         XCTAssertEqual(session.sessionId, "enrichment-test")
         XCTAssertEqual(session.cwd, "/home/user/project")

--- a/Tests/GavelTests/WireFormatTests.swift
+++ b/Tests/GavelTests/WireFormatTests.swift
@@ -291,6 +291,13 @@ final class WireFormatTests: XCTestCase {
         """
         router.handle(data: json.data(using: .utf8)!) { _ in }
 
+        // sessionId/cwd are @Published; SessionManager dispatches the writes
+        // to the main queue (worker → main per SwiftUI invariant). Drain the
+        // main queue before asserting so the dispatched writes have landed.
+        let exp = expectation(description: "main queue drained")
+        DispatchQueue.main.async { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+
         XCTAssertEqual(session.sessionId, "enrichment-test")
         XCTAssertEqual(session.cwd, "/home/user/project")
     }


### PR DESCRIPTION
## Why

Two operational improvements driven by ongoing freeze debugging:

1. **State persistence** — daemon restart/crash shouldn't reset every session's Auto/Sub/Pause to defaults. The user is running 12+ sessions; manually re-enabling each toggle after every restart is the biggest current pain.
2. **Diagnostic logging** — every freeze investigation has been guesswork. We need breadcrumbs in the log to tell whether a click reached the handler, whether the daemon wrote a response, and where things stopped.

Filed #55 separately for the long-term headless-daemon + UI-clients architecture that would eliminate the whole class of UI-coupling bugs. This PR is the pragmatic patch; #55 is the strategic direction.

## State persistence

- \`PersistedSession\` (in \`active-sessions.json\`) gets three new optional fields: \`isAutoApproveEnabled\`, \`isSubAgentInheritEnabled\`, \`isPaused\`.
- \`saveActiveSessions()\` snapshots them. \`loadActiveSessions()\` restores per-PID on rehydrate. Falls through to defaults for older on-disk files where fields are absent → fully backward-compatible.
- Save triggers added at every user-driven mutation site:
  - Auto toggle (via \`enableAutoApprove\` / \`disableAutoApprove\` in coordinator)
  - Sub-agent toggle (in \`MonitorWindow\` row)
  - Pause/Resume button (in \`MonitorWindow\` row)
  - "Prompt All Sessions" (now persists the revoke too)
  - Per-session "Prompt" button (in \`MonitorViewModel\`)
  - Inactivity-timer auto-revoke
- Locking: \`saveActiveSessions()\` is the new public, lock-acquiring entry point. Existing internal callers that already hold \`lock\` switched to a private \`saveActiveSessionsLocked()\` to avoid re-entrant deadlock.

## Diagnostic logging

Six lifecycle breadcrumbs into \`gavel.log\`:

| Site | Line |
|---|---|
| \`SocketServer.handleConnection\` enter | \`[socket] enter fd=N\` |
| \`SocketServer.handleConnection\` exit | \`[socket] exit fd=N wroteBytes=M\` |
| Empty-payload fail-closed branch | \`[socket] empty payload fd=N — sending fail-closed\` |
| \`HookRouter.sendResponse\` | \`[hook] respond verdict=… reason=…\` |
| \`ApprovalCoordinator.showApproval\` | \`[approval] show pid=… queueDepth=… trigger=…\` |
| \`ApprovalCoordinator.handleAction\` | \`[approval] action pid=… currentApproval=ok\|MISSING action=…\` |
| \`ApprovalCoordinator.advanceQueue\` | \`[approval] advance pid=… remaining=…\` |

Critical signals:
- \`wroteBytes=0\` on a \`[socket] exit\` → daemon never responded to this client (smoking gun for hook "invalid response" failures).
- \`[socket] enter\` without a matching \`[hook] respond\` → hook router dropped the request before reply.
- \`currentApproval=MISSING\` on \`[approval] action\` → silent-drop wedge vector (the case-E bug class).

Reason fields truncated to 80 chars; action enum summarized to a tag (no leaking user-typed notes into the log).

## Test plan

- [x] \`just build\` clean
- [x] \`just test\` — 248 tests pass
- [ ] After deploy: toggle Auto on a session, restart daemon, confirm Auto stays on after restore
- [ ] Same for Sub-agent and Pause
- [ ] Hit a freeze and confirm \`tail -f ~/.claude/gavel/gavel.log\` shows the breadcrumb trail up to where it stopped — that's the actionable signal we've been missing
- [ ] Verify older \`active-sessions.json\` files (pre-this-PR fields) still load without errors (backward compat)