### PR TITLE
feat(justfile): add dev-doctor to catch stale dev paths in hook configs

### DIFF
--- a/justfile
+++ b/justfile
@@ -118,6 +118,72 @@ dev-daemon: build
     echo
     .build/release/gavel
 
+# Scan dev-volatile configs for paths under ~/code that reference gavel;
+# offer to reset them to brew paths. Catches the "deleted worktree leaves
+# stale hook config" failure mode (Codex/Claude hooks exit 127). Treat
+# local dev as a temporary state; run this after each dev sprint alongside
+# `just dev-restore`.
+dev-doctor:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    brew_prefix=$(brew --prefix)
+    brew_hook="$brew_prefix/bin/gavel-hook"
+    brew_daemon="$brew_prefix/bin/gavel"
+    code_root="$HOME/code"
+
+    declare -a drift_files=()
+
+    scan() {
+        local file="$1"
+        [[ -f "$file" ]] || return 0
+        local pattern="\"${code_root}[^\"]*/(gavel-hook|gavel)\""
+        if grep -qE "$pattern" "$file" 2>/dev/null; then
+            echo
+            echo "DRIFT in $file:"
+            grep -nE "$pattern" "$file" | sed 's/^/    /'
+            drift_files+=("$file")
+        fi
+    }
+
+    scan "$HOME/.codex/config.toml"
+    scan "$HOME/.claude/settings.json"
+    scan "$HOME/.claude/settings.local.json"
+
+    if [[ ${#drift_files[@]} -eq 0 ]]; then
+        echo "OK: no dev-path drift in known config locations."
+        echo "  brew gavel-hook:   $brew_hook"
+        echo "  brew gavel daemon: $brew_daemon"
+        exit 0
+    fi
+
+    echo
+    echo "${#drift_files[@]} file(s) reference a path under $code_root for gavel."
+    echo "These were probably set by 'just dev-install' or manual hook edits."
+    echo "If the source path no longer exists, hooks will exit 127."
+    echo
+    read -r -p "Reset to brew paths? [y/N] " ans
+    if [[ ! "$ans" =~ ^[Yy]$ ]]; then
+        echo "No changes made."
+        exit 1
+    fi
+
+    stamp=$(date +%Y%m%d-%H%M%S)
+    for file in "${drift_files[@]}"; do
+        backup="${file}.pre-dev-doctor-${stamp}"
+        cp "$file" "$backup"
+        sed -i.tmp -E \
+            -e "s|${code_root}[^\"]*/gavel-hook\"|${brew_hook}\"|g" \
+            -e "s|${code_root}[^\"]*/gavel\"|${brew_daemon}\"|g" \
+            "$file"
+        rm -f "${file}.tmp"
+        echo "  fixed: $file  (backup: $backup)"
+    done
+
+    echo
+    echo "Done. Codex: re-trust the new hook path via interactive 'codex' + '/hooks'."
+    echo "Claude Code: no re-trust needed."
+
 # Restore Homebrew's signed binaries from the dev-install backup.
 dev-restore:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- Adds \`just dev-doctor\`: scans known hook configs for stale paths under \`~/code\` left behind after worktree cleanup, offers to reset them to brew paths.
- Closes the loop on the failure mode we hit today: a deleted dev worktree left Codex's PreToolUse hook pointing at a non-existent binary → every tool call exited 127 → silent breakage from gavel's perspective (the call never reached the daemon).

## How it works

- Scans \`~/.codex/config.toml\`, \`~/.claude/settings.json\`, \`~/.claude/settings.local.json\`.
- Detection scope: *quoted command-path strings* under \`~/code\` ending in \`/gavel-hook\` or \`/gavel\`. Narrow enough that legitimate Codex project-trust declarations (e.g. \`[projects."/.../claude-gavel"]\`) don't false-positive.
- On confirmation, rewrites in place to \`$(brew --prefix)/bin/gavel-hook\` (and \`.../bin/gavel\` for the daemon). Each modified file gets a timestamped backup alongside.
- Exit codes: \`0\` if clean or successfully fixed, \`1\` if drift found and user declined to fix -- so it can drop into a precommit/CI check later if desired.

## Usage

Recommended habit: pair with \`dev-restore\` at the end of each dev sprint to treat local-dev as temporary state.

\`\`\`
just dev-restore   # swap brew Cellar binaries back to brew-pristine
just dev-doctor    # confirm no hook configs still point at code/ paths
\`\`\`

## Test plan

- [x] \`just dev-doctor\` on current configs (post-fix): reports OK, exits 0.
- [x] Sed substitution applied to the actual stale Codex config backup (\`config.toml.pre-hook-repoint-20260519-103429\`): only the broken \`command = "/Users/jjrawlins/code/.../gavel-hook"\` line rewrites; the \`[projects."/.../claude-gavel"]\` trust declaration is untouched.
- [ ] Manual: deliberately introduce a drift line and re-run to exercise the interactive fix path.

## Follow-ups (not blocking)

- Could be expanded later to scan project-level \`<repo>/.claude/settings.json\` and \`<repo>/.claude/settings.local.json\` if those become a vector for drift.