### PR TITLE
feat(justfile): make dev-install actually usable — Dev ID signing + dev-daemon

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,17 +38,42 @@ check: test
 # Codesign local build and swap it into Homebrew's Cellar (backup, revert with dev-restore)
 dev-install: build
     #!/usr/bin/env bash
-    # Build + ad-hoc codesign (hardened runtime) + swap into Homebrew's Cellar.
-    # Caveat: brew bottle ships with Developer ID (TeamIdentifier=4RZ893CQ7B);
-    # ad-hoc may still SIGKILL in hardened spawn contexts (Codex under Ghostty).
-    # If first Codex tool call after dev-install fails, check
-    # ~/Library/Logs/DiagnosticReports/gavel-hook-*.ips. If "Code Signature
-    # Invalid" is present, run `just dev-restore`.
+    # Build + codesign + swap into Homebrew's Cellar. Identity resolution:
+    #   1. $GAVEL_SIGN_IDENTITY env var (user override)
+    #   2. First "Developer ID Application" from `security find-identity`
+    #   3. Ad-hoc `-` (warns; may SIGKILL in hardened spawn contexts like
+    #      Ghostty → Codex CLI → hook, or LaunchAgent → daemon)
+    # The identity NAME is resolved from the local keychain at runtime so the
+    # repo carries no personal info; the private key never leaves the keychain.
+    #
+    # Daemon-side caveat: even with Developer ID, LaunchAgent kills the daemon
+    # for "Invalid Page" because the brew bottle is also notarized — `spctl -a`
+    # confirms `source=Unnotarized Developer ID` rejects this binary. Notarizing
+    # locally is impractical (multi-min round-trip to Apple per build). For
+    # daemon-side dev, use `just dev-daemon` instead — foreground spawn from an
+    # interactive shell is permissive about codesigning. dev-install is most
+    # useful for hook-side testing where the parent chain is more lenient.
     set -euo pipefail
     ver=$(brew list --versions gavel | awk '{print $2}')
     cellar="/opt/homebrew/Cellar/gavel/${ver}/bin"
     backup="$HOME/.cache/gavel-backup"
     mkdir -p "$backup"
+
+    identity="${GAVEL_SIGN_IDENTITY:-}"
+    if [[ -z "$identity" ]]; then
+        identity=$(security find-identity -v -p codesigning 2>/dev/null \
+            | grep "Developer ID Application" \
+            | head -1 \
+            | sed -E 's/^[^"]*"([^"]+)".*$/\1/' || true)
+    fi
+    if [[ -z "$identity" ]]; then
+        identity="-"
+        echo "WARNING: no Developer ID found in keychain — falling back to ad-hoc."
+        echo "         macOS will likely SIGKILL the binaries when spawned by Codex/Claude or LaunchAgent."
+    else
+        echo "Signing with: $identity"
+    fi
+
     for bin in gavel gavel-hook; do
         [[ -f "$cellar/$bin" ]] || { echo "missing $cellar/$bin"; exit 1; }
         # Preserve the FIRST backup as the brew-pristine snapshot — re-running
@@ -59,7 +84,7 @@ dev-install: build
         if [[ ! -f "$bak" ]]; then
             cp -p "$cellar/$bin" "$bak"
         fi
-        codesign --force --sign - --options runtime ".build/release/$bin"
+        codesign --force --sign "$identity" --options runtime ".build/release/$bin"
         chmod u+w "$cellar/$bin"
         cp ".build/release/$bin" "$cellar/$bin"
         chmod 555 "$cellar/$bin"
@@ -70,7 +95,28 @@ dev-install: build
     echo "Restore: just dev-restore  (or: brew reinstall gavel)"
     echo
     echo "Bounce the daemon to pick up daemon-side changes:"
-    echo "  pkill -f /opt/homebrew/opt/gavel/bin/gavel && launchctl kickstart -k gui/\$(id -u)/com.gavel.daemon 2>/dev/null || true"
+    echo "  brew services restart gavel"
+
+# Run a local dev daemon in the foreground; brew-managed daemon is paused for the duration.
+dev-daemon: build
+    #!/usr/bin/env bash
+    # Stop brew-managed gavel, run .build/release/gavel in foreground.
+    # The trap restores brew gavel on exit (Ctrl-C, error, normal return).
+    # Foreground spawn from an interactive shell is permissive about codesigning,
+    # so the linker-only signature from `swift build` works — no codesign or
+    # notarization needed for daemon-side dev.
+    set -euo pipefail
+    cleanup() {
+        echo
+        echo "Restoring brew-managed gavel..."
+        brew services start gavel >/dev/null 2>&1 || true
+    }
+    trap cleanup EXIT INT TERM
+    echo "Stopping brew-managed gavel..."
+    brew services stop gavel >/dev/null
+    echo "Running .build/release/gavel — Ctrl-C to stop and restore brew daemon"
+    echo
+    .build/release/gavel
 
 # Restore Homebrew's signed binaries from the dev-install backup.
 dev-restore:

--- a/justfile
+++ b/justfile
@@ -51,7 +51,14 @@ dev-install: build
     mkdir -p "$backup"
     for bin in gavel gavel-hook; do
         [[ -f "$cellar/$bin" ]] || { echo "missing $cellar/$bin"; exit 1; }
-        cp -p "$cellar/$bin" "$backup/${bin}.${ver}.bak"
+        # Preserve the FIRST backup as the brew-pristine snapshot — re-running
+        # dev-install would otherwise capture the currently-installed dev binary,
+        # erasing the restore path. `cp -p` also preserves source mode (555),
+        # which makes an overwrite-cp permission-denied on subsequent runs.
+        bak="$backup/${bin}.${ver}.bak"
+        if [[ ! -f "$bak" ]]; then
+            cp -p "$cellar/$bin" "$bak"
+        fi
         codesign --force --sign - --options runtime ".build/release/$bin"
         chmod u+w "$cellar/$bin"
         cp ".build/release/$bin" "$cellar/$bin"


### PR DESCRIPTION
## Summary

`just dev-install` had two real problems that together made it non-functional:

1. **Permission denied on re-run** — `cp -p` preserved the source binary's `555` mode on the backup file, so subsequent runs failed trying to overwrite a read-only file. (Worse: had it succeeded, the backup would now point at the dev binary, erasing the restore path.)
2. **SIGKILL'd at launch** — `swift build -c release` produces a binary with only the linker's `adhoc,linker-signed` signature. macOS Gatekeeper SIGKILLs that binary when it's spawned under hardened contexts (Ghostty → Codex → hook, or LaunchAgent → daemon).

This PR addresses both, plus adds the actually-usable path for daemon-side dev:

## Changes

### `dev-install` is now idempotent
Backup is preserved across re-runs as the brew-pristine snapshot. First run captures it; subsequent runs only re-sign + re-install.

### `dev-install` uses real Developer ID signing
Identity resolution, no creds in repo:
1. `$GAVEL_SIGN_IDENTITY` env var (override)
2. First `Developer ID Application` from `security find-identity` (local keychain)
3. Ad-hoc `-` (warning printed; survives only in lenient spawn contexts)

The identity name is resolved from the local keychain at runtime — the repo carries no personal info, and the private key never leaves the keychain.

### `dev-install` has a documented daemon-side limitation
Even with Developer ID, the daemon binary still SIGKILLs under LaunchAgent because the brew bottle is *also notarized*. `spctl -a` confirms: `source=Unnotarized Developer ID` is rejected. Notarization is multi-minute round-trip to Apple per build — impractical for local dev. Documented in the recipe header.

### NEW: `dev-daemon` for daemon-side dev work
The practical workflow for testing daemon code locally:
1. Stops brew-managed gavel
2. Runs `.build/release/gavel` in foreground
3. Trap on Ctrl-C restarts brew daemon

Foreground spawn from an interactive shell is permissive about codesigning — the linker-only signature from `swift build` works without codesign or notarization. This is what `dev-install` *can't* do via LaunchAgent and what users actually need to test PRs like #76 locally.

## Test plan (explicit on what's verified vs not)

- [x] `just dev-install` on clean state: succeeds, creates backup
- [x] `just dev-install` re-run: idempotent, doesn't clobber backup
- [x] `just dev-install` produces real Developer-ID-signed binary: `TeamIdentifier=4RZ893CQ7B`, `Signature size=8978`, `flags=0x10000(runtime)` (matches brew bottle)
- [x] `just dev-restore` returns brew-pristine binary
- [x] `just dev-daemon` stops brew daemon, builds, binds socket via local dev daemon (verified socket presence + dev binary PID active)
- [ ] **Not testable from inside the agent harness**: trap-on-Ctrl-C cleanup. Gavel's own kill-defense rules correctly block test signaling, and `TaskStop` sends SIGKILL which bypasses traps. The trap is a standard `trap cleanup EXIT INT TERM` bash idiom; correctness on real interactive Ctrl-C is verifiable by user in a terminal session.
- [x] `swift test` clean (282 tests)