### PR TITLE
feat: codex CLI support — hook compat + install + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Gavel
 
-Native macOS menu bar daemon for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) session monitoring and approval.
+Native macOS menu bar daemon for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [OpenAI Codex CLI](https://developers.openai.com/codex/cli) session monitoring and approval.
 
-Gavel intercepts every tool call Claude makes — file edits, shell commands, MCP calls — and routes them through a configurable approval engine before they execute. You see what's happening, control what's allowed, and block what isn't.
+Gavel intercepts every tool call your agent makes — file edits, shell commands, MCP calls — and routes them through a configurable approval engine before they execute. You see what's happening, control what's allowed, and block what isn't.
 
 ![Feed tab with auto-approve enabled (green icon)](docs/images/feed-auto-approve.png)
 
@@ -189,7 +189,55 @@ Gavel protects its own config files and Claude Code's hook configuration. Comman
 - **IPC**: Unix domain socket at `~/.claude/gavel/gavel.sock`
 - **Platform**: macOS 13+
 - **Binaries**: `gavel` (daemon, ~1MB) and `gavel-hook` (CLI shim, ~85KB, ~6ms overhead per hook)
-- **Tests**: 200 tests across 6 suites
+- **Tests**: 276 tests across 6 suites
+
+## Using Gavel with Codex CLI
+
+Gavel works with [OpenAI Codex CLI](https://developers.openai.com/codex/cli) in addition to Claude Code. The same approval daemon, rules, and monitor handle both — Codex's `apply_patch`, shell exec, and MCP calls all route through `gavel-hook` to the policy engine. Codex invokes `gavel-hook` directly (no bash shim), so the per-call overhead is the same ~6ms as Claude.
+
+### Auto-setup via install.sh
+
+If `codex` is in `PATH` when you run `./install.sh`, the installer appends a `[[hooks.PreToolUse]]` block to `~/.codex/config.toml` pointing at the installed `gavel-hook`. Re-running is idempotent. `./install.sh --uninstall` removes the block.
+
+### Manual setup (brew users, or any time)
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[[hooks.PreToolUse]]
+matcher = ".*"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/opt/homebrew/bin/gavel-hook"
+timeout = 600
+```
+
+### One-time trust enrollment
+
+Codex requires explicit user trust for any new hook command. After registering:
+
+1. Run `codex` interactively
+2. Banner: `"1 hook needs review before it can run. Open /hooks to review it."`
+3. Type `/hooks`, verify the entry is `gavel-hook`, trust it
+4. Quit the TUI
+
+From then on, every `codex exec` and interactive session routes tool calls through Gavel.
+
+### Codex-specific protections
+
+A seeded `apply_patch` rule (verdict: prompt) catches patches that write to:
+
+- `~/.claude/gavel/`, `~/.claude/settings`, `~/.claude/hooks/`
+- `~/.codex/config`, `~/.codex/hooks`
+- Shell init files (`.zshrc`, `.bashrc`, `.bash_profile`, `.profile`)
+
+This is defense-in-depth for the surface that shell-pattern Bash rules can't reach — Codex's `apply_patch` writes files without invoking `$SHELL`, so shell-level interceptors miss it.
+
+### Known limitations
+
+- **Session attribution**: Codex sessions launched as a child of a Claude Code session attribute to the parent Claude session's row in the Monitor. Standalone `codex` launches get their own row keyed on Codex's process. Distinct Codex monitor rows with full session correlation is a planned follow-up.
+- **No SessionStart hook**: only `PreToolUse` is registered today. Session metadata enrichment (model, cwd at start) is a follow-up.
 
 ## Uninstall
 

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -173,6 +173,16 @@ final class RuleStore: ObservableObject {
             builtIn: true
         ),
 
+        // ── Codex apply_patch self-protection ──
+        PersistentRule(
+            toolName: "apply_patch",
+            pattern: "\\.claude/(gavel/|settings|hooks/)|\\.codex/(config|hooks)|\\.(zshrc|bashrc|bash_profile|profile)\\b",
+            isRegex: true,
+            verdict: .prompt,
+            explanation: "apply_patch references Gavel/Claude/Codex config or shell init — verify intent",
+            builtIn: true
+        ),
+
         // ── Scripting language code execution ──
         PersistentRule(
             toolName: "Bash",

--- a/Sources/GavelHook/main.swift
+++ b/Sources/GavelHook/main.swift
@@ -150,20 +150,22 @@ if needsResponse {
             exit(0)
         }
 
-        var output: [String: Any] = [
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "allow"
-        ]
+        // Codex sends `turn_id` in PreToolUse stdin; Claude doesn't. Codex's
+        // PreToolUseCommandOutputWire rejects permissionDecision:"allow" unless
+        // updatedInput is also present — omit it for Codex callers.
+        let isCodexCaller = stdinJson?["turn_id"] != nil
+        var output: [String: Any] = ["hookEventName": "PreToolUse"]
         if let ctx = json["additionalContext"] as? String, !ctx.isEmpty {
             output["additionalContext"] = ctx
         }
-        if let updated = json["updatedInput"] as? [String: Any] {
+        let updated = json["updatedInput"] as? [String: Any]
+        if let updated = updated {
             output["updatedInput"] = updated
+            output["permissionDecision"] = "allow"
+        } else if !isCodexCaller {
+            output["permissionDecision"] = "allow"
         }
-        var wrapper: [String: Any] = ["hookSpecificOutput": output]
-        if let ctx = json["additionalContext"] as? String, !ctx.isEmpty {
-            wrapper["additionalContext"] = ctx
-        }
+        let wrapper: [String: Any] = ["hookSpecificOutput": output]
         if let data = try? JSONSerialization.data(withJSONObject: wrapper),
            let str = String(data: data, encoding: .utf8) {
             print(str)

--- a/Tests/GavelTests/PersistentRuleTests.swift
+++ b/Tests/GavelTests/PersistentRuleTests.swift
@@ -185,9 +185,9 @@ final class PersistentRuleTests: XCTestCase {
         let store = RuleStore(configPath: "/dev/null")
         let builtInRules = store.rules.filter { $0.builtIn }
         XCTAssertEqual(builtInRules.count, RuleStore.seededDefaults.count)
-        // v7: 5 MCP exfil + 1 self-protection + 1 scripting + 3 sandbox escape
-        //     + 2 git safety + 3 scheduler = 15
-        XCTAssertEqual(builtInRules.count, 15)
+        // v7: 5 MCP exfil + 1 Bash self-protection + 1 apply_patch self-protection
+        //     + 1 scripting + 3 sandbox escape + 2 git safety + 3 scheduler = 16
+        XCTAssertEqual(builtInRules.count, 16)
     }
 
     func testSeededRulesArePromptVerdict() {
@@ -225,6 +225,37 @@ final class PersistentRuleTests: XCTestCase {
             "command": AnyCodable("python3 test_script.py")
         ])
         XCTAssertNil(store.evaluateBuiltInPrompt(payload: payload))
+    }
+
+    // MARK: - Codex apply_patch self-protection built-in
+
+    func testApplyPatchPromptMatchesGavelConfigWrite() {
+        let store = RuleStore(configPath: "/dev/null")
+        let patch = "*** Begin Patch\n*** Update File: /Users/me/.claude/gavel/rules.json\n@@\n+evil\n*** End Patch\n"
+        let payload = PreToolUsePayload(toolName: "apply_patch", toolInput: [
+            "command": AnyCodable(patch)
+        ])
+        let decision = store.evaluateBuiltInPrompt(payload: payload)
+        XCTAssertNotNil(decision, "apply_patch touching .claude/gavel should prompt")
+        XCTAssertTrue(decision?.askUser ?? false)
+    }
+
+    func testApplyPatchPromptMatchesShellInitWrite() {
+        let store = RuleStore(configPath: "/dev/null")
+        let patch = "*** Begin Patch\n*** Update File: /Users/me/.zshrc\n@@\n+alias ls=evil\n*** End Patch\n"
+        let payload = PreToolUsePayload(toolName: "apply_patch", toolInput: [
+            "command": AnyCodable(patch)
+        ])
+        XCTAssertNotNil(store.evaluateBuiltInPrompt(payload: payload), "apply_patch touching ~/.zshrc should prompt")
+    }
+
+    func testApplyPatchAllowsBenignWrite() {
+        let store = RuleStore(configPath: "/dev/null")
+        let patch = "*** Begin Patch\n*** Add File: hello.txt\n+hi\n*** End Patch\n"
+        let payload = PreToolUsePayload(toolName: "apply_patch", toolInput: [
+            "command": AnyCodable(patch)
+        ])
+        XCTAssertNil(store.evaluateBuiltInPrompt(payload: payload), "Benign apply_patch should not match self-protection rule")
     }
 
     // MARK: - Split prompt evaluation

--- a/Tests/GavelTests/WireFormatTests.swift
+++ b/Tests/GavelTests/WireFormatTests.swift
@@ -75,6 +75,118 @@ final class WireFormatTests: XCTestCase {
         XCTAssertEqual(payload.permissionMode, "default")
     }
 
+    func testDecodeCodexPreToolUseEnvelope() throws {
+        let json = """
+        {
+            "hookType": "PreToolUse",
+            "sessionPid": 12345,
+            "timestamp": 1712600000.0,
+            "payload": {
+                "type": "PreToolUse",
+                "session_id": "codex-sess-7",
+                "turn_id": "turn-42",
+                "transcript_path": "/Users/dev/.codex/sessions/abc.jsonl",
+                "cwd": "/Users/dev/work",
+                "hook_event_name": "PreToolUse",
+                "model": "gpt-5.4",
+                "permission_mode": "on-request",
+                "tool_name": "shell",
+                "tool_input": {"command": ["ls", "-la"], "workdir": "/Users/dev/work"},
+                "tool_use_id": "tu-99"
+            }
+        }
+        """
+        let event = try JSONDecoder().decode(HookEvent.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(event.hookType, .preToolUse)
+
+        guard case .preToolUse(let payload) = event.payload else {
+            XCTFail("Expected preToolUse payload")
+            return
+        }
+        XCTAssertEqual(payload.toolName, "shell")
+        XCTAssertEqual(payload.sessionId, "codex-sess-7")
+        XCTAssertEqual(payload.cwd, "/Users/dev/work")
+        XCTAssertEqual(payload.permissionMode, "on-request")
+        XCTAssertEqual(payload.toolUseId, "tu-99")
+        XCTAssertNil(payload.agentId)
+    }
+
+    func testCodexBashCommandExtraction() throws {
+        let json = """
+        {
+            "hookType": "PreToolUse",
+            "sessionPid": 12345,
+            "timestamp": 1712600000.0,
+            "payload": {
+                "type": "PreToolUse",
+                "session_id": "s",
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls -la"}
+            }
+        }
+        """
+        let event = try JSONDecoder().decode(HookEvent.self, from: json.data(using: .utf8)!)
+        guard case .preToolUse(let payload) = event.payload else {
+            XCTFail("Expected preToolUse payload")
+            return
+        }
+        XCTAssertEqual(payload.toolName, "Bash")
+        XCTAssertEqual(payload.command, "ls -la")
+    }
+
+    func testCodexApplyPatchExposesPatchTextAsCommand() throws {
+        let json = """
+        {
+            "hookType": "PreToolUse",
+            "sessionPid": 12345,
+            "timestamp": 1712600000.0,
+            "payload": {
+                "type": "PreToolUse",
+                "session_id": "s",
+                "tool_name": "apply_patch",
+                "tool_input": {"command": "*** Begin Patch\\n*** Add File: hello.txt\\n+hi\\n*** End Patch\\n"}
+            }
+        }
+        """
+        let event = try JSONDecoder().decode(HookEvent.self, from: json.data(using: .utf8)!)
+        guard case .preToolUse(let payload) = event.payload else {
+            XCTFail("Expected preToolUse payload")
+            return
+        }
+        XCTAssertEqual(payload.toolName, "apply_patch")
+        XCTAssertNotNil(payload.command)
+        XCTAssertTrue(payload.command?.contains("*** Add File: hello.txt") ?? false)
+    }
+
+    func testDecodeCodexApplyPatchEnvelope() throws {
+        let json = """
+        {
+            "hookType": "PreToolUse",
+            "sessionPid": 12345,
+            "timestamp": 1712600000.0,
+            "payload": {
+                "type": "PreToolUse",
+                "session_id": "codex-sess-7",
+                "turn_id": "turn-43",
+                "transcript_path": "/Users/dev/.codex/sessions/abc.jsonl",
+                "cwd": "/Users/dev/work",
+                "hook_event_name": "PreToolUse",
+                "model": "gpt-5.4",
+                "permission_mode": "on-request",
+                "tool_name": "apply_patch",
+                "tool_input": {"input": "*** Begin Patch\\n*** Add File: hello.txt\\n+hi\\n*** End Patch\\n"},
+                "tool_use_id": "tu-100"
+            }
+        }
+        """
+        let event = try JSONDecoder().decode(HookEvent.self, from: json.data(using: .utf8)!)
+        guard case .preToolUse(let payload) = event.payload else {
+            XCTFail("Expected preToolUse payload")
+            return
+        }
+        XCTAssertEqual(payload.toolName, "apply_patch")
+    }
+
     func testDecodeSessionStartEnvelope() throws {
         let json = """
         {

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,9 @@ PLIST_DIR="$HOME/Library/LaunchAgents"
 LABEL="com.gavel.daemon"
 PLIST="$PLIST_DIR/$LABEL.plist"
 SETTINGS="$HOME/.claude/settings.json"
+CODEX_CONFIG="$HOME/.codex/config.toml"
+CODEX_MARKER_BEGIN="# ── Gavel hook integration (managed by install.sh) ──"
+CODEX_MARKER_END="# ── end Gavel hook integration ──"
 
 # ── Uninstall ──
 if [[ "$1" == "--uninstall" ]]; then
@@ -44,6 +47,12 @@ if changed:
 else:
     print('No gavel hooks found in settings.json')
 "
+    fi
+
+    # Remove Codex hook block (sed delete between markers; idempotent)
+    if [[ -f "$CODEX_CONFIG" ]] && /usr/bin/grep -qF "$CODEX_MARKER_BEGIN" "$CODEX_CONFIG"; then
+        /usr/bin/sed -i '' "/$CODEX_MARKER_BEGIN/,/$CODEX_MARKER_END/d" "$CODEX_CONFIG"
+        echo "Removed gavel hook from $CODEX_CONFIG"
     fi
 
     rm -rf "$HOME/.claude/gavel"
@@ -149,6 +158,31 @@ else:
 "
 else
     echo "WARNING: Could not register hooks. Please add gavel hooks to $SETTINGS manually."
+fi
+
+# Codex hook registration (optional — only if codex CLI is detected)
+if command -v codex &>/dev/null; then
+    if [[ ! -f "$CODEX_CONFIG" ]]; then
+        echo "Codex detected but $CODEX_CONFIG not found — run codex once to initialize, then re-run install"
+    elif /usr/bin/grep -qF "$CODEX_MARKER_BEGIN" "$CODEX_CONFIG"; then
+        echo "Codex hook already registered in $CODEX_CONFIG"
+    else
+        echo "Registering Codex hook in $CODEX_CONFIG..."
+        cat >> "$CODEX_CONFIG" <<CODEX_HOOK
+
+$CODEX_MARKER_BEGIN
+# Trust this hook on first run: \`codex\` → /hooks → trust gavel-hook.
+[[hooks.PreToolUse]]
+matcher = ".*"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "$INSTALL_DIR/gavel-hook"
+timeout = 600
+$CODEX_MARKER_END
+CODEX_HOOK
+        echo "  → Run \`codex\` interactively once and trust the hook via /hooks to activate"
+    fi
 fi
 
 echo "Starting daemon..."


### PR DESCRIPTION
## Summary
Phase 1+2 of OpenAI Codex CLI support: end-to-end interception of Codex tool calls through Gavel's existing approval daemon, plus the install/docs scaffolding to make it shippable.

**Two commits**:
1. `feat(hook)` — caller detection in `gavel-hook` (Codex callers identified by `turn_id` in stdin; output omits `permissionDecision: "allow"` to satisfy Codex's strict `deny_unknown_fields`). Claude path unchanged. One new seeded `apply_patch` self-protection rule covering `.claude/gavel/**`, `.codex/{config,hooks}`, and shell init files.
2. `feat(install)` — `install.sh` auto-registers a `[[hooks.PreToolUse]]` block in `~/.codex/config.toml` when `codex` is in `PATH`. Idempotent (marker-comment grep), reversible (`--uninstall` sed-removes the block). README adds a "Using Gavel with Codex CLI" section with auto-setup, manual setup, trust enrollment walkthrough, and known limitations.

## Why this needed live testing
Source-reading and unit tests suggested Codex and Claude hook wire formats were near-identical. They are — for the *input* side. The *output* side diverges on the allow path: Codex's strict serde rejects `permissionDecision: "allow"` without `updatedInput`. Only the live `codex exec` round-trip surfaced this (\`hook: PreToolUse Failed\`). Fix uses Codex-only `turn_id` as the caller discriminator.

## Scope explicitly NOT in this PR
- **Cross-agent session correlation** — Codex sessions launched as children of a Claude session attribute to the parent Claude row in the Monitor. Standalone `codex` launches get their own row. Distinct, fully-attributed Codex session rows = follow-up PR (estimated 200-400 line diff across 5-7 files; deserves its own review thread).
- **Codex `SessionStart` hook registration** — only `PreToolUse` is registered today. Session metadata enrichment = follow-up.
- **Extracted, unit-testable response-builder helper** — Phase 2 candidate; current logic is inline script-style in `Sources/GavelHook/main.swift`.

## Test plan
- [x] `swift test` — 276 tests pass locally (no regressions)
- [x] Live: Codex `apply_patch` to `.zshrc` blocked end-to-end; fallback `printf` also blocked; file never created
- [x] Live: Codex with rule-triggered allow path returns `hook: PreToolUse Completed` (was "Failed" pre-fix)
- [x] Live: synthetic Codex stdin against the worktree binary — exit 2 + stderr "User denied" on deny path
- [x] `install.sh` syntax check (`bash -n`) passes
- [x] Manual idempotency simulation: first append works, second run detects marker and skips, `--uninstall` cleanly removes block leaving surrounding user config intact
- [ ] CI green on PR