### PR TITLE
feat(approval): manually select YOLO plan when auto-detect misses

### DIFF
--- a/Sources/Gavel/Approval/YoloMode.swift
+++ b/Sources/Gavel/Approval/YoloMode.swift
@@ -85,6 +85,53 @@ enum YoloMode {
         return planPathRegex.firstMatch(in: path, range: range) != nil
     }
 
+    /// A discoverable plan file under `~/.claude/plans/<folder>/<file>.md`.
+    struct PlanRef: Identifiable {
+        let path: String
+        let folder: String
+        let filename: String
+        let modifiedAt: Date
+        var id: String { path }
+    }
+
+    static func plansDirectory() -> URL {
+        URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent(".claude/plans", isDirectory: true)
+    }
+
+    /// One level deep, `.md` only, newest-modified first. Mirrors the
+    /// `plans/<folder>/<file>.md` shape `isPlanPath` enforces, so the manual
+    /// picker offers exactly the files capture-on-write would have stamped.
+    static func recentPlans(in baseDir: URL = plansDirectory(), limit: Int = 15) -> [PlanRef] {
+        let fm = FileManager.default
+        guard let folders = try? fm.contentsOfDirectory(
+            at: baseDir,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        var refs: [PlanRef] = []
+        for folder in folders {
+            guard (try? folder.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else { continue }
+            let files = (try? fm.contentsOfDirectory(
+                at: folder,
+                includingPropertiesForKeys: [.contentModificationDateKey, .isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )) ?? []
+            for file in files where file.pathExtension == "md" {
+                let values = try? file.resourceValues(forKeys: [.contentModificationDateKey, .isDirectoryKey])
+                guard values?.isDirectory != true else { continue }
+                refs.append(PlanRef(
+                    path: file.path,
+                    folder: folder.lastPathComponent,
+                    filename: file.lastPathComponent,
+                    modifiedAt: values?.contentModificationDate ?? .distantPast
+                ))
+            }
+        }
+        return Array(refs.sorted { $0.modifiedAt > $1.modifiedAt }.prefix(limit))
+    }
+
     static func sha256(ofFileAt path: String) -> String? {
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
             return nil

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// The main monitor window showing the live feed, rules editor, regex tester, and cheat sheet.
 struct MonitorWindow: View {
@@ -428,38 +429,101 @@ private struct SessionRow: View {
 
     @ViewBuilder
     private var yoloControl: some View {
-        if session.isYoloActive {
-            Button(action: {
-                YoloMode.disengage(session: session, reason: "manual")
+        Group {
+            if session.isYoloActive {
+                disengageButton
+            } else {
+                HStack(spacing: 4) {
+                    planPickerMenu
+                    engageButton
+                }
+            }
+        }
+        .frame(width: 110, alignment: .trailing)
+    }
+
+    private var engageButton: some View {
+        Button("YOLO") {
+            if YoloMode.engage(session: session) {
                 viewModel.sessionManager.saveActiveSessions()
                 viewModel.noteInteraction()
-            }) {
-                HStack(spacing: 3) {
-                    Text("YOLO")
-                        .font(.caption.bold())
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.caption2)
-                }
             }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.small)
-            .tint(.red)
-            .frame(width: 76)
-            .help(yoloActiveHelp)
-        } else {
-            Button("YOLO") {
-                if YoloMode.engage(session: session) {
-                    viewModel.sessionManager.saveActiveSessions()
-                    viewModel.noteInteraction()
-                }
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-            .tint(yoloDisabledReasonTint)
-            .frame(width: 76)
-            .disabled(session.lastPlanPath == nil)
-            .help(yoloIdleHelp)
         }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .tint(yoloDisabledReasonTint)
+        .frame(width: 76)
+        .disabled(session.lastPlanPath == nil)
+        .help(yoloIdleHelp)
+    }
+
+    private var disengageButton: some View {
+        Button(action: {
+            YoloMode.disengage(session: session, reason: "manual")
+            viewModel.sessionManager.saveActiveSessions()
+            viewModel.noteInteraction()
+        }) {
+            HStack(spacing: 3) {
+                Text("YOLO")
+                    .font(.caption.bold())
+                Image(systemName: "xmark.circle.fill")
+                    .font(.caption2)
+            }
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        .tint(.red)
+        .frame(width: 76)
+        .help(yoloActiveHelp)
+    }
+
+    private var planPickerMenu: some View {
+        let plans = YoloMode.recentPlans()
+        return Menu {
+            if plans.isEmpty {
+                Text("No plans found")
+            } else {
+                ForEach(plans) { plan in
+                    Button {
+                        armPlan(plan.path)
+                    } label: {
+                        if plan.path == session.lastPlanPath {
+                            Label("\(plan.folder) · \(plan.filename)", systemImage: "checkmark")
+                        } else {
+                            Text("\(plan.folder) · \(plan.filename)")
+                        }
+                    }
+                }
+            }
+            Divider()
+            Button("Browse…") { browseForPlan() }
+        } label: {
+            Image(systemName: "doc.text.magnifyingglass")
+        }
+        .menuStyle(.button)
+        .menuIndicator(.hidden)
+        .controlSize(.small)
+        .frame(width: 30)
+        .help("Pick the plan that gates YOLO for this session (overrides auto-detect).")
+    }
+
+    private func armPlan(_ path: String) {
+        session.lastPlanPath = path
+        viewModel.sessionManager.saveActiveSessions()
+        viewModel.noteInteraction()
+    }
+
+    private func browseForPlan() {
+        let panel = NSOpenPanel()
+        if let markdown = UTType(filenameExtension: "md") {
+            panel.allowedContentTypes = [markdown]
+        }
+        panel.allowsMultipleSelection = false
+        panel.title = "Select Plan for YOLO"
+        panel.message = "Pick a plan markdown file to gate this session's YOLO mode."
+        panel.directoryURL = YoloMode.plansDirectory()
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        armPlan(url.path)
     }
 
     private var yoloActiveHelp: String {
@@ -475,7 +539,7 @@ private struct SessionRow: View {
             let name = (plan as NSString).lastPathComponent
             return "Engage YOLO — tracking \(name). Bypasses user rules; halts on plan changes or protected-path access."
         }
-        return "No plan captured yet — run /propose first."
+        return "No plan armed — pick one from the menu, or run /propose."
     }
 
     private var yoloDisabledReasonTint: Color {

--- a/Tests/GavelTests/YoloModeTests.swift
+++ b/Tests/GavelTests/YoloModeTests.swift
@@ -180,4 +180,63 @@ final class YoloModeTests: XCTestCase {
         XCTAssertFalse(YoloMode.isPlanPath("\(home)/.claude/settings.json"))
         XCTAssertFalse(YoloMode.isPlanPath("/tmp/whatever.md"))
     }
+
+    // MARK: - recentPlans
+
+    func testRecentPlansListsOneLevelMarkdownNewestFirst() throws {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("plans-enum-\(UUID().uuidString)", isDirectory: true)
+        let alpha = base.appendingPathComponent("alpha", isDirectory: true)
+        let beta = base.appendingPathComponent("beta", isDirectory: true)
+        let nested = alpha.appendingPathComponent("nested", isDirectory: true)
+        try fm.createDirectory(at: nested, withIntermediateDirectories: true)
+        try fm.createDirectory(at: beta, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: base) }
+
+        let older = alpha.appendingPathComponent("old-plan.md")
+        let newer = beta.appendingPathComponent("new-plan.md")
+        try "old".write(to: older, atomically: true, encoding: .utf8)
+        try "new".write(to: newer, atomically: true, encoding: .utf8)
+        try "x".write(to: alpha.appendingPathComponent("notes.txt"), atomically: true, encoding: .utf8)
+        try "x".write(to: nested.appendingPathComponent("buried.md"), atomically: true, encoding: .utf8)
+        try "x".write(to: base.appendingPathComponent("loose.md"), atomically: true, encoding: .utf8)
+        try fm.setAttributes([.modificationDate: Date(timeIntervalSince1970: 1000)], ofItemAtPath: older.path)
+        try fm.setAttributes([.modificationDate: Date()], ofItemAtPath: newer.path)
+
+        let plans = YoloMode.recentPlans(in: base)
+        XCTAssertEqual(plans.map { $0.filename }, ["new-plan.md", "old-plan.md"], "newest-modified first, one level only")
+        XCTAssertEqual(plans.first?.folder, "beta")
+        XCTAssertFalse(plans.contains { $0.filename == "notes.txt" }, "non-.md excluded")
+        XCTAssertFalse(plans.contains { $0.filename == "buried.md" }, "deeper than one level excluded")
+        XCTAssertFalse(plans.contains { $0.filename == "loose.md" }, "flat plans/*.md excluded")
+    }
+
+    func testRecentPlansHonorsLimit() throws {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("plans-limit-\(UUID().uuidString)", isDirectory: true)
+        let folder = base.appendingPathComponent("proj", isDirectory: true)
+        try fm.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: base) }
+        for i in 0..<5 {
+            try "p".write(to: folder.appendingPathComponent("plan-\(i).md"), atomically: true, encoding: .utf8)
+        }
+        XCTAssertEqual(YoloMode.recentPlans(in: base, limit: 3).count, 3)
+    }
+
+    func testRecentPlansEmptyWhenDirMissing() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("does-not-exist-\(UUID().uuidString)", isDirectory: true)
+        XCTAssertTrue(YoloMode.recentPlans(in: missing).isEmpty)
+    }
+
+    func testEngageAfterManualArmFreezesPlanAndHaltsOnWrite() {
+        session.lastPlanPath = planPath
+        XCTAssertTrue(YoloMode.engage(session: session))
+        waitForMain()
+        XCTAssertEqual(session.yoloPlanPath, planPath, "manually-armed path is frozen identically to auto-detect")
+        XCTAssertEqual(
+            YoloMode.shouldHalt(session: session, payload: payload(tool: "Write", filePath: planPath)),
+            "plan modified by agent"
+        )
+    }
 }


### PR DESCRIPTION
## Problem

YOLO mode's plan discovery is **capture-on-write**: `session.lastPlanPath` is only stamped when an approved Write/Edit/MultiEdit lands on `~/.claude/plans/<folder>/*.md` **for the session whose process wrote it**. So YOLO stays disabled whenever the plan was authored in a *different* session/PID — a fresh `claude`, a `--resume`, a subagent, or a separate `/propose` terminal. The plan exists on disk, but the executing session never wrote it, so the button is stuck.

## Fix

Add a manual plan picker to the idle YOLO control:

- A **menu** listing recent plans under `~/.claude/plans/<folder>/*.md`, newest-modified first, labeled `folder · filename`, with a checkmark on the currently-armed plan.
- A **Browse…** fallback (`NSOpenPanel` scoped to `~/.claude/plans/`, `.md`-filtered) for anything not in the list.
- Selecting **arms** `session.lastPlanPath`; the existing YOLO button then engages with the *same* freeze-path-and-hash + halt-on-modification semantics. Two-step and orthogonal — the engage path is unchanged.
- The picker is **always available**, so a wrong auto-detected plan can be overridden.

Capture-on-write, `engage`/`shouldHalt`/`disengage`, and the lock-guarded sync flag are untouched — the picker only writes the `lastPlanPath` field that already existed.

## Tests

`Tests/GavelTests/YoloModeTests.swift` — 4 new:
- `recentPlans` enumeration: one-level `.md` only, newest-first, excludes non-`.md`/deeper-nested/flat files
- limit honored; empty when dir missing
- engage-after-manual-arm freezes the plan and halts on a Write to it (parity with auto-detect)

Full suite: 21/21 `YoloModeTests` pass; build clean. (3 unrelated pre-existing `ResumeCommandTests` failures exist on `main` — not touched here.)

## Manual verification

`just dev-daemon` — picker lists plans, arming enables the YOLO button, engage + halt-on-plan-change behave as before.