### PR TITLE
chore(justfile): add dev-install / dev-restore

### DIFF
--- a/justfile
+++ b/justfile
@@ -34,3 +34,52 @@ log:
 
 # Run tests; placeholder for future swiftformat/swiftlint hooks
 check: test
+
+# Codesign local build and swap it into Homebrew's Cellar (backup, revert with dev-restore)
+dev-install: build
+    #!/usr/bin/env bash
+    # Build + ad-hoc codesign (hardened runtime) + swap into Homebrew's Cellar.
+    # Caveat: brew bottle ships with Developer ID (TeamIdentifier=4RZ893CQ7B);
+    # ad-hoc may still SIGKILL in hardened spawn contexts (Codex under Ghostty).
+    # If first Codex tool call after dev-install fails, check
+    # ~/Library/Logs/DiagnosticReports/gavel-hook-*.ips. If "Code Signature
+    # Invalid" is present, run `just dev-restore`.
+    set -euo pipefail
+    ver=$(brew list --versions gavel | awk '{print $2}')
+    cellar="/opt/homebrew/Cellar/gavel/${ver}/bin"
+    backup="$HOME/.cache/gavel-backup"
+    mkdir -p "$backup"
+    for bin in gavel gavel-hook; do
+        [[ -f "$cellar/$bin" ]] || { echo "missing $cellar/$bin"; exit 1; }
+        cp -p "$cellar/$bin" "$backup/${bin}.${ver}.bak"
+        codesign --force --sign - --options runtime ".build/release/$bin"
+        chmod u+w "$cellar/$bin"
+        cp ".build/release/$bin" "$cellar/$bin"
+        chmod 555 "$cellar/$bin"
+    done
+    echo
+    echo "Local build installed at $cellar/"
+    echo "Backup: $backup/"
+    echo "Restore: just dev-restore  (or: brew reinstall gavel)"
+    echo
+    echo "Bounce the daemon to pick up daemon-side changes:"
+    echo "  pkill -f /opt/homebrew/opt/gavel/bin/gavel && launchctl kickstart -k gui/\$(id -u)/com.gavel.daemon 2>/dev/null || true"
+
+# Restore Homebrew's signed binaries from the dev-install backup.
+dev-restore:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ver=$(brew list --versions gavel | awk '{print $2}')
+    cellar="/opt/homebrew/Cellar/gavel/${ver}/bin"
+    backup="$HOME/.cache/gavel-backup"
+    for bin in gavel gavel-hook; do
+        src="$backup/${bin}.${ver}.bak"
+        if [[ ! -f "$src" ]]; then
+            echo "no backup for $bin at $src — try 'brew reinstall gavel'"
+            continue
+        fi
+        chmod u+w "$cellar/$bin"
+        cp -p "$src" "$cellar/$bin"
+        chmod 555 "$cellar/$bin"
+        echo "restored $cellar/$bin"
+    done


### PR DESCRIPTION
## Summary

Adds `just dev-install` and `just dev-restore` for swapping a local `swift build -c release` into Homebrew's Cellar with proper codesigning.

## Why

Discovered while shipping #72: `swift build -c release` produces a binary with `flags=0x20002(adhoc,linker-signed)` from the Swift toolchain. macOS Gatekeeper SIGKILLs that binary when it's spawned under a hardened/quarantine-aware parent — Ghostty → Codex CLI → gavel-hook is one such tree. The brew bottle ships with Developer ID + hardened runtime (`flags=0x10000`, `TeamIdentifier=4RZ893CQ7B`), so production survives; uncommitted local builds don't.

`dev-install` does `codesign --force --sign - --options runtime` on both binaries (yields `flags=0x10002(adhoc,runtime)`), backs up the Cellar copies, and swaps. `dev-restore` reverses it. `brew reinstall gavel` is the always-works fallback.

## Caveat documented in the recipe

Ad-hoc + runtime may still get SIGKILL'd in stricter spawn contexts (no Developer ID cert). The recipe header tells users to check `~/Library/Logs/DiagnosticReports/gavel-hook-*.ips` after their first Codex tool call and run `dev-restore` if "Code Signature Invalid" shows up.

## Test plan

- [x] `just --list` shows both recipes with single-line descriptions
- [ ] Live: `just dev-install` against a fresh `swift build -c release`, verify Codex tool call doesn't SIGKILL the hook (check DiagnosticReports)
- [ ] Live: `just dev-restore` returns the Cellar to brew-shipped state