### PR TITLE
Quick links + JSONL label seed; fix --name pollution from Resume

### DIFF
--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -22,6 +22,8 @@ final class SessionManager: ObservableObject {
     /// User-typed labels keyed by Claude Code session UUID. Survives daemon restarts.
     @Published private var sessionLabels: [String: String] = [:]
 
+    private var jsonlSeedTriedPids: Set<Int> = []
+
     private var lastInteraction: Date = Date()
 
     private let defaultsPath: String
@@ -98,11 +100,12 @@ final class SessionManager: ObservableObject {
         let changed = session.sessionId != sid
         let savedLabel = sessionLabels[sid]
         let currentLabel = session.label
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
             session.sessionId = sid
             if session.label.isEmpty, let saved = savedLabel {
                 session.label = saved
             }
+            self?.tryJsonlSeed(session: session)
         }
         if !currentLabel.isEmpty && savedLabel != currentLabel {
             sessionLabels[sid] = currentLabel
@@ -120,14 +123,24 @@ final class SessionManager: ObservableObject {
     /// Worker-thread caller; @Published mutation dispatched to main.
     func recordCwd(_ cwd: String, on session: Session) {
         let changed = session.cwd != cwd
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
             session.cwd = cwd
+            self?.tryJsonlSeed(session: session)
         }
         if changed {
             lock.lock()
             saveActiveSessionsLocked()
             lock.unlock()
         }
+    }
+
+    private func tryJsonlSeed(session: Session) {
+        guard session.label.isEmpty, !jsonlSeedTriedPids.contains(session.pid) else { return }
+        guard let sid = session.sessionId, let cwd = session.cwd else { return }
+        jsonlSeedTriedPids.insert(session.pid)
+        guard let seeded = JsonlRenameReader.latestRename(cwd: cwd, sessionId: sid) else { return }
+        session.label = seeded
+        setLabel(seeded, for: sid)
     }
 
     /// Save (or clear) the label for a session UUID. Empty/whitespace removes the entry.
@@ -259,6 +272,7 @@ final class SessionManager: ObservableObject {
             session.label = label
         }
         sessions[snap.pid] = session
+        tryJsonlSeed(session: session)
     }
 
     private func rehydrateTombstone(_ snap: PersistedSession, sessionId: String) {

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -152,6 +152,24 @@ struct MonitorWindow: View {
                 .tint(.blue)
                 .help("Scan for Claude Code CLI processes that haven't fired a hook yet (e.g. started while gavel was down).")
 
+                Button("Plans") {
+                    EditorPreference.open(URL(fileURLWithPath:
+                        (NSHomeDirectory() as NSString).appendingPathComponent(".claude/plans")))
+                    viewModel.noteInteraction()
+                }
+                .buttonStyle(.bordered)
+                .tint(.indigo)
+                .help("Open ~/.claude/plans/ in your preferred editor.")
+
+                Button("Skills") {
+                    EditorPreference.open(URL(fileURLWithPath:
+                        (NSHomeDirectory() as NSString).appendingPathComponent(".claude/skills")))
+                    viewModel.noteInteraction()
+                }
+                .buttonStyle(.bordered)
+                .tint(.indigo)
+                .help("Open ~/.claude/skills/ in your preferred editor (resolves through your symlinks).")
+
                 sessionFilterField
 
                 activeOnlyToggle

--- a/Sources/Gavel/System/JsonlRenameReader.swift
+++ b/Sources/Gavel/System/JsonlRenameReader.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Reads the latest session title from a Claude Code JSONL transcript. Catches
+/// both `/rename` events and `--name`-set titles. Best-effort: read errors,
+/// missing files, and malformed lines all return nil.
+enum JsonlRenameReader {
+    static func latestRename(cwd: String, sessionId: String) -> String? {
+        let encoded = cwd
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+        let path = (NSHomeDirectory() as NSString)
+            .appendingPathComponent(".claude/projects")
+            .appending("/\(encoded)/\(sessionId).jsonl")
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let text = String(data: data, encoding: .utf8) else { return nil }
+
+        let patterns = [
+            #"<command-message>rename</command-message>[\s\S]*?<command-args>(.+?)</command-args>"#,
+            #""type":"custom-title","customTitle":"([^"]*)""#
+        ]
+
+        var latestEnd = -1
+        var latestValue: String? = nil
+        let nsRange = NSRange(text.startIndex..., in: text)
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            for match in regex.matches(in: text, range: nsRange) {
+                let end = match.range.location + match.range.length
+                guard end > latestEnd,
+                      match.numberOfRanges >= 2,
+                      let captureRange = Range(match.range(at: 1), in: text) else { continue }
+                latestEnd = end
+                latestValue = String(text[captureRange])
+            }
+        }
+
+        guard let value = latestValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
+    }
+}

--- a/Sources/Gavel/System/ResumeCommand.swift
+++ b/Sources/Gavel/System/ResumeCommand.swift
@@ -5,7 +5,7 @@ enum ResumeCommand {
         let invocation: String
         switch agent {
         case .claude:
-            invocation = "claude --name \(pid) --resume \(sessionId)"
+            invocation = "claude --resume \(sessionId)"
         case .codex:
             invocation = "codex resume \(sessionId)"
         }


### PR DESCRIPTION
## Summary

- **Monitor quick links**: new `Plans` and `Skills` buttons in the bottom control bar — open `~/.claude/plans/` and `~/.claude/skills/` in the user's preferred editor (resolved through whatever symlinks live there).
- **JSONL label seed**: when `SessionManager` first learns a session's `sessionId + cwd`, read the transcript tail for the latest `/rename` or `--name`-set `custom-title` and seed `session.label` with it if none is set. Fires from `recordSessionId`, `recordCwd`, and `rehydrateLive`. Tracked per-PID so the JSONL is read at most once per session.
- **Fix: drop `--name <pid>`** from the Resume button's clipboard command. The PID was sneaking in as the session title every time someone pasted+ran the resume command (Claude Code honors `--name` even on resume). New clipboard: `cd <cwd> && claude --resume <sid>`.

## Why

Hook-based rename propagation isn't viable on Claude Code 2.1.x (UserPromptExpansion isn't implemented despite docs; UserPromptSubmit doesn't fire for `/rename`). This lands the cheap-but-effective alternative: one-time JSONL seed at session discovery, plus the ergonomic monitor shortcuts that came up alongside it. The Resume fix is in the same area — small, related, biting actively.

## Test plan

- [ ] `just dev-daemon`; open monitor → confirm `Plans` and `Skills` buttons render after `Discover` with indigo tint, click each → preferred editor opens the right directory
- [ ] Resume a tombstoned session via Gavel's Resume button → pasted clipboard text contains NO `--name`, runs cleanly, resumed session keeps its prior title
- [ ] Fresh session whose JSONL contains a `/rename` or `--name`-set `custom-title`: bring up gavel with that session's record cleared from `sessionLabels` → row label seeds to the latest title from JSONL
- [ ] Session with no rename history → row label remains empty (no spurious values)