### PR TITLE
feat(monitor+approval): click PID to focus Ghostty tab

### DIFF
--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -147,9 +147,16 @@ struct ApprovalPanelView: View {
                     .cornerRadius(4)
             }
 
-            Text(verbatim: "PID \(approval.session.pid)")
-                .font(.caption.monospaced())
-                .foregroundColor(.secondary)
+            Button(action: {
+                TerminalActivator.focusGhosttyTab(pid: approval.session.pid)
+            }) {
+                Text(verbatim: "PID \(approval.session.pid)")
+                    .font(.caption.monospaced())
+                    .foregroundColor(.accentColor)
+                    .underline()
+            }
+            .buttonStyle(.plain)
+            .help("Focus this session's Ghostty tab")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -202,9 +202,18 @@ private struct SessionRow: View {
                 .frame(width: 8, height: 8)
 
             // verbatim avoids LocalizedStringKey's locale grouping (e.g. "12,345")
-            Text(verbatim: "PID \(session.pid)")
-                .font(.system(.caption, design: .monospaced))
-                .frame(width: 70, alignment: .leading)
+            Button(action: {
+                TerminalActivator.focusGhosttyTab(pid: session.pid)
+                viewModel.noteInteraction()
+            }) {
+                Text(verbatim: "PID \(session.pid)")
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundColor(.accentColor)
+                    .underline()
+            }
+            .buttonStyle(.plain)
+            .frame(width: 70, alignment: .leading)
+            .help("Focus this session's Ghostty tab")
 
             if let cwd = session.cwd {
                 Text(cwd.split(separator: "/").suffix(2).joined(separator: "/"))

--- a/Sources/Gavel/System/TerminalActivator.swift
+++ b/Sources/Gavel/System/TerminalActivator.swift
@@ -1,0 +1,58 @@
+import Cocoa
+
+enum TerminalActivator {
+
+    /// Bring the Ghostty tab whose title encodes `pid` to the front.
+    /// Returns true if a matching tab was found and activated.
+    @discardableResult
+    static func focusGhosttyTab(pid: Int) -> Bool {
+        let script = """
+        on stripPrefix(s)
+            set i to 1
+            repeat while i ≤ length of s
+                set ch to character i of s
+                if ch is in "0123456789" then exit repeat
+                set i to i + 1
+            end repeat
+            if i > length of s then return ""
+            return text i thru -1 of s
+        end stripPrefix
+
+        on isMatch(itemName, pidStr)
+            set tail to my stripPrefix(itemName)
+            if tail is "" then return false
+            if tail is pidStr then return true
+            if tail starts with (pidStr & " ") then return true
+            if tail starts with (pidStr & "-") then return true
+            return false
+        end isMatch
+
+        tell application "System Events"
+            if not (exists process "Ghostty") then return false
+            tell process "Ghostty"
+                try
+                    repeat with mi in menu bar 1's menu bar item "Window"'s menu 1's menu items
+                        try
+                            set n to name of mi as string
+                            if my isMatch(n, "\(pid)") then
+                                click mi
+                                return true
+                            end if
+                        end try
+                    end repeat
+                end try
+            end tell
+        end tell
+        return false
+        """
+
+        var error: NSDictionary?
+        guard let appleScript = NSAppleScript(source: script) else { return false }
+        let result = appleScript.executeAndReturnError(&error)
+        if let error = error {
+            gavelLog("[terminal] focus pid=\(pid) error=\(error)")
+            return false
+        }
+        return result.booleanValue
+    }
+}


### PR DESCRIPTION
Replaces the planned filter-by-PID feature. Filter narrowed the view; this solves the underlying need: *get me to that terminal*.

## Behavior
- PID label in monitor rows is now a button — click activates the Ghostty tab whose title matches that PID
- Same affordance on the approval-dialog PID label (jump from a pending approval to the underlying terminal)
- Renders the PID in accent color + underline so the click affordance is obvious

## How it works
Ghostty's `NSWindow` tabs aren't separate `AXWindow` elements, so direct Accessibility enumeration only finds one entry per window (the active tab). But macOS apps list every tab and window under the Window menu, and those menu items are scriptable.

`TerminalActivator.focusGhosttyTab(pid:)` runs an `NSAppleScript` that:
1. Checks Ghostty is running (no-op if not)
2. Walks Window menu items via System Events
3. Strips Ghostty's activity prefix glyph (`✳ ` or `⠂ `)
4. Matches the PID with a word boundary — start, followed by space/dash/end — avoiding false matches like `"Pull 70409"`
5. Clicks the matching menu item

Same code path handles tabs AND standalone windows because both live in the Window menu.

## Caveats
- Requires Automation permission for System Events on first click (one-time prompt). User grants via Settings → Privacy & Security → Automation.
- Ghostty-specific. If a user runs a different terminal, button is a silent no-op. Could be made configurable later if there's demand.

## Test plan
- [x] `swift test` — 253/253 pass
- [x] Manual: `osascript` smoke test confirmed end-to-end (find tab, raise it)
- [ ] Manual (after daemon restart): click a PID in the monitor → corresponding Ghostty tab activates
- [ ] Manual: open an approval dialog → click the PID → Ghostty tab activates while dialog stays open