### PR TITLE
feat(monitor): agent-aware Resume — codex sessions get `codex resume <sid>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Gavel protects its own config files and Claude Code's hook configuration. Comman
 - **IPC**: Unix domain socket at `~/.claude/gavel/gavel.sock`
 - **Platform**: macOS 13+
 - **Binaries**: `gavel` (daemon, ~1MB) and `gavel-hook` (CLI shim, ~85KB, ~6ms overhead per hook)
-- **Tests**: 280 tests across 6 suites
+- **Tests**: 282 tests across 6 suites
 
 ## Using Gavel with Codex CLI
 

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -445,12 +445,12 @@ private struct SessionRow: View {
 
     private var resumeHelpText: String {
         guard let sid = session.sessionId else { return "No session ID — can't resume" }
-        return "Copy `\(ResumeCommand.build(pid: session.pid, sessionId: sid, cwd: session.cwd))` to clipboard."
+        return "Copy `\(ResumeCommand.build(pid: session.pid, sessionId: sid, cwd: session.cwd, agent: session.agent))` to clipboard."
     }
 
     private func copyResumeCommand() {
         guard let sid = session.sessionId else { return }
-        let cmd = ResumeCommand.build(pid: session.pid, sessionId: sid, cwd: session.cwd)
+        let cmd = ResumeCommand.build(pid: session.pid, sessionId: sid, cwd: session.cwd, agent: session.agent)
         let pb = NSPasteboard.general
         pb.clearContents()
         pb.setString(cmd, forType: .string)

--- a/Sources/Gavel/System/ResumeCommand.swift
+++ b/Sources/Gavel/System/ResumeCommand.swift
@@ -1,10 +1,16 @@
 import Foundation
 
 enum ResumeCommand {
-    static func build(pid: Int, sessionId: String, cwd: String?) -> String {
-        let claudeInvocation = "claude --name \(pid) --resume \(sessionId)"
-        guard let cwd = cwd else { return claudeInvocation }
-        return "cd \(shellQuote(cwd)) && \(claudeInvocation)"
+    static func build(pid: Int, sessionId: String, cwd: String?, agent: AgentKind = .claude) -> String {
+        let invocation: String
+        switch agent {
+        case .claude:
+            invocation = "claude --name \(pid) --resume \(sessionId)"
+        case .codex:
+            invocation = "codex resume \(sessionId)"
+        }
+        guard let cwd = cwd else { return invocation }
+        return "cd \(shellQuote(cwd)) && \(invocation)"
     }
 
     /// Bash single-quote escaping: close-quote, escape, reopen for each embedded apostrophe.

--- a/Tests/GavelTests/ResumeCommandTests.swift
+++ b/Tests/GavelTests/ResumeCommandTests.swift
@@ -67,4 +67,19 @@ final class ResumeCommandTests: XCTestCase {
         )
         XCTAssertEqual(cmd, "cd '/Users/jay/My Projects' && claude --name 1 --resume s")
     }
+
+    func testBuildCodexAgentEmitsCodexResume() {
+        let cmd = ResumeCommand.build(
+            pid: 9999,
+            sessionId: "019e38ed-2ed8-7cd2-ae18-e5f6eaec080b",
+            cwd: "/tmp/codex-spike-sandbox",
+            agent: .codex
+        )
+        XCTAssertEqual(cmd, "cd '/tmp/codex-spike-sandbox' && codex resume 019e38ed-2ed8-7cd2-ae18-e5f6eaec080b")
+    }
+
+    func testBuildCodexWithoutCwdOmitsCdPrefix() {
+        let cmd = ResumeCommand.build(pid: 7, sessionId: "abc", cwd: nil, agent: .codex)
+        XCTAssertEqual(cmd, "codex resume abc")
+    }
 }


### PR DESCRIPTION
## Summary
Follow-up to #68. The Resume button on a Codex tombstone in the Monitor now copies a working `codex resume <session_id>` command instead of `claude --resume <codex-sid>` (which Claude can't parse — Codex session IDs aren't Claude session IDs).

`ResumeCommand.build` now branches on `AgentKind`:
- `.claude` → `claude --name <pid> --resume <sid>` (unchanged)
- `.codex`  → `codex resume <sid>`

Both call sites in `MonitorWindow.swift` (the help-text preview and the actual clipboard copy) pass `session.agent` through.

## Lifecycle
When the user pastes and runs `codex resume <sid>`, codex emits its session_id on first hook → daemon's existing `recordSessionId` logic promotes the tombstone → live row transparently. Same dance as Claude, no new daemon code needed.

## Tests (2 new, 282 pass)
- `testBuildCodexAgentEmitsCodexResume`
- `testBuildCodexWithoutCwdOmitsCdPrefix`

## Test plan
- [x] `swift test` — 282 pass
- [x] `swift build` — clean
- [ ] Live: click Resume on a Codex tombstone, verify clipboard contains `codex resume <sid>` (after #68 lands a release with the Codex badge surface)
- [ ] CI green