### PR TITLE
chore(resume): align ResumeCommandTests with shipped resume command

### DIFF
--- a/Tests/GavelTests/ResumeCommandTests.swift
+++ b/Tests/GavelTests/ResumeCommandTests.swift
@@ -51,12 +51,12 @@ final class ResumeCommandTests: XCTestCase {
             sessionId: "abc-def-123",
             cwd: "/Users/jay/project"
         )
-        XCTAssertEqual(cmd, "cd '/Users/jay/project' && claude --name 12345 --resume abc-def-123")
+        XCTAssertEqual(cmd, "cd '/Users/jay/project' && claude --resume abc-def-123")
     }
 
     func testBuildWithoutCwdOmitsCdPrefix() {
         let cmd = ResumeCommand.build(pid: 42, sessionId: "sid-9", cwd: nil)
-        XCTAssertEqual(cmd, "claude --name 42 --resume sid-9")
+        XCTAssertEqual(cmd, "claude --resume sid-9")
     }
 
     func testBuildEscapesCwdSpaces() {
@@ -65,7 +65,7 @@ final class ResumeCommandTests: XCTestCase {
             sessionId: "s",
             cwd: "/Users/jay/My Projects"
         )
-        XCTAssertEqual(cmd, "cd '/Users/jay/My Projects' && claude --name 1 --resume s")
+        XCTAssertEqual(cmd, "cd '/Users/jay/My Projects' && claude --resume s")
     }
 
     func testBuildCodexAgentEmitsCodexResume() {


### PR DESCRIPTION
## Problem

Three `ResumeCommandTests` build() cases fail on `main`:

```
testBuildWithCwd, testBuildWithoutCwdOmitsCdPrefix, testBuildEscapesCwdSpaces
expected: claude --name <pid> --resume <sid>
   actual: claude --resume <sid>
```

## Root cause (not a regression)

#83 (`965c237`, *fix(resume): drop --name <pid> from clipboard command*) **deliberately** removed `--name <pid>` from `ResumeCommand.build` for the claude agent -- pasting `claude --name <pid>` makes Claude Code rewrite the resumed session's custom-title to the literal PID, clobbering the user's `/rename` value. That commit updated `ResumeCommand.swift` but **not** `ResumeCommandTests.swift`, leaving three assertions pinned to the old `--name` output. (There's no swift-test CI on PRs, so the red went unnoticed.)

## Fix

Update the three stale expected strings to the shipped behavior -- `claude --resume <sid>` (optionally `cd '<cwd>' && …`), no `--name`. **Test-only; `ResumeCommand.swift` is untouched.** The `--name`-free behavior is the intended one and stays.

## Tests

`swift test` → **324 passed, 0 failures** (was 3 failing). Codex-agent and `shellQuote` cases unchanged.