### PR TITLE
feat(monitor): codex sessions get their own row + agent tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Gavel protects its own config files and Claude Code's hook configuration. Comman
 - **IPC**: Unix domain socket at `~/.claude/gavel/gavel.sock`
 - **Platform**: macOS 13+
 - **Binaries**: `gavel` (daemon, ~1MB) and `gavel-hook` (CLI shim, ~85KB, ~6ms overhead per hook)
-- **Tests**: 276 tests across 6 suites
+- **Tests**: 280 tests across 6 suites
 
 ## Using Gavel with Codex CLI
 
@@ -234,9 +234,12 @@ A seeded `apply_patch` rule (verdict: prompt) catches patches that write to:
 
 This is defense-in-depth for the surface that shell-pattern Bash rules can't reach — Codex's `apply_patch` writes files without invoking `$SHELL`, so shell-level interceptors miss it.
 
+### Session attribution
+
+Codex sessions get their own row in the Monitor, distinct from any Claude Code session that may have launched them. The row is tagged with a small orange **Codex** badge so it's identifiable at a glance. The hook subprocess walks the process tree looking for the `codex` ancestor (parallel to the existing `claude` walk) whenever `gavel-hook` was invoked from Codex — detected via the `turn_id` field Codex includes in hook stdin but Claude doesn't. The envelope carries `agent: "codex"` so the daemon creates and persists a Codex-tagged session.
+
 ### Known limitations
 
-- **Session attribution**: Codex sessions launched as a child of a Claude Code session attribute to the parent Claude session's row in the Monitor. Standalone `codex` launches get their own row keyed on Codex's process. Distinct Codex monitor rows with full session correlation is a planned follow-up.
 - **No SessionStart hook**: only `PreToolUse` is registered today. Session metadata enrichment (model, cwd at start) is a follow-up.
 
 ## Uninstall

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -29,7 +29,7 @@ final class HookRouter {
             return
         }
 
-        let session = sessionManager.session(for: event.sessionPid)
+        let session = sessionManager.session(for: event.sessionPid, agent: event.agent)
         let ts = Date(timeIntervalSince1970: event.timestamp)
 
         switch event.payload {

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -51,15 +51,15 @@ final class SessionManager: ObservableObject {
         inactivityTimer?.cancel()
     }
 
-    /// Get or create a session for the given PID.
+    /// Get or create a session for the given PID and agent kind.
     /// New sessions inherit the default Auto/Sub settings.
-    func session(for pid: Int) -> Session {
+    func session(for pid: Int, agent: AgentKind = .claude) -> Session {
         lock.lock()
         defer { lock.unlock() }
         if let existing = sessions[pid] {
             return existing
         }
-        let session = Session(pid: pid)
+        let session = Session(pid: pid, agent: agent)
         session.isAutoApproveEnabled = defaultAutoApprove
         session.isSubAgentInheritEnabled = defaultSubAgentInherit
         session.isPaused = defaultPaused
@@ -177,6 +177,7 @@ final class SessionManager: ObservableObject {
         let isPaused: Bool?
         let label: String?
         let endedAt: Date?
+        let agent: AgentKind?
     }
 
     private struct PersistedState: Codable {
@@ -214,7 +215,8 @@ final class SessionManager: ObservableObject {
             isSubAgentInheritEnabled: session.isSubAgentInheritEnabled,
             isPaused: session.isPaused,
             label: session.label.isEmpty ? nil : session.label,
-            endedAt: session.endedAt
+            endedAt: session.endedAt,
+            agent: session.agent
         )
     }
 
@@ -246,7 +248,7 @@ final class SessionManager: ObservableObject {
 
     private func rehydrateLive(_ snap: PersistedSession) {
         let started = ProcessTree.startTime(of: Int32(snap.pid))
-        let session = Session(pid: snap.pid, cwd: snap.cwd, startedAt: started)
+        let session = Session(pid: snap.pid, cwd: snap.cwd, startedAt: started, agent: snap.agent ?? .claude)
         session.sessionId = snap.sessionId
         session.isAutoApproveEnabled = snap.isAutoApproveEnabled ?? defaultAutoApprove
         session.isSubAgentInheritEnabled = snap.isSubAgentInheritEnabled ?? defaultSubAgentInherit
@@ -260,7 +262,7 @@ final class SessionManager: ObservableObject {
     }
 
     private func rehydrateTombstone(_ snap: PersistedSession, sessionId: String) {
-        let session = Session(pid: snap.pid, cwd: snap.cwd, startedAt: snap.endedAt ?? Date())
+        let session = Session(pid: snap.pid, cwd: snap.cwd, startedAt: snap.endedAt ?? Date(), agent: snap.agent ?? .claude)
         session.sessionId = sessionId
         session.isAlive = false
         session.endedAt = snap.endedAt ?? Date()

--- a/Sources/Gavel/Models/HookEvent.swift
+++ b/Sources/Gavel/Models/HookEvent.swift
@@ -15,15 +15,38 @@ enum HookType: String, Codable {
     case unknown
 }
 
-/// Incoming event from a Claude Code hook shim.
+/// Incoming event from a gavel-hook subprocess (Claude Code or Codex CLI).
 ///
-/// The gavel-hook binary wraps Claude's raw JSON in this envelope,
-/// adding the PID and hook type.
+/// The gavel-hook binary wraps the agent's raw stdin JSON in this envelope,
+/// adding the PID, hook type, and agent kind. Envelopes without `agent`
+/// (older binaries) default to `.claude` for backward compatibility.
 struct HookEvent: Codable {
     let hookType: HookType
     let sessionPid: Int
     let timestamp: Double
     let payload: HookPayload
+    let agent: AgentKind
+
+    private enum CodingKeys: String, CodingKey {
+        case hookType, sessionPid, timestamp, payload, agent
+    }
+
+    init(hookType: HookType, sessionPid: Int, timestamp: Double, payload: HookPayload, agent: AgentKind = .claude) {
+        self.hookType = hookType
+        self.sessionPid = sessionPid
+        self.timestamp = timestamp
+        self.payload = payload
+        self.agent = agent
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        hookType = try c.decode(HookType.self, forKey: .hookType)
+        sessionPid = try c.decode(Int.self, forKey: .sessionPid)
+        timestamp = try c.decode(Double.self, forKey: .timestamp)
+        payload = try c.decode(HookPayload.self, forKey: .payload)
+        agent = (try? c.decode(AgentKind.self, forKey: .agent)) ?? .claude
+    }
 }
 
 /// The hook-specific payload, matching Claude Code's hook stdin schema.

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -1,9 +1,16 @@
 import Foundation
 
-/// Tracks state for a single Claude Code session.
+/// The agent CLI that owns a session — Claude Code or OpenAI Codex.
+enum AgentKind: String, Codable {
+    case claude
+    case codex
+}
+
+/// Tracks state for a single agent session (Claude Code or Codex CLI).
 final class Session: ObservableObject, Identifiable {
     let pid: Int
     let startedAt: Date
+    let agent: AgentKind
 
     @Published var sessionId: String?
     @Published var cwd: String?
@@ -70,10 +77,11 @@ final class Session: ObservableObject, Identifiable {
         return remaining > 0 ? remaining : nil
     }
 
-    init(pid: Int, cwd: String? = nil, startedAt: Date? = nil) {
+    init(pid: Int, cwd: String? = nil, startedAt: Date? = nil, agent: AgentKind = .claude) {
         self.pid = pid
         self.startedAt = startedAt ?? Date()
         self.cwd = cwd
+        self.agent = agent
     }
 
     func revokeAutoApprove() {

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -276,6 +276,15 @@ private struct SessionRow: View {
                 .fill(session.isAlive ? .green : .gray)
                 .frame(width: 8, height: 8)
 
+            if session.agent == .codex {
+                Text("Codex")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(.orange)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 1)
+                    .background(Color.orange.opacity(0.15), in: RoundedRectangle(cornerRadius: 3))
+            }
+
             // verbatim avoids LocalizedStringKey's locale grouping (e.g. "12,345")
             Text(verbatim: "PID \(session.pid)")
                 .font(.system(.caption, design: .monospaced))

--- a/Sources/Gavel/System/ProcessTree.swift
+++ b/Sources/Gavel/System/ProcessTree.swift
@@ -7,13 +7,16 @@ import Darwin
 /// eliminating ~80ms of subprocess overhead per hook invocation.
 struct ProcessTree {
 
-    /// Walk up the process tree from the given PID to find the Claude Code process.
-    /// Returns the Claude PID if found, nil otherwise.
-    static func findClaudePid(from pid: Int32) -> Int32? {
+    /// Walk up the process tree from `pid` looking for an ancestor whose
+    /// short process name (case-insensitive) contains `needle`. Returns
+    /// that PID or nil after 8 hops. Used to attribute hook calls back
+    /// to their owning agent process.
+    static func findAncestorPid(from pid: Int32, named needle: String) -> Int32? {
+        let target = needle.lowercased()
         var current = pid
         for _ in 0..<8 {
             if let name = processName(pid: current),
-               name.lowercased().contains("claude") {
+               name.lowercased().contains(target) {
                 return current
             }
             guard let ppid = parentPid(of: current), ppid > 1 else {
@@ -22,6 +25,18 @@ struct ProcessTree {
             current = ppid
         }
         return nil
+    }
+
+    /// Convenience wrapper preserved for existing call sites.
+    static func findClaudePid(from pid: Int32) -> Int32? {
+        findAncestorPid(from: pid, named: "claude")
+    }
+
+    /// Codex's hook subprocess is spawned directly by the codex binary, so the
+    /// immediate parent already matches — but we still walk a few hops to be
+    /// resilient to wrapper scripts.
+    static func findCodexPid(from pid: Int32) -> Int32? {
+        findAncestorPid(from: pid, named: "codex")
     }
 
     /// Get the parent PID of a process using sysctl.
@@ -128,17 +143,21 @@ struct ProcessTree {
         }
     }
 
-    /// Discover live Claude Code CLI sessions on the system. Matches on the
-    /// short process name `claude` (the CLI sets p_comm to that), which
-    /// excludes the Electron desktop app helpers — their p_comm is the
-    /// truncated `/Applications/Cl…` binary path.
-    static func findClaudeCliSessions() -> [(pid: Int32, cwd: String)] {
+    /// Discover live CLI sessions whose `p_comm` matches `processName` exactly.
+    /// Exact-match (not substring) so we don't pick up helper processes whose
+    /// truncated paths happen to contain the agent name.
+    static func findCliSessions(processName target: String) -> [(pid: Int32, cwd: String)] {
         var results: [(Int32, String)] = []
         for pid in enumerateAllPids() {
-            guard let name = processName(pid: pid), name == "claude" else { continue }
+            guard let name = processName(pid: pid), name == target else { continue }
             guard let cwd = cwd(of: pid) else { continue }
             results.append((pid, cwd))
         }
         return results
+    }
+
+    /// Convenience wrapper preserved for existing call sites.
+    static func findClaudeCliSessions() -> [(pid: Int32, cwd: String)] {
+        findCliSessions(processName: "claude")
     }
 }

--- a/Sources/GavelHook/main.swift
+++ b/Sources/GavelHook/main.swift
@@ -40,14 +40,19 @@ if let envType = ProcessInfo.processInfo.environment["CLAUDE_HOOK_TYPE"] {
 
 let needsResponse = hookType == "PreToolUse" || hookType == "PermissionRequest"
 
-// Build envelope
+// Build envelope. Codex stdin carries `turn_id` (Claude doesn't) — use that as
+// the caller discriminator and walk the process tree for the right ancestor.
+let isCodexAgent = stdinJson?["turn_id"] != nil
 let timestamp = Date().timeIntervalSince1970
 let pid = getppid()
-let claudePid = findClaudePid(from: pid) ?? pid
+let sessionPid: Int32 = isCodexAgent
+    ? (findAgentPid(from: pid, named: "codex") ?? pid)
+    : (findAgentPid(from: pid, named: "claude") ?? pid)
 
 var envelope: [String: Any] = [
     "hookType": hookType,
-    "sessionPid": Int(claudePid),
+    "sessionPid": Int(sessionPid),
+    "agent": isCodexAgent ? "codex" : "claude",
     "timestamp": timestamp,
 ]
 
@@ -150,10 +155,8 @@ if needsResponse {
             exit(0)
         }
 
-        // Codex sends `turn_id` in PreToolUse stdin; Claude doesn't. Codex's
-        // PreToolUseCommandOutputWire rejects permissionDecision:"allow" unless
-        // updatedInput is also present — omit it for Codex callers.
-        let isCodexCaller = stdinJson?["turn_id"] != nil
+        // Codex's PreToolUseCommandOutputWire rejects permissionDecision:"allow"
+        // unless updatedInput is also present — omit it for Codex callers.
         var output: [String: Any] = ["hookEventName": "PreToolUse"]
         if let ctx = json["additionalContext"] as? String, !ctx.isEmpty {
             output["additionalContext"] = ctx
@@ -162,7 +165,7 @@ if needsResponse {
         if let updated = updated {
             output["updatedInput"] = updated
             output["permissionDecision"] = "allow"
-        } else if !isCodexCaller {
+        } else if !isCodexAgent {
             output["permissionDecision"] = "allow"
         }
         let wrapper: [String: Any] = ["hookSpecificOutput": output]
@@ -196,11 +199,12 @@ func printBlock(_ reason: String) {
 
 // MARK: - Process tree walk (native, no subprocess)
 
-func findClaudePid(from startPid: Int32) -> Int32? {
+func findAgentPid(from startPid: Int32, named needle: String) -> Int32? {
+    let target = needle.lowercased()
     var current = startPid
     for _ in 0..<8 {
         if let name = processName(pid: current),
-           name.lowercased().contains("claude") {
+           name.lowercased().contains(target) {
             return current
         }
         guard let ppid = parentPid(of: current), ppid > 1 else { break }

--- a/Tests/GavelTests/SessionLifecycleTests.swift
+++ b/Tests/GavelTests/SessionLifecycleTests.swift
@@ -146,6 +146,27 @@ final class SessionLifecycleTests: XCTestCase {
         XCTAssertFalse(reloaded.deadSessions[sidDead]?.isAlive ?? true)
     }
 
+    func testCodexAgentAssignedOnSessionCreation() {
+        let pid = Int(getpid())
+        let claudeSession = manager.session(for: pid)
+        XCTAssertEqual(claudeSession.agent, .claude, "Default agent should be claude")
+
+        let otherPid = 1_999_998
+        let codexSession = manager.session(for: otherPid, agent: .codex)
+        XCTAssertEqual(codexSession.agent, .codex)
+    }
+
+    func testAgentPersistsAcrossDaemonRestart() {
+        let pid = Int(getpid())
+        let session = manager.session(for: pid, agent: .codex)
+        session.sessionId = "codex-sid"
+        manager.recordSessionId("codex-sid", on: session)
+        manager.saveActiveSessions()
+
+        let reloaded = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false)
+        XCTAssertEqual(reloaded.sessions[pid]?.agent, .codex, "Codex agent must survive restart")
+    }
+
     func testPersistenceBackwardCompatLegacyArrayFormat() throws {
         // Old format: bare array of live sessions, no tombstones.
         let livePid = Int(getpid())

--- a/Tests/GavelTests/WireFormatTests.swift
+++ b/Tests/GavelTests/WireFormatTests.swift
@@ -75,6 +75,41 @@ final class WireFormatTests: XCTestCase {
         XCTAssertEqual(payload.permissionMode, "default")
     }
 
+    func testEnvelopeAgentFieldDecodes() throws {
+        let json = """
+        {
+            "hookType": "PreToolUse",
+            "sessionPid": 1,
+            "timestamp": 0.0,
+            "agent": "codex",
+            "payload": {
+                "type": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls"}
+            }
+        }
+        """
+        let event = try JSONDecoder().decode(HookEvent.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(event.agent, .codex)
+    }
+
+    func testEnvelopeAgentDefaultsToClaudeWhenAbsent() throws {
+        let json = """
+        {
+            "hookType": "PreToolUse",
+            "sessionPid": 1,
+            "timestamp": 0.0,
+            "payload": {
+                "type": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls"}
+            }
+        }
+        """
+        let event = try JSONDecoder().decode(HookEvent.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(event.agent, .claude, "Envelopes without 'agent' must decode as claude")
+    }
+
     func testDecodeCodexPreToolUseEnvelope() throws {
         let json = """
         {


### PR DESCRIPTION
## Summary
Cross-agent session correlation — Codex sessions now appear as distinct rows in the Monitor instead of attributing to whichever Claude session may have launched them. Each Codex row is tagged with a small orange **Codex** badge between the status circle and the PID. Closes the limitation noted in #66.

## Mechanism
- `gavel-hook` detects Codex callers via the `turn_id` field in stdin (Codex sends it, Claude doesn't) and walks the process tree looking for the `codex` ancestor instead of `claude`. Envelope now carries `agent: "codex"` so the daemon doesn't have to re-detect.
- `Session.agent: AgentKind` (new enum: `claude | codex`, default `claude`). Persisted in active-sessions.json so it survives daemon restart.
- `HookEvent.agent` decodes the envelope field; missing values fall back to `.claude` (backward compat with older binaries that don't emit the field).
- `SessionManager.session(for:agent:)` passes the agent through to `Session` init.
- `ProcessTree.findAncestorPid(from:named:)` and `findCliSessions(processName:)` generalize the existing Claude-specific walks; the old `findClaudePid` / `findClaudeCliSessions` stay as thin wrappers so no other call sites change.

## Visible change

```
●  Codex  PID 12345  spike-sandbox  …    [Pause][Prompt][Auto]
```
vs. the unchanged Claude row:
```
●         PID 67890  my-project     …    [Pause][Prompt][Auto]
```

## Tests
4 new (280/280 pass):
- `WireFormatTests.testEnvelopeAgentFieldDecodes` — envelope with `agent: "codex"` decodes to `.codex`
- `WireFormatTests.testEnvelopeAgentDefaultsToClaudeWhenAbsent` — older envelopes without the field default to `.claude`
- `SessionLifecycleTests.testCodexAgentAssignedOnSessionCreation` — `SessionManager.session(for:agent:.codex)` produces a `.codex`-tagged session
- `SessionLifecycleTests.testAgentPersistsAcrossDaemonRestart` — agent survives the save/rehydrate cycle

## What's NOT in this PR
- **No `SessionStart` hook for Codex** — only `PreToolUse` is registered. Session metadata enrichment (model, cwd at session start) needs the SessionStart hook wired up + Codex config update. Follow-up.

## Backward compatibility
- Envelopes from older `gavel-hook` binaries don't include the `agent` field → decode as `.claude`. No breakage.
- On-disk `active-sessions.json` from older daemons has no `agent` field on persisted sessions → rehydrates as `.claude`. No breakage.
- `Session.init` and `SessionManager.session(for:)` keep their old signatures (agent has a default) — every existing caller compiles unchanged.

## Test plan
- [x] `swift test` — 280 tests pass locally (no regressions)
- [x] `swift build` — clean
- [ ] Live: invoke worktree gavel-hook with synthetic Codex envelope and observe a `.codex`-tagged session appearing in Monitor with the orange badge
- [ ] CI green