### PR TITLE
docs(claude-md): add project CLAUDE.md with release-please convention + dev notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ DerivedData/
 .mcp.json
 dev/
 output.log
+
+# Override global ~/.gitignore: this repo's CLAUDE.md is checked in.
+!CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# Claude Gavel — project conventions for Claude Code
+
+## PR titles MUST be conventional-commit format
+
+This repo uses [release-please](https://github.com/googleapis/release-please)
+(config: `.release-please-config.json`). GitHub's squash-merge takes the PR
+title as the squash-commit's first line — so **the PR title is what
+release-please parses**. Body bullets don't count.
+
+Title format: `<type>(<scope>): <description>`
+
+- Types: `feat`, `fix`, `chore`, `docs`
+- Scopes used here: `justfile`, `matcher`, `approval`, `jsonl`, `monitor`,
+  `session`, `resume`, `notifications`. Pick the specific module touched;
+  avoid generic scopes like "observability" or "refactor".
+
+If a PR's title isn't conventional, the work lands on `main` but never appears
+in any release. Recovery: hand-edit `CHANGELOG.md` in the next release-please
+PR to backfill the missing entry.
+
+Full context (worked / failed examples from PR history, recovery details):
+query engram for `claude-gavel pr title release-please convention`.
+
+## Dev iteration
+
+- `just dev-daemon` — runs the local build in the foreground; brew-managed
+  gavel is paused for the duration; Ctrl-C restores brew gavel via trap.
+  Cleanest test cycle for daemon-side changes.
+- `just dev-install` — codesigns the local build and swaps it into the brew
+  Cellar. Persistent across daemon restarts. Reversal: `just dev-restore`
+  (or `brew reinstall gavel`).
+- `just build` — release build only, no swap.
+- `just dev-doctor` — diagnoses stale dev paths in hook configs.
+
+## Gavel self-protection
+
+Gavel's own PreToolUse hook blocks writes and deletes against:
+
+- `~/.claude/gavel/**`
+- `~/.claude/settings*`
+- `~/.claude/hooks/**`
+- `~/.codex/{config,hooks}`
+- shell init files (`.zshrc`, `.bashrc`, etc.)
+
+If a tool call against those paths fails with `User denied — …` style errors,
+that's Gavel's deny rule firing — not a bug. Either route through Gavel's own
+APIs (`setLabel`, `saveDefaults`, etc.) or have the user run the operation
+in a non-Gavel-monitored terminal.


### PR DESCRIPTION
## Summary

Adds a project `CLAUDE.md` so Claude Code sessions opening this repo have the conventions specific to claude-gavel loaded automatically. Two recent PRs (#83 and #84) landed without conventional-commit titles and as a result are not represented in any release -- this doc encodes the rule prominently so future sessions catch the mistake before opening a PR.

## Why

Project CLAUDE.md is repo-local and auto-loaded by Claude Code when sessions start in the repo root. Better fit than a global SessionStart hook because:

- Only loads when working on claude-gavel (no token cost in other sessions)
- Lives in the repo, version-controlled, reviewable in PRs
- Standard Claude Code feature, no bespoke hook plumbing to maintain

## What's in it

1. **PR title convention** -- full rule + recovery path when missed. References engram for worked / failed examples from the actual PR history.
2. **Dev iteration commands** -- `just dev-daemon`, `just dev-install`, `just dev-restore`, `just dev-doctor`.
3. **Gavel self-protection note** -- which paths the PreToolUse deny rule blocks, so Claude sessions know how to interpret `User denied …` errors.

Keep-it-short principle: short, specific to this repo, pointer to engram for long-form details.

## Also

`.gitignore` gains `!CLAUDE.md` because Jayson's global `~/.gitignore` ignores `CLAUDE.MD` case-insensitively. Same pattern as the [claude-config repo's gitignore override](https://github.com/JaysonRawlins/claude-config).

## Test plan

- [ ] After merge, in a fresh shell: `cd <claude-gavel> && claude` -- the new project CLAUDE.md is loaded into the session context.
- [ ] Verify by asking the session about PR title conventions -- it should respond from the loaded CLAUDE.md.
- [ ] Verify `.gitignore` override works: `git check-ignore CLAUDE.md` from the repo root should NOT mark it as ignored.