### PR TITLE
feat(approval): "Allow Rule" suppresses firing prompt rule for session

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -12,6 +12,8 @@ final class ApprovalCoordinator: ObservableObject {
         case allow(context: String?, updatedCommand: String?, updatedInput: [String: AnyCodable]?)
         case deny(context: String?)
         case allowPatternForSession(pattern: String, context: String?, updatedCommand: String?, updatedInput: [String: AnyCodable]?)
+        /// Suppress firing prompt rule for session — covers the rule's full regex scope.
+        case suppressRuleForSession(ruleId: UUID, context: String?, updatedCommand: String?, updatedInput: [String: AnyCodable]?)
         case denyPatternForSession(pattern: String, explanation: String?)
         case alwaysDenyPattern(pattern: String, isRegex: Bool, explanation: String?)
         case alwaysAllowPattern(pattern: String, isRegex: Bool)
@@ -29,11 +31,12 @@ final class ApprovalCoordinator: ObservableObject {
         let session: Session
         let timestamp: Date
         let forceDialog: Bool
-        /// The reason from the engine decision when the dialog was forced
-        /// (e.g. "Crontab modification"). Nil for default-tier dialogs where no
-        /// rule fired. Surfaced in the panel so the user can see *why* they're
-        /// being asked, instead of rubber-stamping a context-free prompt.
+        /// Reason from the engine when dialog was forced. Nil for default-tier prompts.
         let triggerReason: String?
+        /// ID of the rule that fired, if any. Drives the "Allow rule for session" affordance.
+        let triggeringRuleId: UUID?
+        let triggeringRulePattern: String?
+        let triggeringRuleIsRegex: Bool
         let respond: (Decision) -> Void
     }
 
@@ -69,7 +72,8 @@ final class ApprovalCoordinator: ObservableObject {
         session: Session,
         timestamp: Date,
         forceDialog: Bool = false,
-        triggerReason: String? = nil
+        triggerReason: String? = nil,
+        triggeringRuleId: UUID? = nil
     ) -> Decision {
         if !forceDialog && session.isAutoApproveEnabled {
             return Decision(verdict: .allow, reason: "Auto-approved")
@@ -78,12 +82,16 @@ final class ApprovalCoordinator: ObservableObject {
         let semaphore = DispatchSemaphore(value: 0)
         var result = Decision(verdict: .block, reason: "Approval timed out — fail closed")
 
+        let firingRule = triggeringRuleId.flatMap { ruleStore?.rule(for: $0) }
         let pending = PendingApproval(
             payload: payload,
             session: session,
             timestamp: timestamp,
             forceDialog: forceDialog,
-            triggerReason: triggerReason
+            triggerReason: triggerReason,
+            triggeringRuleId: triggeringRuleId,
+            triggeringRulePattern: firingRule?.pattern,
+            triggeringRuleIsRegex: firingRule?.isRegex ?? false
         ) { decision in
             result = decision
             semaphore.signal()
@@ -149,6 +157,13 @@ final class ApprovalCoordinator: ObservableObject {
             let rule = SessionRule(toolName: current.payload.toolName, pattern: pattern)
             current.session.sessionRules.append(rule)
             current.respond(Decision(verdict: .allow, reason: "User approved (\(current.payload.toolName): \(pattern))", additionalContext: ctx, updatedInput: updated))
+
+        case .suppressRuleForSession(let ruleId, let context, let updatedCommand, let fieldUpdates):
+            ctx = context
+            updated = fieldUpdates ?? buildUpdatedInput(updatedCommand)
+            current.session.suppressedRuleIds.insert(ruleId)
+            let patternTag = current.triggeringRulePattern.map { " (\($0))" } ?? ""
+            current.respond(Decision(verdict: .allow, reason: "User approved — rule suppressed for session\(patternTag)", additionalContext: ctx, updatedInput: updated))
 
         case .denyPatternForSession(let pattern, let explanation):
             ctx = nil; updated = nil
@@ -272,6 +287,7 @@ final class ApprovalCoordinator: ObservableObject {
         case .allow: return "allow"
         case .deny: return "deny"
         case .allowPatternForSession: return "allowPatternForSession"
+        case .suppressRuleForSession: return "suppressRuleForSession"
         case .denyPatternForSession: return "denyPatternForSession"
         case .alwaysDenyPattern: return "alwaysDenyPattern"
         case .alwaysAllowPattern: return "alwaysAllowPattern"

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -489,6 +489,24 @@ struct ApprovalPanelView: View {
                 .buttonStyle(.bordered)
                 .tint(.purple)
                 .keyboardShortcut("s", modifiers: [.command])
+
+                if let ruleId = approval.triggeringRuleId {
+                    Button(action: {
+                        coordinator.handleAction(.suppressRuleForSession(
+                            ruleId: ruleId,
+                            context: noteState.noteForAllowContext,
+                            updatedCommand: cmdIfModified,
+                            updatedInput: updatedInputIfModified
+                        ), on: sessionPanel)
+                        coordinator.sessionManager?.noteInteraction()
+                    }) {
+                        Label("Allow Rule", systemImage: "bell.slash")
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.indigo)
+                    .keyboardShortcut("r", modifiers: [.command])
+                    .help(approval.triggeringRulePattern.map { "Suppress rule for session: \($0)" } ?? "Suppress firing rule for session")
+                }
             }
 
             // One-time actions

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -55,7 +55,7 @@ final class RuleStore: ObservableObject {
     func evaluateUserPrompt(payload: PreToolUsePayload) -> Decision? {
         for i in rules.indices where rules[i].verdict == .prompt && !rules[i].builtIn && !rules[i].isDisabled {
             if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
-                return Decision(verdict: .block, reason: "Always prompt: \(rules[i].name)", askUser: true)
+                return Decision(verdict: .block, reason: "Always prompt: \(rules[i].name)", askUser: true, triggeringRuleId: rules[i].id)
             }
         }
         return nil
@@ -65,10 +65,14 @@ final class RuleStore: ObservableObject {
     func evaluateBuiltInPrompt(payload: PreToolUsePayload) -> Decision? {
         for i in rules.indices where rules[i].verdict == .prompt && rules[i].builtIn && !rules[i].isDisabled {
             if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
-                return Decision(verdict: .block, reason: "Default rule: \(rules[i].name)", askUser: true)
+                return Decision(verdict: .block, reason: "Default rule: \(rules[i].name)", askUser: true, triggeringRuleId: rules[i].id)
             }
         }
         return nil
+    }
+
+    func rule(for id: UUID) -> PersistentRule? {
+        rules.first { $0.id == id }
     }
 
     /// Toggle a rule's disabled state. Persists immediately so the change

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -153,6 +153,15 @@ final class HookRouter {
         let engineDecision = approvalEngine.evaluate(payload: payload, session: session)
         if engineDecision.verdict == .block {
             if engineDecision.askUser {
+                // Rule suppressed for session — covers the rule's full regex scope.
+                if let ruleId = engineDecision.triggeringRuleId,
+                   session.suppressedRuleIds.contains(ruleId) {
+                    session.stats.incrementAllow()
+                    emitFeed(.decision(badge: .allow, reason: "Rule suppressed for session", pid: session.pid, at: timestamp))
+                    sendResponse(Decision(verdict: .allow, reason: "Rule suppressed for session"), respond: respond)
+                    return
+                }
+
                 // Before forcing dialog, check if a session rule already covers this.
                 // Session Allow from a previous dialog should skip re-prompting.
                 if let rule = session.matchesSessionRule(
@@ -172,7 +181,8 @@ final class HookRouter {
                 let decision = approvalCoordinator.requestApproval(
                     payload: payload, session: session, timestamp: timestamp,
                     forceDialog: true,
-                    triggerReason: engineDecision.reason
+                    triggerReason: engineDecision.reason,
+                    triggeringRuleId: engineDecision.triggeringRuleId
                 )
                 switch decision.verdict {
                 case .allow, .prompt:

--- a/Sources/Gavel/Models/Decision.swift
+++ b/Sources/Gavel/Models/Decision.swift
@@ -21,13 +21,16 @@ struct Decision: Codable {
     /// When true, the router should show the interactive dialog instead of hard blocking.
     /// Used for MCP tool blocks that users should be able to approve case-by-case.
     let askUser: Bool
+    /// Set when a persistent prompt rule fired — used by per-session rule suppression.
+    let triggeringRuleId: UUID?
 
-    init(verdict: DecisionVerdict, reason: String?, additionalContext: String? = nil, updatedInput: [String: AnyCodable]? = nil, askUser: Bool = false) {
+    init(verdict: DecisionVerdict, reason: String?, additionalContext: String? = nil, updatedInput: [String: AnyCodable]? = nil, askUser: Bool = false, triggeringRuleId: UUID? = nil) {
         self.verdict = verdict
         self.reason = reason
         self.additionalContext = additionalContext
         self.updatedInput = updatedInput
         self.askUser = askUser
+        self.triggeringRuleId = triggeringRuleId
     }
 
     /// Internal protocol JSON sent to the gavel-hook shim via socket.

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -26,6 +26,9 @@ final class Session: ObservableObject, Identifiable {
     // Session rules — wildcard patterns for approval or denial
     @Published var sessionRules: [SessionRule] = []
 
+    /// Prompt-rule IDs silenced for this session. Transient; cleared on revoke.
+    @Published var suppressedRuleIds: Set<UUID> = []
+
     // Worker-mutable state. NOT @Published on purpose — both are touched on
     // every PreToolUse hook from background threads, and `@Published`
     // mutations from non-main contend with SwiftUI's main-thread publish
@@ -72,6 +75,7 @@ final class Session: ObservableObject, Identifiable {
         isSubAgentInheritEnabled = false
         autoApproveUntil = nil
         sessionRules.removeAll()
+        suppressedRuleIds.removeAll()
     }
 
     /// Check if a tool call matches any session allow rule.

--- a/Tests/GavelTests/PromptOverrideTest.swift
+++ b/Tests/GavelTests/PromptOverrideTest.swift
@@ -1,0 +1,145 @@
+import XCTest
+@testable import Gavel
+
+/// HookRouter-level coverage for the two session-allow paths:
+///   1. pattern-bound SessionRule (allowPatternForSession)
+///   2. rule-suppression by ID (suppressRuleForSession) — covers the rule's
+///      full regex scope (e.g. one prompt rule spanning many MCP tool names).
+final class PromptOverrideTest: XCTestCase {
+
+    private func runRouter(
+        session: Session,
+        store: RuleStore,
+        toolName: String = "Bash",
+        toolInputJson: String
+    ) -> [String: Any]? {
+        let engine = ApprovalEngine(patternMatcher: PatternMatcher(), ruleStore: store)
+        let manager = SessionManager()
+        let live = manager.session(for: session.pid)
+        live.sessionRules = session.sessionRules
+        live.suppressedRuleIds = session.suppressedRuleIds
+        let coordinator = ApprovalCoordinator()
+        let router = HookRouter(sessionManager: manager, approvalEngine: engine, approvalCoordinator: coordinator)
+
+        let json = """
+        {
+            "hookType": "PreToolUse",
+            "sessionPid": \(session.pid),
+            "timestamp": 1712600000.0,
+            "payload": {
+                "type": "PreToolUse",
+                "tool_name": "\(toolName)",
+                "tool_input": \(toolInputJson),
+                "session_id": "test-session"
+            }
+        }
+        """
+
+        var responseJson: [String: Any]?
+        router.handle(data: json.data(using: .utf8)!) { data in
+            responseJson = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        }
+        return responseJson
+    }
+
+    private func bashInput(_ command: String) -> String {
+        "{\"command\": \"\(command)\"}"
+    }
+
+    func testSessionAllowOverridesUserPromptRule() {
+        let path = NSTemporaryDirectory() + "promptoverride-\(UUID().uuidString).json"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let store = RuleStore(configPath: path)
+        store.addRule(PersistentRule(toolName: "Bash", pattern: "git push*", verdict: .prompt))
+
+        let session = Session(pid: 88881)
+        session.sessionRules.append(SessionRule(toolName: "Bash", pattern: "git push*"))
+
+        let response = runRouter(session: session, store: store, toolInputJson: bashInput("git push origin main"))
+        XCTAssertEqual(response?["verdict"] as? String, "allow",
+                       "Session allow should override user always-prompt rule. Got: \(String(describing: response))")
+    }
+
+    func testSessionAllowOverridesBuiltInPromptRule() {
+        let path = NSTemporaryDirectory() + "promptoverride-\(UUID().uuidString).json"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let store = RuleStore(configPath: path)
+        store.addRule(PersistentRule(toolName: "Bash", pattern: "git push*", isRegex: false, verdict: .prompt, builtIn: true))
+
+        let session = Session(pid: 88882)
+        session.sessionRules.append(SessionRule(toolName: "Bash", pattern: "git push*"))
+
+        let response = runRouter(session: session, store: store, toolInputJson: bashInput("git push origin main"))
+        XCTAssertEqual(response?["verdict"] as? String, "allow",
+                       "Session allow should override built-in prompt rule. Got: \(String(describing: response))")
+    }
+
+    /// Suppress-by-ID covers the full regex scope: one Playwright prompt rule
+    /// spans many MCP tool names; suppressing the rule covers all sibling methods.
+    func testSuppressedRuleCoversSiblingMcpToolNames() {
+        let path = NSTemporaryDirectory() + "promptoverride-\(UUID().uuidString).json"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let store = RuleStore(configPath: path)
+
+        let rule = PersistentRule(
+            toolName: "*",
+            pattern: "mcp__.*[Pp]laywright.*(navigate|evaluate|click|type)",
+            isRegex: true,
+            verdict: .prompt
+        )
+        store.addRule(rule)
+
+        let session = Session(pid: 88883)
+        session.suppressedRuleIds.insert(rule.id)
+
+        let r1 = runRouter(session: session, store: store, toolName: "mcp__Playwright__browser_click", toolInputJson: "{}")
+        XCTAssertEqual(r1?["verdict"] as? String, "allow")
+
+        let r2 = runRouter(session: session, store: store, toolName: "mcp__Playwright__browser_navigate", toolInputJson: "{}")
+        XCTAssertEqual(r2?["verdict"] as? String, "allow")
+
+        let r3 = runRouter(session: session, store: store, toolName: "mcp__Playwright__browser_type", toolInputJson: "{}")
+        XCTAssertEqual(r3?["verdict"] as? String, "allow")
+    }
+
+    /// Pattern-bound SessionRule does NOT cover sibling MCP methods —
+    /// motivates the suppress-by-ID path.
+    func testPatternBoundSessionRuleDoesNotCoverSiblings() {
+        let path = NSTemporaryDirectory() + "promptoverride-\(UUID().uuidString).json"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let store = RuleStore(configPath: path)
+
+        store.addRule(PersistentRule(
+            toolName: "*",
+            pattern: "mcp__.*[Pp]laywright.*",
+            isRegex: true,
+            verdict: .prompt
+        ))
+
+        let session = Session(pid: 88884)
+        // Simulates clicking "Session Allow" on a click event with default pattern "*".
+        session.sessionRules.append(SessionRule(toolName: "mcp__Playwright__browser_click", pattern: "*"))
+
+        let click = runRouter(session: session, store: store, toolName: "mcp__Playwright__browser_click", toolInputJson: "{}")
+        XCTAssertEqual(click?["verdict"] as? String, "allow", "Same tool name should match the pattern-bound rule")
+
+        // Sibling method has no SessionRule for it, so the prompt rule still fires.
+        // The test runner can't open the dialog — match path takes the dialog branch
+        // and times out. We verify the lack of allow path differently: pattern rule
+        // for *_click does not match _navigate by toolName check.
+        let navRule = SessionRule(toolName: "mcp__Playwright__browser_click", pattern: "*")
+        XCTAssertNil(
+            navRule.matches(toolName: "mcp__Playwright__browser_navigate", command: nil, filePath: nil) ? navRule : nil,
+            "Pattern-bound rule for click should not match navigate"
+        )
+    }
+
+    func testRevokeAutoApproveClearsSuppressedRules() {
+        let session = Session(pid: 88885)
+        session.suppressedRuleIds.insert(UUID())
+        session.suppressedRuleIds.insert(UUID())
+        XCTAssertEqual(session.suppressedRuleIds.count, 2)
+        session.revokeAutoApprove()
+        XCTAssertTrue(session.suppressedRuleIds.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- New "Allow Rule" button in the approval dialog (next to Session Allow), shown only when a persistent prompt rule fired
- Suppresses the firing rule by UUID for the rest of the session — covers the rule's **full regex scope** instead of binding to one tool name
- Solves the MCP gap: a single regex prompt rule like `mcp__.*Playwright.*(navigate|evaluate|...)` spans many tool names, so pattern-bound Session Allow couldn't silence sibling methods

## Why
Session Allow today appends a `SessionRule(toolName: payload.toolName, pattern: "*")`. For MCP tools where one regex prompt rule spans navigate / click / evaluate / type / fill, allowing one method left every sibling re-prompting. Two different intents were glued under one button: "allow this command pattern for the session" vs "stop asking me about this category."

## Implementation
- `Decision.triggeringRuleId: UUID?` — populated by `RuleStore.evaluateUserPrompt` / `evaluateBuiltInPrompt`
- `Session.suppressedRuleIds: Set<UUID>` — transient, cleared on `revokeAutoApprove`
- `HookRouter` checks suppression before existing pattern-rule check and before forcing the dialog
- `ApprovalCoordinator.Action.suppressRuleForSession(ruleId, ...)` — new action variant
- `PendingApproval` carries the firing rule's pattern + isRegex for tooltip display
- `ApprovalPanelView` shows "Allow Rule" (Cmd+R, indigo) only when `triggeringRuleId != nil` — no UI clutter on default-tier or hard-coded sensitive-path dialogs

## Test plan
- [x] `swift test` — 253/253 pass (3 new tests in `PromptOverrideTest.swift`)
- [x] Manual: Playwright navigate → "Allow Rule" → Playwright evaluate (different tool name, same regex) passes without re-prompting
- [x] `revokeAutoApprove` clears `suppressedRuleIds`