### PR TITLE
fix(matcher): stop AWS write rule false-firing on --start-time

### DIFF
--- a/Sources/Gavel/Approval/PatternMatcher.swift
+++ b/Sources/Gavel/Approval/PatternMatcher.swift
@@ -7,6 +7,28 @@ import Foundation
 /// 2. **Protected path patterns** — block Write/Edit to sensitive file paths
 struct PatternMatcher {
 
+    private static let awsWriteOperationParts: Set<String> = [
+        "create", "delete", "update", "put", "remove", "terminate", "stop", "start", "modify", "run"
+    ]
+
+    private static let awsGlobalOptionsWithValues: Set<String> = [
+        "--ca-bundle",
+        "--cli-auto-prompt",
+        "--cli-binary-format",
+        "--cli-connect-timeout",
+        "--cli-input-json",
+        "--cli-input-yaml",
+        "--cli-read-timeout",
+        "--color",
+        "--endpoint-url",
+        "--output",
+        "--profile",
+        "--query",
+        "--region"
+    ]
+
+    private static let shellSegmentSeparators = CharacterSet(charactersIn: "\n;&|")
+
     /// Pre-compiled dangerous bash command patterns — hard block.
     private let bashPatterns: [(regex: NSRegularExpression, reason: String)]
 
@@ -145,7 +167,6 @@ struct PatternMatcher {
             ("\\brm\\s+--recursive", "Recursive delete (long flag)"),
             // Cloud CLI write operations
             ("\\baz\\s+.*\\b(update|create|delete|set|add|remove|start|stop|restart)\\b", "Azure CLI write operation"),
-            ("\\baws\\s+.*\\b(create|delete|update|put|remove|terminate|stop|start|modify|run)\\b(?!.*--dry-run)", "AWS CLI write operation"),
             ("\\bgcloud\\s+.*\\b(create|delete|update|add|remove|start|stop|deploy)\\b", "GCloud CLI write operation"),
             // ── Bypass-coverage fallbacks ──
             // The hard-block versions of these (rawBash above) anchor to command
@@ -334,6 +355,9 @@ struct PatternMatcher {
 
     private func checkAskUserBash(_ command: String) -> String? {
         let stripped = Self.stripQuotedContent(command)
+        if Self.containsAwsWriteOperation(stripped) {
+            return "AWS CLI write operation"
+        }
         let range = NSRange(stripped.startIndex..., in: stripped)
         for (regex, reason) in askUserBashPatterns {
             if regex.firstMatch(in: stripped, range: range) != nil {
@@ -341,6 +365,65 @@ struct PatternMatcher {
             }
         }
         return nil
+    }
+
+    private static func containsAwsWriteOperation(_ command: String) -> Bool {
+        for segment in command.components(separatedBy: shellSegmentSeparators) {
+            let tokens = segment.split { $0.isWhitespace }.map(String.init)
+            for index in tokens.indices where isAwsExecutable(tokens[index]) {
+                let args = Array(tokens.dropFirst(index + 1))
+                if argsContainDryRun(args) { continue }
+                guard let operation = awsOperation(from: args) else { continue }
+                if awsOperationLooksWrite(operation) { return true }
+            }
+        }
+        return false
+    }
+
+    private static func isAwsExecutable(_ token: String) -> Bool {
+        let cleaned = cleanShellToken(token)
+        return cleaned == "aws" || cleaned.hasSuffix("/aws")
+    }
+
+    private static func argsContainDryRun(_ args: [String]) -> Bool {
+        args.contains { arg in
+            let cleaned = cleanShellToken(arg)
+            return cleaned == "--dry-run" || cleaned.hasPrefix("--dry-run=")
+        }
+    }
+
+    private static func awsOperation(from args: [String]) -> String? {
+        var index = 0
+        guard nextAwsPositional(args, index: &index) != nil else { return nil }
+        return nextAwsPositional(args, index: &index)
+    }
+
+    private static func nextAwsPositional(_ args: [String], index: inout Int) -> String? {
+        while index < args.count {
+            let token = cleanShellToken(args[index])
+            index += 1
+            if token.isEmpty { continue }
+            if token.hasPrefix("-") {
+                if awsOptionConsumesValue(token), index < args.count { index += 1 }
+                continue
+            }
+            return token
+        }
+        return nil
+    }
+
+    private static func awsOptionConsumesValue(_ token: String) -> Bool {
+        token.hasPrefix("--") && !token.contains("=") && awsGlobalOptionsWithValues.contains(token)
+    }
+
+    private static func cleanShellToken(_ token: String) -> String {
+        token.trimmingCharacters(in: CharacterSet(charactersIn: #""'`"#)).lowercased()
+    }
+
+    private static func awsOperationLooksWrite(_ operation: String) -> Bool {
+        operation.split(separator: "-").contains { part in
+            awsWriteOperationParts.contains(String(part))
+        }
     }
 
     // MARK: - Bash command matching

--- a/Tests/GavelTests/PatternMatcherTests.swift
+++ b/Tests/GavelTests/PatternMatcherTests.swift
@@ -152,6 +152,31 @@ final class PatternMatcherTests: XCTestCase {
         XCTAssertNil(matcher.matchDangerous(payload: bashPayload(command: cmd)))
     }
 
+    func testAwsLogsFilterWithStartTimeDoesNotAskUser() {
+        let cmd = "AWS_PROFILE=$PROFILE aws logs filter-log-events --region us-east-1 --log-group-name $LG --start-time 1779155400000 --output json"
+        XCTAssertNil(matcher.matchSensitivePath(payload: bashPayload(command: cmd)))
+    }
+
+    func testMultilineAwsLogsReadCommandsDoNotAskUser() {
+        let cmd = """
+        PROFILE=Xceleration-Root-886004726701-AWSAdministratorAccess
+        LG=/aws/lambda/maintenance-orchestrator-st-OrchestratorFnh67FCE538-yzF8GdBPw455
+        AWS_PROFILE=$PROFILE aws logs describe-log-streams --region us-east-1 --log-group-name $LG --order-by LastEventTime --descending --max-items 6 --output json > /tmp/streams3.json
+        AWS_PROFILE=$PROFILE aws logs filter-log-events --region us-east-1 --log-group-name $LG --start-time 1779155400000 --output json > /tmp/orch_late.json
+        """
+        XCTAssertNil(matcher.matchSensitivePath(payload: bashPayload(command: cmd)))
+    }
+
+    func testAwsWriteOperationAsksUser() {
+        let cmd = "AWS_PROFILE=$PROFILE aws ec2 start-instances --instance-ids i-1234567890abcdef0"
+        XCTAssertEqual(matcher.matchSensitivePath(payload: bashPayload(command: cmd)), "AWS CLI write operation")
+    }
+
+    func testAwsDryRunWriteDoesNotAskUser() {
+        let cmd = "aws ec2 start-instances --instance-ids i-1234567890abcdef0 --dry-run"
+        XCTAssertNil(matcher.matchSensitivePath(payload: bashPayload(command: cmd)))
+    }
+
     // MARK: - Environment theft (expanded)
 
     func testEnvPipeBlocked() {


### PR DESCRIPTION
## Summary

- The `\baws\s+.*\b(...|start|...)\b(?!.*--dry-run)` regex matched `start` inside `--start-time` because `-` is a non-word character, so `\b` boundaries are satisfied on both sides. Read-only commands like `aws logs filter-log-events --start-time ...` were prompting as "AWS CLI write operation".
- Replaced with a token-based parser: find the `aws` token in each shell segment, skip global options that consume values, take the next two positional tokens as service + operation, check the operation's hyphen-split parts against the write-verb set. `--dry-run` (and `--dry-run=value`) handled via a separate token scan.
- True-positive coverage preserved (`aws ec2 start-instances` still prompts); pre-existing gaps around `aws s3 cp/sync/rm/mv` are unchanged and left for a follow-up.

## Test plan

- [x] `swift test` — 294/294 pass
- [x] New regressions in `PatternMatcherTests.swift`:
  - `aws logs filter-log-events --start-time` not prompting
  - Multi-line AWS Logs read shape from the original report not prompting
  - `aws ec2 start-instances` still prompting
  - `aws ec2 start-instances --dry-run` not prompting
- [ ] Re-run the original `PROFILE=Xceleration-Root-...` command path in a live Gavel session post-merge to confirm no panel opens

## Follow-ups (not blocking)

- Heredoc-aware `splitCommandSegments` in `Session.swift` so multi-line session-allow globs match commands containing `|` inside heredocs/quoted strings.
- Migrate `PatternMatcher.askUserBashPatterns` into `RuleStore` so built-in askUser rules carry UUIDs — would make the "Allow Rule" suppression button render for them in the approval panel.
- Expand AWS write coverage to include `s3 cp`/`sync`/`rm`/`mv` (pre-existing gap from the original regex; not a regression).