### PR TITLE
feat(install): codex SessionStart hook — context injection parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,9 @@ This is defense-in-depth for the surface that shell-pattern Bash rules can't rea
 
 Codex sessions get their own row in the Monitor, distinct from any Claude Code session that may have launched them. The row is tagged with a small orange **Codex** badge so it's identifiable at a glance. The hook subprocess walks the process tree looking for the `codex` ancestor (parallel to the existing `claude` walk) whenever `gavel-hook` was invoked from Codex — detected via the `turn_id` field Codex includes in hook stdin but Claude doesn't. The envelope carries `agent: "codex"` so the daemon creates and persists a Codex-tagged session.
 
-### Known limitations
+### Session context injection
 
-- **No SessionStart hook**: only `PreToolUse` is registered today. Session metadata enrichment (model, cwd at start) is a follow-up.
+Codex sessions get the same philosophy injection Claude sessions do — `~/.claude/gavel/session-context.md` is read at SessionStart and emitted as `additionalContext` in Codex's hookSpecificOutput shape, so the same engineering principles, user-interaction guidance, and personal tuning are loaded into Codex's model context on every session. One file, both agents.
 
 ## Uninstall
 

--- a/hooks/codex_session_start.sh
+++ b/hooks/codex_session_start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Gavel Codex SessionStart hook — emits ~/.claude/gavel/session-context.md as
+# additionalContext so a Codex session starts with the same philosophy injection
+# every Claude session gets. Outputs the Codex hookSpecificOutput JSON shape
+# (camelCase fields under deny_unknown_fields).
+CONTEXT_FILE="$HOME/.claude/gavel/session-context.md"
+[[ -f "$CONTEXT_FILE" ]] || exit 0
+
+/usr/bin/python3 <<'PYEOF'
+import json, os, pathlib
+content = pathlib.Path(os.environ["HOME"], ".claude/gavel/session-context.md").read_text()
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": content,
+    }
+}))
+PYEOF

--- a/install.sh
+++ b/install.sh
@@ -164,14 +164,19 @@ fi
 if command -v codex &>/dev/null; then
     if [[ ! -f "$CODEX_CONFIG" ]]; then
         echo "Codex detected but $CODEX_CONFIG not found — run codex once to initialize, then re-run install"
-    elif /usr/bin/grep -qF "$CODEX_MARKER_BEGIN" "$CODEX_CONFIG"; then
-        echo "Codex hook already registered in $CODEX_CONFIG"
+    elif /usr/bin/grep -qF "$HOOKS_DIR/codex_session_start.sh" "$CODEX_CONFIG"; then
+        echo "Codex hooks already registered in $CODEX_CONFIG"
     else
-        echo "Registering Codex hook in $CODEX_CONFIG..."
+        # Upgrading from an older install (PreToolUse only)? Drop the old block first.
+        if /usr/bin/grep -qF "$CODEX_MARKER_BEGIN" "$CODEX_CONFIG"; then
+            /usr/bin/sed -i '' "/$CODEX_MARKER_BEGIN/,/$CODEX_MARKER_END/d" "$CODEX_CONFIG"
+            echo "Replaced older gavel block in $CODEX_CONFIG"
+        fi
+        echo "Registering Codex hooks in $CODEX_CONFIG..."
         cat >> "$CODEX_CONFIG" <<CODEX_HOOK
 
 $CODEX_MARKER_BEGIN
-# Trust this hook on first run: \`codex\` → /hooks → trust gavel-hook.
+# Trust each hook on first run: \`codex\` → /hooks → trust both entries.
 [[hooks.PreToolUse]]
 matcher = ".*"
 
@@ -179,9 +184,17 @@ matcher = ".*"
 type = "command"
 command = "$INSTALL_DIR/gavel-hook"
 timeout = 600
+
+[[hooks.SessionStart]]
+matcher = ".*"
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "$HOOKS_DIR/codex_session_start.sh"
+timeout = 30
 $CODEX_MARKER_END
 CODEX_HOOK
-        echo "  → Run \`codex\` interactively once and trust the hook via /hooks to activate"
+        echo "  → Run \`codex\` interactively once and trust the hooks via /hooks to activate"
     fi
 fi
 


### PR DESCRIPTION
## Summary
Closes the only remaining gap from the Codex integration loop: Codex sessions now get the same `~/.claude/gavel/session-context.md` injection that Claude sessions do, so engineering principles, user-interaction tuning, and personal philosophy are loaded into Codex's model context on every session.

## What's new
- **`hooks/codex_session_start.sh`** — tiny shim that reads `~/.claude/gavel/session-context.md` and prints Codex's expected `hookSpecificOutput` JSON with the file contents in `additionalContext`. Codex's `SessionStartHookSpecificOutputWire` has `deny_unknown_fields` so the shape is strict: camelCase `hookEventName` + `additionalContext`. Exits 0 with no output if the context file doesn't exist (graceful no-op).
- **`install.sh`** appends a `[[hooks.SessionStart]]` block alongside the existing `[[hooks.PreToolUse]]` block under the same managed-block markers.
- **Upgrade path**: idempotency check changed from "marker exists" to "SessionStart command path appears in config." Re-running install.sh from an older version (PreToolUse only) cleanly replaces the managed block. PreToolUse trust hash is unchanged; the new SessionStart entry needs a one-time `/hooks` trust.
- **README** "Known limitations / No SessionStart hook" → "Session context injection" with a description.

## Why use the *same* context file
The user's `session-context.md` is the canonical philosophy/tuning file — engineering principles, user interaction patterns, drift-reversal rules. Splitting per-agent would mean maintaining the same content twice. One file, both agents = single source of truth.

## Test plan
- [x] `bash -n install.sh` — syntax OK
- [x] Shim smoke test: pipe to `python3 json.load` confirms valid JSON with the right `hookEventName` and ~6.7KB `additionalContext` from the user's context file
- [x] Upgrade-path simulation: tmpfile with old PR #66-era block → install.sh's new idempotency branch correctly removes the old block before appending the new full version
- [x] `swift test` — 280 pass (no Swift code changed; sanity)
- [ ] Live: re-run `./install.sh`, see SessionStart hook registered; trust in TUI; run `codex exec` and verify session-context.md content appears in the model's initial context
- [ ] CI green

## Follow-up after merge
After this merges and release-please cuts a release with brew formula update:
1. `brew upgrade gavel`
2. Re-run `./install.sh` (or `gavel-setup` for brew users) to pick up the SessionStart block
3. One-time `/hooks` trust for the new entry