### PR TITLE
chore(ci): bump release-please-action v5 + create-github-app-token v3

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
       - name: Mint app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Run release-please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: .release-please-config.json


### PR DESCRIPTION
## Why

The `release-please` run after the **v1.14.0** tag failed with `Bad credentials` on the post-tag GraphQL "Fetching releases" call ([run 26334629649](https://github.com/JaysonRawlins/claude-gavel/actions/runs/26334629649)).

**The release itself succeeded** — v1.14.0 tag, GitHub Release ("Latest"), and Homebrew tap bump all completed. Only release-please's *next* phase (opening the following release PR) failed.

**Root cause:** GitHub's [GitHub App installation-token format rollout](https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/) — installation tokens grow from ~40 to ~520 chars (brownout mid-May 2026, full cutover ~late June 2026). We mint a GitHub App token (`gavel-release-bot`) and hand it to release-please; the REST phase accepted it, the GraphQL phase didn't. Same workflow succeeded for 1.12.0/1.13.0 — consistent with the rollout reaching us now.

Our failed run also flagged that **both actions run on deprecated Node 20** (forced off **June 2, 2026**).

## Change

Bump both actions to their Node 24 majors:

| Action | From | To | Notes |
|--------|------|----|-------|
| `googleapis/release-please-action` | `v4` (v4.4.1, release-please **17.3.0**) | `v5` (release-please **17.6.0**) | only breaking change is Node 24; our `config-file`/`manifest-file`/`token` inputs are unchanged |
| `actions/create-github-app-token` | `v2` | `v3` | Node 24; its other breaking change (require `NODE_USE_ENV_PROXY` for proxies) doesn't apply — we use no proxy |

This clears the Node 20 deadline **and** moves to the newest release-please core (17.6.0) — the best available shot at handling the new token format.

## Validation caveat

`release-please.yml` only triggers on **push to main**, not on PRs — so this change **cannot be exercised by PR CI**. It can only be verified on the **next release-triggering merge** to main. If `Bad credentials` recurs after this lands, the fallbacks are: switch the token source off the App-installation token (security tradeoff vs the narrow-scoped app), or add a retry / `release-please:force-run`.

Semgrep/Socket will run on this PR (no production code touched).