### PR TITLE
feat(monitor): sleep + resume sessions across daemon restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ DerivedData/
 .claude-account
 .mcp.json
 dev/
+output.log

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -1,11 +1,9 @@
 import Foundation
 
-/// Manages all active Claude Code sessions.
-///
-/// Sessions are keyed by PID. The manager periodically checks for
-/// dead processes and cleans up their state.
+/// Live sessions keyed by PID; tombstones keyed by sessionId (so PID reuse can't clobber them).
 final class SessionManager: ObservableObject {
     @Published private(set) var sessions: [Int: Session] = [:]
+    @Published private(set) var deadSessions: [String: Session] = [:]
 
     private let lock = NSLock()
     private var cleanupTimer: DispatchSourceTimer?
@@ -26,20 +24,26 @@ final class SessionManager: ObservableObject {
 
     private var lastInteraction: Date = Date()
 
-    private static var defaultsPath: String {
-        FileManager.default.homeDirectoryForCurrentUser.path + "/.claude/gavel/session-defaults.json"
-    }
+    private let defaultsPath: String
+    private let sessionsPath: String
 
-    private static var sessionsPath: String {
-        FileManager.default.homeDirectoryForCurrentUser.path + "/.claude/gavel/active-sessions.json"
-    }
+    init(
+        homeDir: URL = FileManager.default.homeDirectoryForCurrentUser,
+        autoStartTimers: Bool = true,
+        autoDiscover: Bool = true
+    ) {
+        let base = homeDir.path + "/.claude/gavel"
+        self.defaultsPath = base + "/session-defaults.json"
+        self.sessionsPath = base + "/active-sessions.json"
+        try? FileManager.default.createDirectory(atPath: base, withIntermediateDirectories: true)
 
-    init() {
         loadDefaults()
         loadActiveSessions()
-        discoverRunningSessions()
-        startCleanupTimer()
-        startInactivityTimer()
+        if autoDiscover { discoverRunningSessions() }
+        if autoStartTimers {
+            startCleanupTimer()
+            startInactivityTimer()
+        }
     }
 
     deinit {
@@ -74,12 +78,12 @@ final class SessionManager: ObservableObject {
             "sessionLabels": sessionLabels
         ]
         if let json = try? JSONSerialization.data(withJSONObject: data, options: .prettyPrinted) {
-            FileManager.default.createFile(atPath: Self.defaultsPath, contents: json)
+            FileManager.default.createFile(atPath: defaultsPath, contents: json)
         }
     }
 
     private func loadDefaults() {
-        guard let data = FileManager.default.contents(atPath: Self.defaultsPath),
+        guard let data = FileManager.default.contents(atPath: defaultsPath),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
         defaultAutoApprove = (json["autoApprove"] as? Bool) ?? false
         defaultSubAgentInherit = (json["subAgentInherit"] as? Bool) ?? false
@@ -88,10 +92,8 @@ final class SessionManager: ObservableObject {
         sessionLabels = (json["sessionLabels"] as? [String: String]) ?? [:]
     }
 
-    /// Bind a Claude Code session UUID to a Session and apply any saved label.
-    /// If the user typed a label before the sessionId was known, persist it now.
-    /// Called from socket-worker threads — `@Published` mutations on `session`
-    /// are dispatched to main per SwiftUI's main-thread invariant.
+    /// Worker-thread caller; @Published mutations dispatched to main.
+    /// A matching tombstone is dropped — same conversation, new PID.
     func recordSessionId(_ sid: String, on session: Session) {
         let changed = session.sessionId != sid
         let savedLabel = sessionLabels[sid]
@@ -108,6 +110,7 @@ final class SessionManager: ObservableObject {
         }
         if changed {
             lock.lock()
+            deadSessions.removeValue(forKey: sid)
             saveActiveSessionsLocked()
             lock.unlock()
         }
@@ -138,26 +141,25 @@ final class SessionManager: ObservableObject {
         saveDefaults()
     }
 
-    /// Remove a session (e.g., when the process exits).
-    func removeSession(pid: Int) {
+    func forgetTombstone(sessionId: String) {
         lock.lock()
-        sessions.removeValue(forKey: pid)
-        saveActiveSessionsLocked()
+        if deadSessions.removeValue(forKey: sessionId) != nil {
+            saveActiveSessionsLocked()
+        }
         lock.unlock()
     }
 
-    /// Drop any sessions whose process has exited. Triggered by the "Clear Dead"
-    /// monitor button so the user doesn't have to wait for the cleanup timer's
-    /// grace period.
     func clearDeadSessions() {
         lock.lock()
-        let toRemove = sessions.compactMap { (pid, session) -> Int? in
+        let strayPids = sessions.compactMap { (pid, session) -> Int? in
             (!session.isAlive || !isProcessAlive(pid: pid)) ? pid : nil
         }
-        for pid in toRemove {
+        for pid in strayPids {
             sessions.removeValue(forKey: pid)
         }
-        if !toRemove.isEmpty {
+        let hadTombstones = !deadSessions.isEmpty
+        deadSessions.removeAll()
+        if !strayPids.isEmpty || hadTombstones {
             saveActiveSessionsLocked()
         }
         lock.unlock()
@@ -165,10 +167,7 @@ final class SessionManager: ObservableObject {
 
     // MARK: - Active session persistence
 
-    /// Snapshot of a live session, persisted to active-sessions.json so the
-    /// daemon can rehydrate per-session toggle state across restarts/crashes.
-    /// New fields (auto/sub/paused) are optional so older on-disk files
-    /// load cleanly — missing values fall through to defaults.
+    /// Fields beyond `pid` are optional so older on-disk files load cleanly.
     private struct PersistedSession: Codable {
         let pid: Int
         let sessionId: String?
@@ -176,6 +175,13 @@ final class SessionManager: ObservableObject {
         let isAutoApproveEnabled: Bool?
         let isSubAgentInheritEnabled: Bool?
         let isPaused: Bool?
+        let label: String?
+        let endedAt: Date?
+    }
+
+    private struct PersistedState: Codable {
+        let live: [PersistedSession]
+        let dead: [PersistedSession]
     }
 
     /// Persist all live sessions and their per-session toggle state.
@@ -190,43 +196,80 @@ final class SessionManager: ObservableObject {
 
     /// Caller's responsibility: hold `lock` (or know that no concurrent writer can race).
     private func saveActiveSessionsLocked() {
-        let snapshot = sessions.values
+        let live = sessions.values
             .filter { $0.isAlive }
-            .map { PersistedSession(
-                pid: $0.pid,
-                sessionId: $0.sessionId,
-                cwd: $0.cwd,
-                isAutoApproveEnabled: $0.isAutoApproveEnabled,
-                isSubAgentInheritEnabled: $0.isSubAgentInheritEnabled,
-                isPaused: $0.isPaused
-            ) }
-        guard let json = try? JSONEncoder().encode(snapshot) else { return }
-        FileManager.default.createFile(atPath: Self.sessionsPath, contents: json)
+            .map { snapshotOf($0) }
+        let dead = deadSessions.values.map { snapshotOf($0) }
+        let state = PersistedState(live: Array(live), dead: Array(dead))
+        guard let json = try? JSONEncoder().encode(state) else { return }
+        FileManager.default.createFile(atPath: sessionsPath, contents: json)
     }
 
-    /// Rehydrate sessions seen by the daemon before restart. Filters out PIDs
-    /// whose process is no longer alive. Must run after loadDefaults() so that
-    /// labels are already populated and can be applied here.
-    private func loadActiveSessions() {
-        guard let data = FileManager.default.contents(atPath: Self.sessionsPath),
-              let snapshots = try? JSONDecoder().decode([PersistedSession].self, from: data) else { return }
+    private func snapshotOf(_ session: Session) -> PersistedSession {
+        PersistedSession(
+            pid: session.pid,
+            sessionId: session.sessionId,
+            cwd: session.cwd,
+            isAutoApproveEnabled: session.isAutoApproveEnabled,
+            isSubAgentInheritEnabled: session.isSubAgentInheritEnabled,
+            isPaused: session.isPaused,
+            label: session.label.isEmpty ? nil : session.label,
+            endedAt: session.endedAt
+        )
+    }
 
-        for snap in snapshots {
-            guard isProcessAlive(pid: snap.pid) else { continue }
-            let started = ProcessTree.startTime(of: Int32(snap.pid))
-            let session = Session(pid: snap.pid, cwd: snap.cwd, startedAt: started)
-            session.sessionId = snap.sessionId
-            // Apply persisted per-session settings if present, else fall back
-            // to defaults (covers older on-disk files written before this
-            // field set existed).
-            session.isAutoApproveEnabled = snap.isAutoApproveEnabled ?? defaultAutoApprove
-            session.isSubAgentInheritEnabled = snap.isSubAgentInheritEnabled ?? defaultSubAgentInherit
-            session.isPaused = snap.isPaused ?? defaultPaused
-            if let sid = snap.sessionId, let savedLabel = sessionLabels[sid] {
-                session.label = savedLabel
-            }
-            sessions[snap.pid] = session
+    /// Must run after loadDefaults() so labels are populated before they're applied here.
+    private func loadActiveSessions() {
+        guard let data = FileManager.default.contents(atPath: sessionsPath) else { return }
+        let decoder = JSONDecoder()
+
+        let live: [PersistedSession]
+        let dead: [PersistedSession]
+        if let state = try? decoder.decode(PersistedState.self, from: data) {
+            live = state.live
+            dead = state.dead
+        } else if let legacy = try? decoder.decode([PersistedSession].self, from: data) {
+            live = legacy
+            dead = []
+        } else {
+            return
         }
+
+        for snap in live + dead {
+            if isProcessAlive(pid: snap.pid) {
+                rehydrateLive(snap)
+            } else if let sid = snap.sessionId {
+                rehydrateTombstone(snap, sessionId: sid)
+            }
+        }
+    }
+
+    private func rehydrateLive(_ snap: PersistedSession) {
+        let started = ProcessTree.startTime(of: Int32(snap.pid))
+        let session = Session(pid: snap.pid, cwd: snap.cwd, startedAt: started)
+        session.sessionId = snap.sessionId
+        session.isAutoApproveEnabled = snap.isAutoApproveEnabled ?? defaultAutoApprove
+        session.isSubAgentInheritEnabled = snap.isSubAgentInheritEnabled ?? defaultSubAgentInherit
+        session.isPaused = snap.isPaused ?? defaultPaused
+        if let sid = snap.sessionId, let savedLabel = sessionLabels[sid] {
+            session.label = savedLabel
+        } else if let label = snap.label {
+            session.label = label
+        }
+        sessions[snap.pid] = session
+    }
+
+    private func rehydrateTombstone(_ snap: PersistedSession, sessionId: String) {
+        let session = Session(pid: snap.pid, cwd: snap.cwd, startedAt: snap.endedAt ?? Date())
+        session.sessionId = sessionId
+        session.isAlive = false
+        session.endedAt = snap.endedAt ?? Date()
+        if let savedLabel = sessionLabels[sessionId] {
+            session.label = savedLabel
+        } else if let label = snap.label {
+            session.label = label
+        }
+        deadSessions[sessionId] = session
     }
 
     /// Find Claude Code CLI processes running on this machine and add any we
@@ -272,23 +315,29 @@ final class SessionManager: ObservableObject {
         cleanupTimer = timer
     }
 
-    private func cleanupDeadSessions() {
+    /// Internal so tests can drive lifecycle without waiting on the timer.
+    func cleanupDeadSessions() {
         lock.lock()
         let pids = Array(sessions.keys)
         lock.unlock()
         for pid in pids {
-            if !isProcessAlive(pid: pid) {
-                lock.lock()
-                let session = sessions[pid]
+            guard !isProcessAlive(pid: pid) else { continue }
+            lock.lock()
+            guard let session = sessions[pid] else {
                 lock.unlock()
-                // `isAlive` is @Published; SwiftUI requires main-thread
-                // mutation. The cleanup timer runs on a global utility queue.
-                DispatchQueue.main.async {
-                    session?.isAlive = false
-                }
-                DispatchQueue.global().asyncAfter(deadline: .now() + GavelConstants.sessionRemovalGraceSeconds) { [weak self] in
-                    self?.removeSession(pid: pid)
-                }
+                continue
+            }
+            let now = Date()
+            sessions.removeValue(forKey: pid)
+            if let sid = session.sessionId {
+                deadSessions[sid] = session
+            }
+            saveActiveSessionsLocked()
+            lock.unlock()
+            // @Published mutations need main thread; this runs on a utility queue.
+            DispatchQueue.main.async {
+                session.isAlive = false
+                session.endedAt = now
             }
         }
     }

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -11,6 +11,7 @@ final class Session: ObservableObject, Identifiable {
     @Published var label: String = ""
     @Published var isPaused: Bool = false
     @Published var isAlive: Bool = true
+    @Published var endedAt: Date?
     @Published var isAutoApproveEnabled: Bool = false
     @Published var isSubAgentInheritEnabled: Bool = false
     @Published var lastPrompt: String?
@@ -52,6 +53,11 @@ final class Session: ObservableObject, Identifiable {
     var blockCount: Int { stats.blockCount }
 
     var id: Int { pid }
+
+    /// PID reuse can produce a live + dead session with the same PID; isAlive disambiguates.
+    var rowIdentity: String {
+        "\(pid)-\(isAlive ? "live" : "dead")-\(sessionId ?? "")"
+    }
 
     var isAutoApproveActive: Bool {
         guard let until = autoApproveUntil else { return false }

--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -16,12 +16,6 @@ final class MonitorViewModel: ObservableObject {
     @Published var testerTestString: String = ""
     @Published var testerIsRegex: Bool = true
 
-    /// User-pinned session PID. Click any row to pin (highlight); click the
-    /// pinned row again to unpin. In-memory only — fresh on app restart.
-    /// Lingers if the pinned session ends; the UI just renders no highlight
-    /// until the user pins something else.
-    @Published var pinnedSessionPid: Int?
-
     let approvalCoordinator: ApprovalCoordinator
     let sessionManager: SessionManager
     private let maxFeedEntries = GavelConstants.maxFeedEntries
@@ -48,15 +42,6 @@ final class MonitorViewModel: ObservableObject {
     }
 
     // MARK: - Controls
-
-    func togglePin(for session: Session) {
-        if pinnedSessionPid == session.pid {
-            pinnedSessionPid = nil
-        } else {
-            pinnedSessionPid = session.pid
-        }
-        noteInteraction()
-    }
 
     func toggleAutoApprove(for session: Session) {
         if session.isAutoApproveEnabled {

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -6,6 +6,7 @@ struct MonitorWindow: View {
     @State private var isPinned: Bool = false
     @State private var selectedTab: MonitorTab = .feed
     @State private var sessionFilter: String = ""
+    @State private var hideTombstones: Bool = false
 
     enum MonitorTab {
         case feed, rules, sessions, context, tester, reference
@@ -78,8 +79,13 @@ struct MonitorWindow: View {
 
     private var sessionControls: some View {
         VStack(spacing: 2) {
-            let allSessions = Array(viewModel.sessionManager.sessions.values)
+            let liveSessions = Array(viewModel.sessionManager.sessions.values)
                 .sorted { $0.startedAt > $1.startedAt }
+            let deadSessions = hideTombstones
+                ? []
+                : Array(viewModel.sessionManager.deadSessions.values)
+                    .sorted { ($0.endedAt ?? .distantPast) > ($1.endedAt ?? .distantPast) }
+            let allSessions = liveSessions + deadSessions
             let sessions = filterSessions(allSessions, query: sessionFilter)
 
             if allSessions.isEmpty {
@@ -97,14 +103,18 @@ struct MonitorWindow: View {
                     Spacer()
                 }
             } else {
-                ForEach(Array(sessions.enumerated()), id: \.element.pid) { index, session in
-                    SessionRow(
-                        session: session,
-                        viewModel: viewModel,
-                        isPinned: viewModel.pinnedSessionPid == session.pid,
-                        alternate: index.isMultiple(of: 2)
-                    )
+                ScrollView(.vertical, showsIndicators: true) {
+                    LazyVStack(spacing: 2) {
+                        ForEach(Array(sessions.enumerated()), id: \.element.rowIdentity) { index, session in
+                            SessionRow(
+                                session: session,
+                                viewModel: viewModel,
+                                alternate: index.isMultiple(of: 2)
+                            )
+                        }
+                    }
                 }
+                .frame(maxHeight: 320)
             }
 
             Divider()
@@ -126,13 +136,13 @@ struct MonitorWindow: View {
                 .tint(.yellow)
                 .help("One-click: clear auto on every session + reset defaults. Same as the menu bar action.")
 
-                Button("Clear Dead") {
+                Button("Forget All Sleeping") {
                     viewModel.sessionManager.clearDeadSessions()
                     viewModel.noteInteraction()
                 }
                 .buttonStyle(.bordered)
                 .tint(.gray)
-                .help("Drop sessions whose Claude Code process has exited.")
+                .help("Remove every sleeping (tombstoned) session from the monitor.")
 
                 Button("Discover") {
                     viewModel.sessionManager.discoverRunningSessions()
@@ -143,6 +153,8 @@ struct MonitorWindow: View {
                 .help("Scan for Claude Code CLI processes that haven't fired a hook yet (e.g. started while gavel was down).")
 
                 sessionFilterField
+
+                activeOnlyToggle
 
                 Spacer()
 
@@ -165,6 +177,20 @@ struct MonitorWindow: View {
                 .help("New sessions start with auto-approve enabled. Deny rules, prompt rules, and sensitive paths still force dialogs.")
             }
         }
+    }
+
+    private var activeOnlyToggle: some View {
+        HStack(spacing: 4) {
+            Text("Active only")
+                .font(.caption)
+                .lineLimit(1)
+            Toggle("", isOn: $hideTombstones)
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .tint(.green)
+                .controlSize(.small)
+        }
+        .help("Hide sleeping sessions from the list")
     }
 
     private var sessionFilterField: some View {
@@ -238,14 +264,10 @@ struct MonitorWindow: View {
 
 }
 
-/// One row in the session-controls strip. Extracted into its own View so it can
-/// observe the Session directly — the function-form predecessor only refreshed
-/// on the 2-second stats timer, which made Pause/Resume label changes feel
-/// laggy and made the per-tool-call flash highlight impossible.
+/// Observes Session directly so Pause/Resume labels and the per-tool-call flash repaint promptly.
 private struct SessionRow: View {
     @ObservedObject var session: Session
     let viewModel: MonitorViewModel
-    let isPinned: Bool
     let alternate: Bool
 
     var body: some View {
@@ -259,6 +281,7 @@ private struct SessionRow: View {
                 .font(.system(.caption, design: .monospaced))
                 .foregroundColor(.secondary)
                 .frame(width: 70, alignment: .leading)
+                .strikethrough(!session.isAlive)
 
             if let cwd = session.cwd {
                 Text(cwd.split(separator: "/").suffix(2).joined(separator: "/"))
@@ -276,8 +299,13 @@ private struct SessionRow: View {
 
             Spacer()
 
-            actionCluster
+            if session.isAlive {
+                actionCluster
+            } else {
+                tombstoneActionCluster
+            }
         }
+        .opacity(session.isAlive ? 1.0 : 0.55)
         .padding(.vertical, 3)
         .padding(.leading, 8)
         .padding(.trailing, 6)
@@ -287,27 +315,10 @@ private struct SessionRow: View {
                 Color.yellow.opacity(session.lastActivityAt != nil ? 0.20 : 0)
             }
         )
-        .overlay(alignment: .leading) {
-            if isPinned {
-                Rectangle()
-                    .fill(Color.accentColor)
-                    .frame(width: 3)
-            }
-        }
         .clipShape(RoundedRectangle(cornerRadius: 4))
-        // Hit-test the entire row, including padding/Spacer gaps. Buttons and
-        // toggles still consume their own taps (SwiftUI default), so only the
-        // identity area (status dot, PID, cwd, label gap) triggers the pin.
-        .contentShape(Rectangle())
-        .onTapGesture {
-            viewModel.togglePin(for: session)
-        }
         .animation(.easeOut(duration: 0.45), value: session.lastActivityAt)
-        .help(isPinned ? "Pinned — click again to unpin" : "Click to pin this row")
     }
 
-    /// Right-side controls in fixed widths so Sub/Auto/Prompt/Pause/Kill line up
-    /// across rows regardless of cwd or label length.
     @ViewBuilder
     private var actionCluster: some View {
         HStack(spacing: 6) {
@@ -374,21 +385,83 @@ private struct SessionRow: View {
             .tint(session.isPaused ? .green : .orange)
             .frame(width: 76)
 
-            Button("Kill") {
+            Button("Sleep") {
                 kill(Int32(session.pid), SIGINT)
                 viewModel.noteInteraction()
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
-            .tint(.red)
-            .frame(width: 56)
-            .help("Send SIGINT to this session's Claude Code process")
+            .tint(.indigo)
+            .frame(width: 60)
+            .help("SIGINT this Claude Code process so it saves to disk; resume later from the asleep row.")
         }
     }
 
+    /// Width must match actionCluster so live and dead rows align.
+    @ViewBuilder
+    private var tombstoneActionCluster: some View {
+        HStack(spacing: 6) {
+            if let ended = session.endedAt {
+                Text("asleep \(Self.relativeTime(ended))")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .frame(width: 222, alignment: .trailing)
+            } else {
+                Spacer().frame(width: 222)
+            }
+
+            Button("Resume") {
+                copyResumeCommand()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .tint(.blue)
+            .frame(width: 76)
+            .disabled(session.sessionId == nil)
+            .help(resumeHelpText)
+
+            Button("Forget") {
+                if let sid = session.sessionId {
+                    viewModel.sessionManager.forgetTombstone(sessionId: sid)
+                    viewModel.noteInteraction()
+                }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .tint(.gray)
+            .frame(width: 56)
+            .help("Remove this tombstone from the monitor.")
+        }
+    }
+
+    private var resumeHelpText: String {
+        guard let sid = session.sessionId else { return "No session ID — can't resume" }
+        return "Copy `\(ResumeCommand.build(pid: session.pid, sessionId: sid, cwd: session.cwd))` to clipboard."
+    }
+
+    private func copyResumeCommand() {
+        guard let sid = session.sessionId else { return }
+        let cmd = ResumeCommand.build(pid: session.pid, sessionId: sid, cwd: session.cwd)
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(cmd, forType: .string)
+        viewModel.noteInteraction()
+        GavelNotifications.notify(
+            title: "Gavel — Resume command copied",
+            body: "Paste in any terminal"
+        )
+    }
+
+    private static func relativeTime(_ date: Date) -> String {
+        let secs = Int(-date.timeIntervalSinceNow)
+        if secs < 60 { return "\(secs)s ago" }
+        if secs < 3600 { return "\(secs / 60)m ago" }
+        if secs < 86400 { return "\(secs / 3600)h ago" }
+        return "\(secs / 86400)d ago"
+    }
+
     private var rowBackground: Color {
-        if isPinned { return Color.accentColor.opacity(0.10) }
-        return alternate ? Color.secondary.opacity(0.06) : Color.clear
+        alternate ? Color.secondary.opacity(0.06) : Color.clear
     }
 }
 

--- a/Sources/Gavel/System/Constants.swift
+++ b/Sources/Gavel/System/Constants.swift
@@ -32,9 +32,6 @@ enum GavelConstants {
     /// Session cleanup check interval in seconds.
     static let sessionCleanupInterval: TimeInterval = 5.0
 
-    /// Grace period before removing dead sessions.
-    static let sessionRemovalGraceSeconds: TimeInterval = 3.0
-
     /// Minimum content length to scan for dangerous patterns.
     /// Short content can't contain both file I/O and network code.
     static let minContentScanLength = 50

--- a/Sources/Gavel/System/ResumeCommand.swift
+++ b/Sources/Gavel/System/ResumeCommand.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum ResumeCommand {
+    static func build(pid: Int, sessionId: String, cwd: String?) -> String {
+        let claudeInvocation = "claude --name \(pid) --resume \(sessionId)"
+        guard let cwd = cwd else { return claudeInvocation }
+        return "cd \(shellQuote(cwd)) && \(claudeInvocation)"
+    }
+
+    /// Bash single-quote escaping: close-quote, escape, reopen for each embedded apostrophe.
+    static func shellQuote(_ s: String) -> String {
+        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/Tests/GavelTests/Phase1RefactorTests.swift
+++ b/Tests/GavelTests/Phase1RefactorTests.swift
@@ -164,7 +164,6 @@ final class Phase1RefactorTests: XCTestCase {
         XCTAssertEqual(GavelConstants.socketBufferSize, 65536)
         XCTAssertEqual(GavelConstants.socketReadTimeoutSeconds, 30)
         XCTAssertEqual(GavelConstants.sessionCleanupInterval, 5.0)
-        XCTAssertEqual(GavelConstants.sessionRemovalGraceSeconds, 3.0)
         XCTAssertEqual(GavelConstants.minContentScanLength, 50)
         XCTAssertEqual(GavelConstants.panelWidth, 640)
         XCTAssertEqual(GavelConstants.panelHeight, 480)

--- a/Tests/GavelTests/ResumeCommandTests.swift
+++ b/Tests/GavelTests/ResumeCommandTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import Gavel
+
+final class ResumeCommandTests: XCTestCase {
+
+    // MARK: - shellQuote
+
+    func testQuotesSimplePath() {
+        XCTAssertEqual(ResumeCommand.shellQuote("/Users/jay/code"), "'/Users/jay/code'")
+    }
+
+    func testQuotesPathWithSpaces() {
+        XCTAssertEqual(
+            ResumeCommand.shellQuote("/Users/jay/My Projects/repo"),
+            "'/Users/jay/My Projects/repo'"
+        )
+    }
+
+    func testEscapesEmbeddedApostrophe() {
+        // bash form: 'foo'\''bar' represents the string foo'bar
+        XCTAssertEqual(
+            ResumeCommand.shellQuote("/Users/jay/foo'bar"),
+            "'/Users/jay/foo'\\''bar'"
+        )
+    }
+
+    func testEscapesMultipleApostrophes() {
+        XCTAssertEqual(
+            ResumeCommand.shellQuote("a'b'c"),
+            "'a'\\''b'\\''c'"
+        )
+    }
+
+    func testQuotesEmptyString() {
+        XCTAssertEqual(ResumeCommand.shellQuote(""), "''")
+    }
+
+    func testQuotesPathWithDollarAndBackticksLiterally() {
+        // Single quotes neutralize $ and ` in bash, so no escape needed.
+        XCTAssertEqual(
+            ResumeCommand.shellQuote("/tmp/$HOME/`whoami`"),
+            "'/tmp/$HOME/`whoami`'"
+        )
+    }
+
+    // MARK: - build
+
+    func testBuildWithCwd() {
+        let cmd = ResumeCommand.build(
+            pid: 12345,
+            sessionId: "abc-def-123",
+            cwd: "/Users/jay/project"
+        )
+        XCTAssertEqual(cmd, "cd '/Users/jay/project' && claude --name 12345 --resume abc-def-123")
+    }
+
+    func testBuildWithoutCwdOmitsCdPrefix() {
+        let cmd = ResumeCommand.build(pid: 42, sessionId: "sid-9", cwd: nil)
+        XCTAssertEqual(cmd, "claude --name 42 --resume sid-9")
+    }
+
+    func testBuildEscapesCwdSpaces() {
+        let cmd = ResumeCommand.build(
+            pid: 1,
+            sessionId: "s",
+            cwd: "/Users/jay/My Projects"
+        )
+        XCTAssertEqual(cmd, "cd '/Users/jay/My Projects' && claude --name 1 --resume s")
+    }
+}

--- a/Tests/GavelTests/SessionLifecycleTests.swift
+++ b/Tests/GavelTests/SessionLifecycleTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import Gavel
+
+/// Tombstone lifecycle: live → dead migration, promotion back to live,
+/// per-row forget, bulk clear, and persistence round-trip.
+final class SessionLifecycleTests: XCTestCase {
+
+    private var tmpHome: URL!
+    private var manager: SessionManager!
+
+    /// A PID effectively guaranteed not to exist on macOS. macOS reserves up
+    /// to ~99999; anything above that range is unused by any real process.
+    private let deadPid = 1_999_999
+
+    override func setUp() {
+        super.setUp()
+        tmpHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gavel-test-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tmpHome, withIntermediateDirectories: true)
+        manager = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false)
+    }
+
+    override func tearDown() {
+        manager = nil
+        try? FileManager.default.removeItem(at: tmpHome)
+        super.tearDown()
+    }
+
+    // MARK: - Migration
+
+    func testDeadSessionWithSessionIdMigratesToTombstone() {
+        let sid = "test-session-uuid-1"
+        let session = manager.session(for: deadPid)
+        session.sessionId = sid
+        session.cwd = "/tmp/test-project"
+
+        manager.cleanupDeadSessions()
+
+        XCTAssertNil(manager.sessions[deadPid], "Live dict should drop the dead PID")
+        XCTAssertNotNil(manager.deadSessions[sid], "Tombstone should appear keyed by sessionId")
+        XCTAssertEqual(manager.deadSessions[sid]?.cwd, "/tmp/test-project")
+    }
+
+    func testDeadSessionWithoutSessionIdIsDropped() {
+        let session = manager.session(for: deadPid)
+        session.cwd = "/tmp/test-project"
+        // No sessionId set — not resumable.
+
+        manager.cleanupDeadSessions()
+
+        XCTAssertNil(manager.sessions[deadPid], "Live dict should drop")
+        XCTAssertTrue(manager.deadSessions.isEmpty, "No sessionId means no tombstone")
+    }
+
+    // MARK: - Removal controls
+
+    func testForgetTombstoneRemovesOnlyThatEntry() {
+        let sidA = "uuid-A"
+        let sidB = "uuid-B"
+        let sessA = manager.session(for: deadPid)
+        sessA.sessionId = sidA
+        let sessB = manager.session(for: deadPid + 1)
+        sessB.sessionId = sidB
+        manager.cleanupDeadSessions()
+        XCTAssertEqual(manager.deadSessions.count, 2)
+
+        manager.forgetTombstone(sessionId: sidA)
+
+        XCTAssertNil(manager.deadSessions[sidA])
+        XCTAssertNotNil(manager.deadSessions[sidB])
+    }
+
+    func testClearDeadSessionsEmptiesTombstonesOnly() {
+        let sid = "uuid-1"
+        let dead = manager.session(for: deadPid)
+        dead.sessionId = sid
+        manager.cleanupDeadSessions()
+        XCTAssertEqual(manager.deadSessions.count, 1)
+
+        // Live session (own PID is alive — XCTest is running)
+        let livePid = Int(getpid())
+        _ = manager.session(for: livePid)
+        XCTAssertNotNil(manager.sessions[livePid])
+
+        manager.clearDeadSessions()
+
+        XCTAssertTrue(manager.deadSessions.isEmpty)
+        XCTAssertNotNil(manager.sessions[livePid], "Live session must survive clearDead")
+    }
+
+    // MARK: - Promotion
+
+    func testRecordSessionIdPromotesMatchingTombstoneToLive() {
+        let sid = "uuid-promote"
+        let original = manager.session(for: deadPid)
+        original.sessionId = sid
+        manager.cleanupDeadSessions()
+        XCTAssertNotNil(manager.deadSessions[sid])
+
+        // Simulate a new live `claude --resume <sid>` arriving on a different PID.
+        let newPid = Int(getpid())
+        let revived = manager.session(for: newPid)
+        manager.recordSessionId(sid, on: revived)
+
+        // recordSessionId mutates @Published sessionId via DispatchQueue.main.async
+        // so the binding plumbing matches SwiftUI's main-thread invariant.
+        // Drain the main queue before asserting.
+        let drained = expectation(description: "main queue drained")
+        DispatchQueue.main.async { drained.fulfill() }
+        wait(for: [drained], timeout: 1.0)
+
+        XCTAssertNil(manager.deadSessions[sid], "Tombstone must be removed on resume")
+        XCTAssertEqual(manager.sessions[newPid]?.sessionId, sid)
+    }
+
+    // MARK: - Persistence
+
+    func testPersistenceRoundTripsBothLiveAndDead() {
+        let sidDead = "uuid-dead"
+        let sidLive = "uuid-live"
+
+        // Live session keyed on this test process's own PID so the reload
+        // path classifies it as alive.
+        let livePid = Int(getpid())
+        let live = manager.session(for: livePid)
+        live.sessionId = sidLive
+        live.cwd = "/tmp/live-project"
+        live.label = "my live one"
+        manager.recordSessionId(sidLive, on: live)
+
+        // Dead session: insert + migrate.
+        let dead = manager.session(for: deadPid)
+        dead.sessionId = sidDead
+        dead.cwd = "/tmp/dead-project"
+        manager.cleanupDeadSessions()
+
+        manager.saveActiveSessions()
+
+        // Spin up a fresh manager pointing at the same tmp home.
+        let reloaded = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false)
+
+        XCTAssertNotNil(reloaded.sessions[livePid], "Live session must rehydrate")
+        XCTAssertEqual(reloaded.sessions[livePid]?.sessionId, sidLive)
+        XCTAssertNotNil(reloaded.deadSessions[sidDead], "Tombstone must rehydrate")
+        XCTAssertEqual(reloaded.deadSessions[sidDead]?.cwd, "/tmp/dead-project")
+        XCTAssertFalse(reloaded.deadSessions[sidDead]?.isAlive ?? true)
+    }
+
+    func testPersistenceBackwardCompatLegacyArrayFormat() throws {
+        // Old format: bare array of live sessions, no tombstones.
+        let livePid = Int(getpid())
+        let legacy: [[String: Any]] = [
+            ["pid": livePid, "sessionId": "legacy-sid", "cwd": "/tmp/legacy"]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: legacy)
+        let path = tmpHome.path + "/.claude/gavel/active-sessions.json"
+        try? FileManager.default.createDirectory(
+            atPath: tmpHome.path + "/.claude/gavel",
+            withIntermediateDirectories: true
+        )
+        FileManager.default.createFile(atPath: path, contents: data)
+
+        let reloaded = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false)
+
+        XCTAssertEqual(reloaded.sessions[livePid]?.sessionId, "legacy-sid")
+        XCTAssertTrue(reloaded.deadSessions.isEmpty, "Legacy format has no tombstones")
+    }
+}


### PR DESCRIPTION
## Summary

- **Sleep workflow.** Sessions whose process exits transition to a tombstone ("asleep") instead of being grace-removed. Sleep a session you don't need right now to free up its claude-process resources; resume later from the row's Resume button.
- **Survives daemon restart.** Live + asleep state persisted via a `{live, dead}` JSON envelope (backward-compat decode for the bare-array format). Killing `just run-local` and bringing it back leaves both buckets intact.
- **One-paste resume.** Resume copies `cd '<cwd>' && claude --name <pid> --resume <sid>` to the clipboard, shell-quoted so paths with spaces or apostrophes survive. When a new claude process registers the matching sessionId, the tombstone is dropped and the new live row takes its place.

### UI changes
- Asleep rows: dimmed, strikethrough PID, `asleep Xm ago` label, Resume + Forget buttons
- `Kill` → `Sleep` (still SIGINT — claude exits gracefully and saves the transcript)
- `Clear Dead` → `Forget All Sleeping`; per-row Forget for single removal
- `Active only` toggle hides asleep rows on demand
- Row list wrapped in ScrollView/LazyVStack so many tombstones don't push controls off-screen
- Row-pin UX removed (it was visual-only and captured clicks on the row body)

### Internal cleanup
- `sessionRemovalGraceSeconds` constant removed (no grace period anymore)
- `removeSession(pid:)` removed (no callers after the migration switch)
- `SessionManager.init(homeDir:autoStartTimers:autoDiscover:)` for test isolation

## Test plan

- [x] `swift test` — 269 passing (added `SessionLifecycleTests` × 7, `ResumeCommandTests` × 9)
- [x] `swift build -c release` clean
- [x] Manual smoke test:
  - [x] Kill the local gavel daemon, restart — live + asleep sessions both rehydrate
  - [x] Sleep a session via the row's Sleep button → tombstone appears within ~5s
  - [x] Click Resume → clipboard contains `cd '<cwd>' && claude --name <pid> --resume <sid>`
  - [x] Paste in a terminal → conversation resumes; tombstone is removed when first hook fires
  - [x] `Active only` toggle hides asleep rows
  - [x] `Forget All Sleeping` empties tombstones without touching live sessions
- [ ] Validate sleep workflow over a full work-day before merge (reviewer's call)

## Notes

- Branch was originally `feat/focus-terminal-tab` but that feature was reverted on 2026-05-14; renamed to match what actually shipped here.
- Resume action is terminal-neutral — clipboard-and-paste, not auto-launch — consistent with the 2026-05-14 decision to drop click-PID-to-focus-Ghostty.