### PR TITLE
fix(hook): drop updatedInput for Codex callers, gate edit UI

### DIFF
--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -72,6 +72,13 @@ struct ApprovalPanelView: View {
     /// architectural rationale (re-render isolation + bug fix).
     @StateObject private var noteState = NoteFieldState()
 
+    /// Codex's PreToolUseHookSpecificOutputWire has no updatedInput field, so
+    /// command/field edits made in the panel can't be honored — render as
+    /// read-only for Codex sessions.
+    private var isCodexSession: Bool {
+        sessionPanel.currentApproval?.session.agent == .codex
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if let approval = sessionPanel.currentApproval {
@@ -213,32 +220,37 @@ struct ApprovalPanelView: View {
 
     private func bashDetails(_ payload: PreToolUsePayload) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("Command (editable)")
-                .font(.caption.bold())
-                .foregroundColor(.secondary)
-
-            // Size editor to content: ~18pt per line, min 3 lines, max 20 lines.
-            // Wrapping estimate: assume ~80 chars per line at monospaced body size.
-            let newlineCount = editedCommand.components(separatedBy: .newlines).count
-            let wrapEstimate = max(1, editedCommand.count / 80)
-            let lineCount = max(6, max(newlineCount, wrapEstimate) + 1)
-            let height = CGFloat(min(lineCount, 20)) * 18
-
-            TextEditor(text: $editedCommand)
-                .font(.system(.body, design: .monospaced))
-                .frame(height: height)
-                .padding(4)
-                .background(Color.orange.opacity(0.08))
-                .cornerRadius(6)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .stroke(editedCommand != (payload.command ?? "") ? Color.orange : Color.orange.opacity(0.2), lineWidth: editedCommand != (payload.command ?? "") ? 2 : 1)
-                )
-
-            if editedCommand != (payload.command ?? "") {
-                Text("Modified — original will be replaced")
+            if isCodexSession {
+                labeledField("Command", value: payload.command ?? "")
+                Text("Read-only — Codex doesn't support hook command edits")
                     .font(.caption2)
-                    .foregroundColor(.orange)
+                    .foregroundColor(.secondary)
+            } else {
+                Text("Command (editable)")
+                    .font(.caption.bold())
+                    .foregroundColor(.secondary)
+
+                let newlineCount = editedCommand.components(separatedBy: .newlines).count
+                let wrapEstimate = max(1, editedCommand.count / 80)
+                let lineCount = max(6, max(newlineCount, wrapEstimate) + 1)
+                let height = CGFloat(min(lineCount, 20)) * 18
+
+                TextEditor(text: $editedCommand)
+                    .font(.system(.body, design: .monospaced))
+                    .frame(height: height)
+                    .padding(4)
+                    .background(Color.orange.opacity(0.08))
+                    .cornerRadius(6)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(editedCommand != (payload.command ?? "") ? Color.orange : Color.orange.opacity(0.2), lineWidth: editedCommand != (payload.command ?? "") ? 2 : 1)
+                    )
+
+                if editedCommand != (payload.command ?? "") {
+                    Text("Modified — original will be replaced")
+                        .font(.caption2)
+                        .foregroundColor(.orange)
+                }
             }
 
             if let desc = payload.toolInput["description"]?.stringValue {
@@ -325,7 +337,7 @@ struct ApprovalPanelView: View {
         VStack(alignment: .leading, spacing: 6) {
             ForEach(Array(payload.toolInput.keys.sorted()), id: \.self) { key in
                 if let value = payload.toolInput[key]?.stringValue {
-                    if Self.editableKeys.contains(key) {
+                    if Self.editableKeys.contains(key) && !isCodexSession {
                         editableField(key, original: value)
                     } else {
                         labeledField(key, value: value)
@@ -635,13 +647,18 @@ struct ApprovalPanelView: View {
     }
 
     /// Returns the edited command only if it differs from the original.
+    /// Always nil for Codex sessions — Codex can't honor edits and the
+    /// resetFields dash-sanitize would otherwise leak a phantom edit.
     private var cmdIfModified: String? {
+        guard !isCodexSession else { return nil }
         guard let original = sessionPanel.currentApproval?.payload.command else { return nil }
         return editedCommand != original ? editedCommand : nil
     }
 
     /// Returns updated toolInput if any editable fields were modified.
+    /// Always nil for Codex sessions.
     private var updatedInputIfModified: [String: AnyCodable]? {
+        guard !isCodexSession else { return nil }
         guard let payload = sessionPanel.currentApproval?.payload else { return nil }
         let changes = editedFields.filter { key, value in
             value != (payload.toolInput[key]?.stringValue ?? "")

--- a/Sources/GavelHook/main.swift
+++ b/Sources/GavelHook/main.swift
@@ -155,18 +155,21 @@ if needsResponse {
             exit(0)
         }
 
-        // Codex's PreToolUseCommandOutputWire rejects permissionDecision:"allow"
-        // unless updatedInput is also present — omit it for Codex callers.
+        // Codex's PreToolUseHookSpecificOutputWire rejects both
+        // permissionDecision:"allow" and updatedInput as unsupported; the allow
+        // path is signaled by emitting hookEventName only (with optional
+        // additionalContext). Claude wants permissionDecision:"allow" and
+        // honors updatedInput. NOTE: this drops user-edited commands on Codex
+        // sessions silently — the edit UI should be gated agent-side.
         var output: [String: Any] = ["hookEventName": "PreToolUse"]
         if let ctx = json["additionalContext"] as? String, !ctx.isEmpty {
             output["additionalContext"] = ctx
         }
-        let updated = json["updatedInput"] as? [String: Any]
-        if let updated = updated {
-            output["updatedInput"] = updated
+        if !isCodexAgent {
             output["permissionDecision"] = "allow"
-        } else if !isCodexAgent {
-            output["permissionDecision"] = "allow"
+            if let updated = json["updatedInput"] as? [String: Any] {
+                output["updatedInput"] = updated
+            }
         }
         let wrapper: [String: Any] = ["hookSpecificOutput": output]
         if let data = try? JSONSerialization.data(withJSONObject: wrapper),


### PR DESCRIPTION
## Summary

- **Wire fix**: `Sources/GavelHook/main.swift` no longer sends `updatedInput` or `permissionDecision:"allow"` to Codex callers. Codex 0.130.0's `PreToolUseHookSpecificOutputWire` rejects both as unsupported (verified via binary strings: `PreToolUse hook returned unsupported updatedInput`, `unsupported permissionDecision:allow`). The prior workaround was based on a misread of the Codex contract and forwarded `updatedInput` whenever the approval panel had any field edit — which surfaced live as the error report that triggered this PR.
- **UX gate**: `ApprovalPanelView` now renders the Bash command as a read-only labeled field and routes editable toolInput keys through `labeledField` for Codex sessions. `cmdIfModified` and `updatedInputIfModified` also short-circuit to `nil` for Codex (defense in depth — `resetFields` sanitizes em-dashes on init, which could otherwise phantom-modify a command).

Claude path is unchanged.

## Why two commits

The wire fix is the urgent one — it stops a hook-failure error mid-tool-call. The UX gate prevents the user from typing into a field that can never take effect. They're orthogonal, hence two reviewable commits, but they pair: the UI prevents the input and the hook strips it if anything still leaks.

## Test plan

- [x] `swift test` — 282 tests pass
- [x] `swift build -c release --product gavel-hook` clean
- [x] Patched release binary smoke-tested locally by replacing `/opt/homebrew/Cellar/gavel/1.9.0/bin/gavel-hook`
- [ ] Live e2e: trigger a tool-call approval from Codex, verify (a) no `updatedInput`-related error, (b) Bash command renders read-only with "Codex doesn't support hook command edits" caption
- [ ] Live e2e: trigger a tool-call approval from Claude, verify command remains editable and `updatedInput` flows when edited

## Notes / Out of scope

There's an unrelated daemon-side concurrency bug surfaced in the same session — `gavel.log` shows `SIGNAL: 11` (SIGSEGV) immediately after two concurrent socket connections, after which the hook gets an empty response and reports "Gavel: daemon returned invalid response". Tracking separately; not addressed here. There's a prior engram note ("HookRouter threading inconsistency") that may be the same root cause.