### PR TITLE
feat(monitor): surface suppressed rules + fix PID display

### DIFF
--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -147,7 +147,7 @@ struct ApprovalPanelView: View {
                     .cornerRadius(4)
             }
 
-            Text("PID \(approval.session.pid)")
+            Text(verbatim: "PID \(approval.session.pid)")
                 .font(.caption.monospaced())
                 .foregroundColor(.secondary)
         }

--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -126,6 +126,10 @@ final class MonitorViewModel: ObservableObject {
         approvalCoordinator.ruleStore?.setDisabled(id: id, isDisabled: isDisabled)
     }
 
+    func unsuppressRule(session: Session, ruleId: UUID) {
+        session.suppressedRuleIds.remove(ruleId)
+    }
+
     func exportRules(to url: URL) throws {
         guard let rules = approvalCoordinator.ruleStore?.rules else { return }
         let encoder = JSONEncoder()

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -962,6 +962,10 @@ struct SessionRulesView: View {
                     .foregroundColor(.red)
                 Text("Rules: \(session.sessionRules.count)")
                     .foregroundColor(.purple)
+                if !session.suppressedRuleIds.isEmpty {
+                    Text("Suppressed: \(session.suppressedRuleIds.count)")
+                        .foregroundColor(.indigo)
+                }
                 Text("Tainted: \(session.taintedPaths.count)")
                     .foregroundColor(.orange)
             }
@@ -1005,6 +1009,47 @@ struct SessionRulesView: View {
                                 .foregroundColor(.secondary)
                         }
                         .buttonStyle(.plain)
+                    }
+                    .padding(.leading, 16)
+                }
+            }
+
+            if !session.suppressedRuleIds.isEmpty {
+                ForEach(Array(session.suppressedRuleIds), id: \.self) { ruleId in
+                    HStack(spacing: 6) {
+                        Text("SUPPRESSED")
+                            .font(.caption2.bold())
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Color.indigo)
+                            .cornerRadius(3)
+
+                        if let rule = viewModel.persistentRules.first(where: { $0.id == ruleId }) {
+                            Text(rule.toolName)
+                                .foregroundColor(.orange)
+                            if rule.isRegex { Text("/").foregroundColor(.orange) }
+                            Text(rule.pattern)
+                                .foregroundColor(.primary)
+                                .lineLimit(1)
+                            if rule.isRegex { Text("/").foregroundColor(.orange) }
+                        } else {
+                            Text("(deleted rule)")
+                                .foregroundColor(.secondary)
+                                .italic()
+                        }
+
+                        Spacer()
+
+                        Button(action: {
+                            viewModel.unsuppressRule(session: session, ruleId: ruleId)
+                            viewModel.noteInteraction()
+                        }) {
+                            Image(systemName: "xmark.circle")
+                                .foregroundColor(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Stop suppressing this rule — it will prompt again on next match")
                     }
                     .padding(.leading, 16)
                 }


### PR DESCRIPTION
Follow-up to #58 — two small UI fixes.

## 1. Surface suppressed rules in Session Rules tab
`session.suppressedRuleIds` was invisible. Once a user clicked "Allow Rule" there was no way to see which rules were silenced or undo it short of revoking auto-approve (which also wipes session rules).

- `Suppressed: N` counter on the session info row when N > 0
- Each suppressed rule listed with `SUPPRESSED` badge + `toolName` + pattern (resolved via `persistentRules` lookup)
- `x` button removes the ID from the session's suppressed set so the rule prompts again next match
- Orphan IDs (rule deleted post-suppression) render as `(deleted rule)`
- New `MonitorViewModel.unsuppressRule(session:ruleId:)`

## 2. Drop thousands separator from PID in approval panel
`Text("PID \(int)")` flowed `Int` through SwiftUI's locale-aware formatter, rendering 81208 as `81,208`. Monitor rows already use `Text(verbatim:)` — matched it.

## Test plan
- [x] `swift build` clean
- [x] `swift test` — 253/253 pass
- [x] Manual: click "Allow Rule" on an MCP prompt → Session Rules tab shows the row → click x → next matching call re-prompts
- [x] Manual: open any approval dialog with PID > 999 → header shows "PID 81208" not "PID 81,208"