### PR TITLE
JSONL observability layer: mid-session rename sync + secret detection

### DIFF
--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -23,6 +23,7 @@ final class SessionManager: ObservableObject {
     @Published private var sessionLabels: [String: String] = [:]
 
     private var jsonlSeedTriedPids: Set<Int> = []
+    private var watchers: [Int: JsonlWatcher] = [:]
 
     private var lastInteraction: Date = Date()
 
@@ -135,12 +136,50 @@ final class SessionManager: ObservableObject {
     }
 
     private func tryJsonlSeed(session: Session) {
+        startWatcherIfReady(for: session)
         guard session.label.isEmpty, !jsonlSeedTriedPids.contains(session.pid) else { return }
         guard let sid = session.sessionId, let cwd = session.cwd else { return }
         jsonlSeedTriedPids.insert(session.pid)
         guard let seeded = JsonlRenameReader.latestRename(cwd: cwd, sessionId: sid) else { return }
         session.label = seeded
         setLabel(seeded, for: sid)
+    }
+
+    /// Apply an externally-sourced label update (e.g., from JSONL watcher); no-op on empty or unchanged input.
+    func updateLabel(_ newLabel: String, on session: Session, sessionId: String? = nil) {
+        let trimmed = newLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let currentLabel = session.label
+        guard currentLabel != trimmed else { return }
+        DispatchQueue.main.async {
+            session.label = trimmed
+        }
+        if let sid = sessionId ?? session.sessionId {
+            sessionLabels[sid] = trimmed
+            saveDefaults()
+        }
+        saveActiveSessions()
+    }
+
+    private func startWatcherIfReady(for session: Session) {
+        guard watchers[session.pid] == nil else { return }
+        guard let sid = session.sessionId, let cwd = session.cwd else { return }
+        let encoded = cwd
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+        let path = (NSHomeDirectory() as NSString)
+            .appendingPathComponent(".claude/projects")
+            .appending("/\(encoded)/\(sid).jsonl")
+        let handlers: [JsonlEventHandler] = [RenameHandler(), SecretHandler()]
+        let dispatcher = JsonlEventDispatcher(handlers: handlers, manager: self, session: session)
+        let watcher = JsonlWatcher(path: path, dispatcher: dispatcher)
+        watchers[session.pid] = watcher
+        watcher.start()
+    }
+
+    private func stopWatcher(forPid pid: Int) {
+        guard let watcher = watchers.removeValue(forKey: pid) else { return }
+        watcher.stop()
     }
 
     /// Save (or clear) the label for a session UUID. Empty/whitespace removes the entry.
@@ -350,6 +389,7 @@ final class SessionManager: ObservableObject {
             }
             saveActiveSessionsLocked()
             lock.unlock()
+            stopWatcher(forPid: pid)
             // @Published mutations need main thread; this runs on a utility queue.
             DispatchQueue.main.async {
                 session.isAlive = false

--- a/Sources/Gavel/Observability/Handlers/RenameHandler.swift
+++ b/Sources/Gavel/Observability/Handlers/RenameHandler.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+final class RenameHandler: JsonlEventHandler {
+    let name = "rename"
+
+    private static let patterns: [NSRegularExpression] = {
+        let raw = [
+            #"<command-message>rename</command-message>[\s\S]*?<command-args>(.+?)</command-args>"#,
+            #""type":"custom-title","customTitle":"([^"]*)""#
+        ]
+        return raw.compactMap { try? NSRegularExpression(pattern: $0) }
+    }()
+
+    func handle(_ event: JsonlEvent, manager: SessionManager, session: Session) {
+        guard let newLabel = extractLabel(from: event.rawLine) else { return }
+        manager.updateLabel(newLabel, on: session, sessionId: event.sessionId)
+    }
+
+    private func extractLabel(from line: String) -> String? {
+        let range = NSRange(line.startIndex..., in: line)
+        for regex in Self.patterns {
+            guard let match = regex.firstMatch(in: line, range: range),
+                  match.numberOfRanges >= 2,
+                  let r = Range(match.range(at: 1), in: line) else { continue }
+            let value = String(line[r]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !value.isEmpty { return value }
+        }
+        return nil
+    }
+}

--- a/Sources/Gavel/Observability/Handlers/SecretHandler.swift
+++ b/Sources/Gavel/Observability/Handlers/SecretHandler.swift
@@ -40,8 +40,8 @@ final class SecretHandler: JsonlEventHandler {
             lastFireByLabel[pattern.label] = Date()
             let sessionTag = session.label.isEmpty ? "PID \(session.pid)" : session.label
             GavelNotifications.notify(
-                title: "Gavel — secret detected",
-                body: "\(pattern.label) in session \(sessionTag).\n\nReview the conversation transcript before continuing.",
+                title: "Gavel",
+                body: "⚠️ Secret detected — \(pattern.label)\n\nSession: \(sessionTag)\n\nReview the conversation transcript before continuing.",
                 critical: true
             )
             return

--- a/Sources/Gavel/Observability/Handlers/SecretHandler.swift
+++ b/Sources/Gavel/Observability/Handlers/SecretHandler.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+final class SecretHandler: JsonlEventHandler {
+    let name = "secret"
+
+    private struct SecretPattern {
+        let label: String
+        let regex: NSRegularExpression
+    }
+
+    private static let patterns: [SecretPattern] = {
+        let raw: [(String, String)] = [
+            ("AWS access key", #"AKIA[0-9A-Z]{16}"#),
+            ("GitHub PAT", #"ghp_[A-Za-z0-9]{36,}"#),
+            ("GitHub OAuth token", #"gho_[A-Za-z0-9]{36,}"#),
+            ("GitHub server token", #"ghs_[A-Za-z0-9]{36,}"#),
+            ("Anthropic API key", #"sk-ant-[A-Za-z0-9_\-]{40,}"#),
+            ("OpenAI API key", #"sk-[A-Za-z0-9]{40,}"#),
+            ("Slack token", #"xox[bpoa]-[A-Za-z0-9\-]{10,}"#),
+            ("Slack webhook URL", #"https://hooks\.slack\.com/services/[A-Z0-9/]{20,}"#)
+        ]
+        return raw.compactMap { (label, pattern) in
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+            return SecretPattern(label: label, regex: regex)
+        }
+    }()
+
+    func handle(_ event: JsonlEvent, manager: SessionManager, session: Session) {
+        let line = event.rawLine
+        let range = NSRange(line.startIndex..., in: line)
+        for pattern in Self.patterns where pattern.regex.firstMatch(in: line, range: range) != nil {
+            GavelNotifications.notify(
+                title: "Gavel — secret detected",
+                body: "\(pattern.label) in session PID \(session.pid)"
+            )
+            return
+        }
+    }
+}

--- a/Sources/Gavel/Observability/Handlers/SecretHandler.swift
+++ b/Sources/Gavel/Observability/Handlers/SecretHandler.swift
@@ -25,13 +25,24 @@ final class SecretHandler: JsonlEventHandler {
         }
     }()
 
+    private static let cooldown: TimeInterval = 300
+
+    private var lastFireByLabel: [String: Date] = [:]
+
     func handle(_ event: JsonlEvent, manager: SessionManager, session: Session) {
         let line = event.rawLine
         let range = NSRange(line.startIndex..., in: line)
         for pattern in Self.patterns where pattern.regex.firstMatch(in: line, range: range) != nil {
+            if let last = lastFireByLabel[pattern.label],
+               Date().timeIntervalSince(last) < Self.cooldown {
+                return
+            }
+            lastFireByLabel[pattern.label] = Date()
+            let sessionTag = session.label.isEmpty ? "PID \(session.pid)" : session.label
             GavelNotifications.notify(
                 title: "Gavel — secret detected",
-                body: "\(pattern.label) in session PID \(session.pid)"
+                body: "\(pattern.label) in session \(sessionTag).\n\nReview the conversation transcript before continuing.",
+                critical: true
             )
             return
         }

--- a/Sources/Gavel/Observability/JsonlEventDispatcher.swift
+++ b/Sources/Gavel/Observability/JsonlEventDispatcher.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+final class JsonlEventDispatcher {
+    private let handlers: [JsonlEventHandler]
+    private weak var manager: SessionManager?
+    private weak var session: Session?
+
+    init(handlers: [JsonlEventHandler], manager: SessionManager, session: Session) {
+        self.handlers = handlers
+        self.manager = manager
+        self.session = session
+    }
+
+    func dispatch(_ rawLine: String) {
+        guard let manager = manager, let session = session else { return }
+        guard let sid = session.sessionId, let cwd = session.cwd else { return }
+
+        let json = parseJson(rawLine)
+        let event = JsonlEvent(rawLine: rawLine, json: json, sessionId: sid, cwd: cwd)
+
+        for handler in handlers {
+            let start = Date()
+            handler.handle(event, manager: manager, session: session)
+            let elapsedMs = Date().timeIntervalSince(start) * 1000
+            if elapsedMs > 5 {
+                gavelLog("[obs] handler=\(handler.name) elapsed=\(Int(elapsedMs))ms")
+            }
+        }
+    }
+
+    private func parseJson(_ line: String) -> [String: Any]? {
+        guard let data = line.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+}

--- a/Sources/Gavel/Observability/JsonlEventHandler.swift
+++ b/Sources/Gavel/Observability/JsonlEventHandler.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct JsonlEvent {
+    let rawLine: String
+    let json: [String: Any]?
+    let sessionId: String
+    let cwd: String
+}
+
+protocol JsonlEventHandler {
+    var name: String { get }
+    func handle(_ event: JsonlEvent, manager: SessionManager, session: Session)
+}

--- a/Sources/Gavel/Observability/JsonlWatcher.swift
+++ b/Sources/Gavel/Observability/JsonlWatcher.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+final class JsonlWatcher {
+    private let path: String
+    private let dispatcher: JsonlEventDispatcher
+    private let queue: DispatchQueue
+
+    private var fileHandle: FileHandle?
+    private var source: DispatchSourceFileSystemObject?
+    private var lastOffset: UInt64 = 0
+    private var lineBuffer = Data()
+
+    init(path: String, dispatcher: JsonlEventDispatcher) {
+        self.path = path
+        self.dispatcher = dispatcher
+        self.queue = DispatchQueue(
+            label: "gavel.jsonl-watcher.\(UUID().uuidString.prefix(8))",
+            qos: .utility
+        )
+    }
+
+    func start() {
+        queue.async { [weak self] in self?.openAndSubscribe() }
+    }
+
+    func stop() {
+        queue.async { [weak self] in self?.tearDown() }
+    }
+
+    private func openAndSubscribe() {
+        let url = URL(fileURLWithPath: path)
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
+            queue.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                self?.openAndSubscribe()
+            }
+            return
+        }
+        fileHandle = handle
+        lastOffset = handle.seekToEndOfFile()
+        lineBuffer.removeAll()
+
+        let src = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: handle.fileDescriptor,
+            eventMask: [.write, .delete, .rename],
+            queue: queue
+        )
+        src.setEventHandler { [weak self] in self?.handleFsEvent() }
+        src.resume()
+        source = src
+    }
+
+    private func handleFsEvent() {
+        guard let source = source else { return }
+        let mask = source.data
+        if mask.contains(.delete) || mask.contains(.rename) {
+            reopenAfterRotation()
+            return
+        }
+        if mask.contains(.write) {
+            readNewBytes()
+        }
+    }
+
+    private func reopenAfterRotation() {
+        tearDown()
+        queue.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            self?.openAndSubscribe()
+        }
+    }
+
+    private func tearDown() {
+        source?.cancel()
+        source = nil
+        try? fileHandle?.close()
+        fileHandle = nil
+    }
+
+    private func readNewBytes() {
+        guard let handle = fileHandle else { return }
+        let currentEnd = handle.seekToEndOfFile()
+        guard currentEnd > lastOffset else { return }
+        try? handle.seek(toOffset: lastOffset)
+        let newData = handle.readData(ofLength: Int(currentEnd - lastOffset))
+        lastOffset = currentEnd
+
+        lineBuffer.append(newData)
+        while let nlIdx = lineBuffer.firstIndex(of: 0x0A) {
+            let lineData = lineBuffer.subdata(in: 0..<nlIdx)
+            lineBuffer.removeSubrange(0...nlIdx)
+            if let line = String(data: lineData, encoding: .utf8), !line.isEmpty {
+                dispatcher.dispatch(line)
+            }
+        }
+    }
+}

--- a/Sources/Gavel/System/Notifications.swift
+++ b/Sources/Gavel/System/Notifications.swift
@@ -23,13 +23,21 @@ struct GavelNotifications {
         }
     }
 
-    /// Post a native macOS notification.
-    static func notify(title: String, body: String, sound: Bool = true) {
-        // osascript works universally — no bundle required
-        let soundClause = sound ? #" sound name "Glass""# : ""
-        let escaped_title = title.replacingOccurrences(of: "\"", with: "\\\"")
-        let escaped_body = body.replacingOccurrences(of: "\"", with: "\\\"")
-        let script = #"display notification "\#(escaped_body)" with title "\#(escaped_title)"\#(soundClause)"#
+    /// Post a native macOS notification. When `critical` is true, uses a modal
+    /// `display dialog` that persists until the user dismisses it — for events
+    /// the user must not miss (e.g., secret leaks). Otherwise uses the standard
+    /// banner-style `display notification`.
+    static func notify(title: String, body: String, sound: Bool = true, critical: Bool = false) {
+        let escapedTitle = title.replacingOccurrences(of: "\"", with: "\\\"")
+        let escapedBody = body.replacingOccurrences(of: "\"", with: "\\\"")
+
+        let script: String
+        if critical {
+            script = #"display dialog "\#(escapedBody)" with title "\#(escapedTitle)" buttons {"OK"} default button "OK" with icon caution"#
+        } else {
+            let soundClause = sound ? #" sound name "Glass""# : ""
+            script = #"display notification "\#(escapedBody)" with title "\#(escapedTitle)"\#(soundClause)"#
+        }
 
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
@@ -37,6 +45,5 @@ struct GavelNotifications {
         task.standardOutput = FileHandle.nullDevice
         task.standardError = FileHandle.nullDevice
         try? task.run()
-        // Fire and forget — don't wait
     }
 }

--- a/Sources/Gavel/System/Notifications.swift
+++ b/Sources/Gavel/System/Notifications.swift
@@ -28,15 +28,16 @@ struct GavelNotifications {
     /// the user must not miss (e.g., secret leaks). Otherwise uses the standard
     /// banner-style `display notification`.
     static func notify(title: String, body: String, sound: Bool = true, critical: Bool = false) {
-        let escapedTitle = title.replacingOccurrences(of: "\"", with: "\\\"")
-        let escapedBody = body.replacingOccurrences(of: "\"", with: "\\\"")
+        let escapedTitle = appleScriptQuoted(title)
 
         let script: String
         if critical {
-            script = #"display dialog "\#(escapedBody)" with title "\#(escapedTitle)" buttons {"OK"} default button "OK" with icon caution"#
+            let appleScriptBody = appleScriptMultilineString(body)
+            script = #"display dialog \#(appleScriptBody) with title \#(escapedTitle) buttons {"OK"} default button "OK" with icon caution"#
         } else {
+            let escapedBody = appleScriptQuoted(body.replacingOccurrences(of: "\n", with: " "))
             let soundClause = sound ? #" sound name "Glass""# : ""
-            script = #"display notification "\#(escapedBody)" with title "\#(escapedTitle)"\#(soundClause)"#
+            script = #"display notification \#(escapedBody) with title \#(escapedTitle)\#(soundClause)"#
         }
 
         let task = Process()
@@ -45,5 +46,18 @@ struct GavelNotifications {
         task.standardOutput = FileHandle.nullDevice
         task.standardError = FileHandle.nullDevice
         try? task.run()
+    }
+
+    private static func appleScriptQuoted(_ s: String) -> String {
+        let escaped = s
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+
+    private static func appleScriptMultilineString(_ s: String) -> String {
+        s.components(separatedBy: "\n")
+            .map { appleScriptQuoted($0) }
+            .joined(separator: " & return & ")
     }
 }


### PR DESCRIPTION
## Summary

First slice of the JSONL observability layer designed in plan #G. A per-session `JsonlWatcher` tails each live session's transcript and dispatches new lines to a handler chain. Two MVP handlers:

- **RenameHandler** -- completes the mid-session rename → Gavel label sync that the Plan #3 seed couldn't (seed only fires at session discovery). Now every `/rename` or `--name`-set `custom-title` propagates within seconds.
- **SecretHandler** -- pattern-matches AWS / GitHub / Anthropic / OpenAI / Slack tokens and emits a macOS notification on match. Never logs or persists the matched value.

## Architecture

```
Sources/Gavel/Observability/
├── JsonlEventHandler.swift     ← protocol + event struct
├── JsonlEventDispatcher.swift  ← handler invocation, >5ms budget warn
├── JsonlWatcher.swift          ← DispatchSourceFileSystemObject, per-session
└── Handlers/
    ├── RenameHandler.swift
    └── SecretHandler.swift
```

`SessionManager` gains `watchers: [Int: JsonlWatcher]` keyed by PID. Watcher lifecycle piggybacks on the existing `tryJsonlSeed` trigger conditions (sessionId+cwd known) for startup and `cleanupDeadSessions` for teardown.

Also reintroduces `SessionManager.updateLabel(_:on:sessionId:)` -- drafted during the Plan #2 attempt, justified now that there's an external writer (the rename handler) for `session.label`.

## v1 deliberate cuts

- **No catch-up tail-read** on watcher start. Watcher seeks to EOF; pre-existing rename events are still caught by `JsonlRenameReader`'s seed pass at session discovery.
- **No per-(label,value) dedupe** for secrets. Repeated lines containing the same secret trigger repeated notifications. Add via hashed-set if noisy.
- **No auto-pause** on secret detection. Just notify.
- **No high-entropy fallback** in SecretHandler. Prefix patterns only -- fewer false positives.
- **No tests yet**. RenameHandler's `extractLabel(from:)` and SecretHandler's pattern set are the obvious unit-test surfaces; add in a follow-up.

## Test plan

- [ ] `just dev-daemon`, open monitor.
- [ ] **Rename sync**: `/rename foo` mid-session → Gavel row label updates to "foo" within ~1s without restart.
- [ ] **Secret detection**: prompt or tool output containing `AKIAFAKEKEY1234567A` triggers a macOS notification "Gavel -- secret detected: AWS access key in session PID …". Repeat with `ghp_…`, `sk-ant-…`, etc.
- [ ] **Lifecycle**: kill a session; `lsof -p <gavel-pid> | grep <sid>.jsonl` shows the descriptor released within the cleanup tick.
- [ ] **No false positives on quiet sessions**: a long session with normal tool calls but no secrets and no renames produces zero notifications and no daemon-log entries.
- [ ] **Performance**: tail the dev-daemon foreground output during a busy session; any `[obs] handler=<name> elapsed=Xms` line where X > 5 is a budget breach to investigate.