### PR TITLE
feat(approval): standing commit + infra-apply checkpoints, panel label + minimize

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -12,7 +12,6 @@ final class ApprovalCoordinator: ObservableObject {
         case allow(context: String?, updatedCommand: String?, updatedInput: [String: AnyCodable]?)
         case deny(context: String?)
         case allowPatternForSession(pattern: String, context: String?, updatedCommand: String?, updatedInput: [String: AnyCodable]?)
-        /// Suppress firing prompt rule for session — covers the rule's full regex scope.
         case suppressRuleForSession(ruleId: UUID, context: String?, updatedCommand: String?, updatedInput: [String: AnyCodable]?)
         case denyPatternForSession(pattern: String, explanation: String?)
         case alwaysDenyPattern(pattern: String, isRegex: Bool, explanation: String?)
@@ -47,6 +46,8 @@ final class ApprovalCoordinator: ObservableObject {
         @Published var queueCount: Int = 0
         var pendingQueue: [PendingApproval] = []
         var panel: NSPanel?
+        /// Full-size frame captured when the panel is minimized, restored on expand.
+        var savedFrame: NSRect?
 
         init(pid: Int) { self.pid = pid }
     }

--- a/Sources/Gavel/Approval/ApprovalEngine.swift
+++ b/Sources/Gavel/Approval/ApprovalEngine.swift
@@ -6,17 +6,19 @@ import Foundation
 /// 2. Persistent DENY rules from RuleStore (block even under auto-approve)
 /// 3. Session pause state
 /// 4. User PROMPT rules (force dialog even under auto-approve)
+/// 4.5 Non-overridable built-in checkpoints — e.g. git commit (force dialog, beats allow rules)
 /// 5. Sensitive paths — gavel config, hooks, shell config (force dialog, not overridable)
 /// 6. Persistent ALLOW rules from RuleStore
-/// 7. Built-in PROMPT rules (seeded MCP exfil defaults, overridable by allow rules)
+/// 7. Overridable built-in PROMPT rules (seeded MCP exfil / infra-apply defaults, overridable by allow rules)
 /// 8. Timed auto-approve
 /// 9. Default: pass through to interactive approval
 ///
 /// Key invariants:
 /// - Deny rules ALWAYS win over auto-approve.
 /// - Sensitive paths ALWAYS force a dialog — even with a broad allow rule like `Read: *`.
-/// - Built-in prompt rules are overridable by user allow rules (Stage 6 beats Stage 7).
-/// - User prompt rules are NOT overridable by allow rules (Stage 4 beats Stage 6).
+/// - Overridable built-in prompt rules are overridable by user allow rules (Stage 6 beats Stage 7).
+/// - User prompt rules and non-overridable checkpoints are NOT overridable by allow rules
+///   (Stage 4 / 4.5 beat Stage 6).
 final class ApprovalEngine {
     let patternMatcher: PatternMatcher
     let ruleStore: RuleStore
@@ -69,6 +71,12 @@ final class ApprovalEngine {
 
         // 4. User PROMPT rules (builtIn=false) — force dialog, beats allow rules
         if let decision = ruleStore.evaluateUserPrompt(payload: payload) {
+            return decision
+        }
+
+        // 4.5 Non-overridable built-in checkpoints (e.g. git commit) — force dialog,
+        //     checked before allow rules so a broad allow rule can't silence them.
+        if let decision = ruleStore.evaluateBuiltInPromptNonOverridable(payload: payload) {
             return decision
         }
 

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// All state for the note-to-Claude field, hoisted into an ObservableObject so
@@ -67,6 +68,8 @@ struct ApprovalPanelView: View {
     @State private var editedCommand: String = ""
     @State private var editedFields: [String: String] = [:]
     @State private var isRegexMode: Bool = false
+    /// Minimized to a compact bar so the user can read the code/diff behind it.
+    @State private var isCollapsed: Bool = false
 
     /// All note-field state lives here. See `NoteFieldState` for the
     /// architectural rationale (re-render isolation + bug fix).
@@ -80,31 +83,111 @@ struct ApprovalPanelView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
+        Group {
             if let approval = sessionPanel.currentApproval {
-                toolHeader(approval)
-                if let reason = approval.triggerReason, !reason.isEmpty {
-                    triggerBanner(reason)
+                if isCollapsed {
+                    collapsedBar(approval)
+                } else {
+                    fullPanel(approval)
                 }
-                Divider()
-                toolDetails(approval)
-                Divider()
-                noteToClaudeField()
-                Divider()
-                actionBar(approval)
             } else {
                 Text("Waiting for tool calls...")
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .frame(minWidth: 560, minHeight: 300)
+        .frame(minWidth: isCollapsed ? 320 : 560, minHeight: isCollapsed ? 44 : 300)
         .onChange(of: sessionPanel.currentApproval?.timestamp) { _ in
+            setCollapsed(false)
             resetFields()
         }
         .onAppear {
             resetFields()
         }
+    }
+
+    @ViewBuilder
+    private func fullPanel(_ approval: ApprovalCoordinator.PendingApproval) -> some View {
+        VStack(spacing: 0) {
+            toolHeader(approval)
+            if let reason = approval.triggerReason, !reason.isEmpty {
+                triggerBanner(reason)
+            }
+            Divider()
+            toolDetails(approval)
+            Divider()
+            noteToClaudeField()
+            Divider()
+            actionBar(approval)
+        }
+    }
+
+    /// Compact one-line bar shown when minimized. Anchored top-right of the
+    /// screen so the code/diff behind the panel is readable. Click expand to act.
+    @ViewBuilder
+    private func collapsedBar(_ approval: ApprovalCoordinator.PendingApproval) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: iconForTool(approval.payload.toolName))
+                .foregroundColor(colorForTool(approval.payload.toolName))
+
+            if !approval.session.label.isEmpty {
+                Text(approval.session.label)
+                    .font(.headline)
+                    .lineLimit(1)
+            }
+
+            Text(approval.payload.toolName)
+                .font(.callout.bold())
+                .foregroundColor(colorForTool(approval.payload.toolName))
+
+            Text(approval.payload.command ?? approval.payload.filePath ?? "")
+                .font(.system(.caption, design: .monospaced))
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Spacer(minLength: 6)
+
+            if sessionPanel.queueCount > 0 {
+                Text("+\(sessionPanel.queueCount)")
+                    .font(.caption)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.orange.opacity(0.2))
+                    .cornerRadius(4)
+            }
+
+            Button(action: { setCollapsed(false) }) {
+                Image(systemName: "arrow.up.left.and.arrow.down.right")
+            }
+            .buttonStyle(.borderless)
+            .help("Expand to review and decide")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    /// Minimize/restore the panel. Collapsing shrinks the NSPanel to a corner bar
+    /// and stashes the full frame; expanding restores it.
+    private func setCollapsed(_ collapsed: Bool) {
+        let wasCollapsed = isCollapsed
+        isCollapsed = collapsed
+        guard let panel = sessionPanel.panel else { return }
+        if collapsed {
+            sessionPanel.savedFrame = panel.frame
+            panel.setFrame(collapsedRect(for: panel), display: true, animate: true)
+        } else if wasCollapsed, let saved = sessionPanel.savedFrame {
+            panel.setFrame(saved, display: true, animate: true)
+        }
+    }
+
+    private func collapsedRect(for panel: NSPanel) -> NSRect {
+        let width: CGFloat = 480
+        let height: CGFloat = 52
+        let area = panel.screen?.visibleFrame ?? panel.frame
+        return NSRect(x: area.maxX - width - 16, y: area.maxY - height - 16, width: width, height: height)
     }
 
     private func resetFields() {
@@ -143,6 +226,17 @@ struct ApprovalPanelView: View {
                 .font(.title2.bold())
                 .foregroundColor(colorForTool(approval.payload.toolName))
 
+            if !approval.session.label.isEmpty {
+                Text(approval.session.label)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(Color.accentColor.opacity(0.15))
+                    .cornerRadius(6)
+                    .help("Session label")
+            }
+
             Spacer()
 
             if sessionPanel.queueCount > 0 {
@@ -157,6 +251,12 @@ struct ApprovalPanelView: View {
             Text(verbatim: "PID \(approval.session.pid)")
                 .font(.caption.monospaced())
                 .foregroundColor(.secondary)
+
+            Button(action: { setCollapsed(true) }) {
+                Image(systemName: "arrow.down.right.and.arrow.up.left")
+            }
+            .buttonStyle(.borderless)
+            .help("Minimize to a bar so you can read the code behind it")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -15,7 +15,7 @@ final class RuleStore: ObservableObject {
     private let configPath: String
 
     /// Current seed version — bump when adding new default rules.
-    private static let seedVersion = 7
+    private static let seedVersion = 8
 
     init(configPath: String? = nil) {
         self.configPath = configPath ?? Self.defaultConfigPath
@@ -61,11 +61,23 @@ final class RuleStore: ObservableObject {
         return nil
     }
 
-    /// Built-in prompt rules — lower priority, checked after allow rules so users can override.
+    /// Overridable built-in prompt rules (MCP exfil defaults, infra-apply, scheduler) —
+    /// lower priority, checked AFTER allow rules so a user allow rule or plan overlay can override.
     func evaluateBuiltInPrompt(payload: PreToolUsePayload) -> Decision? {
-        for i in rules.indices where rules[i].verdict == .prompt && rules[i].builtIn && !rules[i].isDisabled {
+        for i in rules.indices where rules[i].verdict == .prompt && rules[i].builtIn && rules[i].overridable && !rules[i].isDisabled {
             if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
                 return Decision(verdict: .block, reason: "Default rule: \(rules[i].name)", askUser: true, triggeringRuleId: rules[i].id)
+            }
+        }
+        return nil
+    }
+
+    /// Non-overridable built-in prompt rules (hard checkpoints like git commit) —
+    /// checked BEFORE allow rules so a broad allow rule can't silence the checkpoint.
+    func evaluateBuiltInPromptNonOverridable(payload: PreToolUsePayload) -> Decision? {
+        for i in rules.indices where rules[i].verdict == .prompt && rules[i].builtIn && !rules[i].overridable && !rules[i].isDisabled {
+            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
+                return Decision(verdict: .block, reason: "Checkpoint: \(rules[i].name)", askUser: true, triggeringRuleId: rules[i].id)
             }
         }
         return nil
@@ -239,6 +251,27 @@ final class RuleStore: ObservableObject {
             builtIn: true
         ),
 
+        // ── Commit checkpoint (non-overridable: a broad allow rule can't silence it) ──
+        PersistentRule(
+            toolName: "Bash",
+            pattern: "\\bgit\\s+commit\\b",
+            isRegex: true,
+            verdict: .prompt,
+            explanation: "Commit checkpoint — review staged changes before recording history",
+            builtIn: true,
+            overridable: false
+        ),
+
+        // ── Infrastructure apply/destroy: prompt by default, plan overlay can pre-authorize ──
+        PersistentRule(
+            toolName: "Bash",
+            pattern: "\\b(cdk\\s+(deploy|destroy)|terraform\\s+(apply|destroy)|sam\\s+deploy|pulumi\\s+up|kubectl\\s+(apply|delete)|aws\\s+cloudformation\\s+deploy)\\b",
+            isRegex: true,
+            verdict: .prompt,
+            explanation: "Infrastructure apply/destroy — review the changeset/plan before mutating real resources",
+            builtIn: true
+        ),
+
         // ── Persistence-creating scheduler tools ──
         // These plant future execution that fires while the user may not be watching.
         // Prompt even under auto-approve so the user sees and confirms each one.
@@ -353,6 +386,10 @@ struct PersistentRule: Codable, Identifiable {
     let explanation: String?
     /// True for seeded default rules (MCP exfil patterns). User rules are always false.
     let builtIn: Bool
+    /// When true (default), a user allow rule or plan-policy overlay can override this
+    /// built-in prompt. False marks a hard checkpoint that allow rules can't silence
+    /// (e.g. git commit). Only consulted for builtIn prompt rules.
+    let overridable: Bool
     /// Skip this rule during evaluation when true. Persisted so the disable
     /// survives daemon restarts (so a forgotten "temporarily off" rule still
     /// surfaces in the UI rather than silently re-engaging on reboot). Toggle
@@ -371,7 +408,7 @@ struct PersistentRule: Codable, Identifiable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, toolName, pattern, isRegex, verdict, createdAt, explanation, builtIn, isDisabled
+        case id, name, toolName, pattern, isRegex, verdict, createdAt, explanation, builtIn, overridable, isDisabled
     }
 
     /// Backward-compatible decoding — isRegex, explanation, builtIn, isDisabled
@@ -387,6 +424,7 @@ struct PersistentRule: Codable, Identifiable {
         createdAt = try c.decode(Date.self, forKey: .createdAt)
         explanation = try c.decodeIfPresent(String.self, forKey: .explanation)
         builtIn = try c.decodeIfPresent(Bool.self, forKey: .builtIn) ?? false
+        overridable = try c.decodeIfPresent(Bool.self, forKey: .overridable) ?? true
         isDisabled = try c.decodeIfPresent(Bool.self, forKey: .isDisabled) ?? false
     }
 
@@ -397,6 +435,7 @@ struct PersistentRule: Codable, Identifiable {
         verdict: DecisionVerdict,
         explanation: String? = nil,
         builtIn: Bool = false,
+        overridable: Bool = true,
         isDisabled: Bool = false
     ) {
         self.id = UUID()
@@ -408,6 +447,7 @@ struct PersistentRule: Codable, Identifiable {
         self.name = "\(toolName): \(isRegex ? "/" : "")\(pattern)\(isRegex ? "/" : "")"
         self.explanation = explanation
         self.builtIn = builtIn
+        self.overridable = overridable
         self.isDisabled = isDisabled
         self._compiledRegex = Self.compilePattern(pattern, isRegex: isRegex)
     }
@@ -423,6 +463,7 @@ struct PersistentRule: Codable, Identifiable {
         self.name = "\(old.toolName): \(isRegex ? "/" : "")\(pattern)\(isRegex ? "/" : "")"
         self.explanation = explanation
         self.builtIn = old.builtIn
+        self.overridable = old.overridable
         self.isDisabled = old.isDisabled
         self._compiledRegex = Self.compilePattern(pattern, isRegex: isRegex)
     }

--- a/Tests/GavelTests/ApprovalEngineTests.swift
+++ b/Tests/GavelTests/ApprovalEngineTests.swift
@@ -71,6 +71,37 @@ final class ApprovalEngineTests: XCTestCase {
         XCTAssertEqual(decision.verdict, .allow)
     }
 
+    // MARK: - Standing checkpoints (commit + infra apply)
+
+    func testCommitPromptsUnderAutoApprove() {
+        session.autoApproveUntil = Date().addingTimeInterval(300)
+        let decision = engine.evaluate(payload: payload(command: "git commit -m \"wip\""), session: session)
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertTrue(decision.askUser)
+    }
+
+    func testInfraApplyPromptsUnderAutoApprove() {
+        session.autoApproveUntil = Date().addingTimeInterval(300)
+        for cmd in ["cdk deploy MyStack", "terraform apply", "aws cloudformation deploy --template-file t.yaml --stack-name s"] {
+            let decision = engine.evaluate(payload: payload(command: cmd), session: session)
+            XCTAssertEqual(decision.verdict, .block, "expected prompt for: \(cmd)")
+            XCTAssertTrue(decision.askUser, "expected dialog for: \(cmd)")
+        }
+    }
+
+    func testCommitCheckpointNotSilencedByAllowRule() {
+        engine.ruleStore.addRule(PersistentRule(toolName: "Bash", pattern: "git *", verdict: .allow))
+        let decision = engine.evaluate(payload: payload(command: "git commit -m \"wip\""), session: session)
+        XCTAssertEqual(decision.verdict, .block, "non-overridable commit checkpoint must beat a broad allow rule")
+        XCTAssertTrue(decision.askUser)
+    }
+
+    func testInfraApplySilencedByAllowRule() {
+        engine.ruleStore.addRule(PersistentRule(toolName: "Bash", pattern: "cdk deploy*", verdict: .allow))
+        let decision = engine.evaluate(payload: payload(command: "cdk deploy GreenfieldStack-Api"), session: session)
+        XCTAssertEqual(decision.verdict, .allow, "overridable infra prompt should be suppressible by an allow rule")
+    }
+
     // MARK: - Session Deny Rules
 
     func testSessionDenyRuleBlocks() {

--- a/Tests/GavelTests/PersistentRuleTests.swift
+++ b/Tests/GavelTests/PersistentRuleTests.swift
@@ -185,9 +185,10 @@ final class PersistentRuleTests: XCTestCase {
         let store = RuleStore(configPath: "/dev/null")
         let builtInRules = store.rules.filter { $0.builtIn }
         XCTAssertEqual(builtInRules.count, RuleStore.seededDefaults.count)
-        // v7: 5 MCP exfil + 1 Bash self-protection + 1 apply_patch self-protection
-        //     + 1 scripting + 3 sandbox escape + 2 git safety + 3 scheduler = 16
-        XCTAssertEqual(builtInRules.count, 16)
+        // v8: 5 MCP exfil + 1 Bash self-protection + 1 apply_patch self-protection
+        //     + 1 scripting + 3 sandbox escape + 2 git safety + 1 commit checkpoint
+        //     + 1 infra apply + 3 scheduler = 18
+        XCTAssertEqual(builtInRules.count, 18)
     }
 
     func testSeededRulesArePromptVerdict() {


### PR DESCRIPTION
## What

Phase A of replacing YOLO-as-bypass with standing checkpoints + a per-plan policy overlay. This PR ships only the **standing checkpoints** and two approval-modal UX additions; it does not touch the YOLO machinery (Phase B).

### Standing checkpoints (fire in every session, including under auto-approve)
- **`git commit`** → prompt, **non-overridable** — a broad allow rule like `Bash: git *` cannot silence it.
- **infra apply/destroy** (`cdk deploy|destroy`, `terraform apply|destroy`, `sam deploy`, `pulumi up`, `kubectl apply|delete`, `aws cloudformation deploy`) → prompt, **overridable** so a future plan overlay / allow rule can pre-authorize a specific command.

### Mechanics
- `PersistentRule` gains `overridable: Bool` (defaults `true`; existing `rules.json` decodes unchanged). `seedVersion` 7 → 8.
- `evaluateBuiltInPrompt` narrowed to the *overridable* tier; new `evaluateBuiltInPromptNonOverridable` for hard checkpoints.
- `ApprovalEngine` **stage 4.5** evaluates non-overridable checkpoints *before* allow rules; overridable built-ins stay after allow rules (stage 7).

### Approval modal UX
- Session **label** in the header and the collapsed bar (answers "which session is this?" at a glance).
- **Minimize** button collapses the panel to a corner bar so the code/diff behind it is readable; expand restores the saved frame. In-place collapse (not dock-miniaturize) keeps the blocking dialog on-screen so it can't be lost while the hook's worker thread waits.

## Tests
- 4 new `ApprovalEngineTests`: commit prompts under auto-approve; infra prompts under auto-approve; commit checkpoint beats an allow rule; infra prompt is suppressible by an allow rule.
- Seeded-count assertion 16 → 18.
- Full suite: 355/355 green.
- Modal UX (label + minimize) verified visually via `just dev-daemon`.

## Deferred to Phase B
- Retiring the YOLO bypass — commit/infra are still bypassed under an *active* YOLO session (throwaway path that Phase B deletes).
- Moving `aws create/update/delete-stack` from the non-overridable sensitive-path tier to the overridable tier (only meaningful once the overlay exists to authorize a specific stack op).