### PR TITLE
refactor(approval): rename YoloMode/yolo* to PlanPolicy

### DIFF
--- a/Sources/Gavel/Approval/PlanPolicy.swift
+++ b/Sources/Gavel/Approval/PlanPolicy.swift
@@ -1,22 +1,22 @@
 import CryptoKit
 import Foundation
 
-/// Plan-gated YOLO mode: bypass user-authored rules between engage and halt.
+/// Engaging a plan for a session: layer the plan's allow/deny overlay and turn
+/// on auto-approve for the inner loop. This is NOT a bypass — standing
+/// checkpoints, sensitive paths, and hard blocks still apply (see ApprovalEngine).
 ///
-/// While engaged, the approval engine takes an early branch that honors only
-/// stage-1 hard-block patterns, sensitive-path protection (which halts YOLO),
-/// and built-in scheduler prompts. User DENY / PROMPT / ALLOW / session rules
-/// are skipped. Halt triggers:
-///   1. Agent issues Write/Edit/MultiEdit on the tracked plan path.
-///   2. Plan file's sha256 differs from the hash captured at engage time.
-///   3. Plan file is deleted.
-///   4. Tool call hits matchSensitivePath (gavel-protected surface).
-///   5. Manual disengage via the UI.
+/// Engage reads the plan's ```gavel-policy block into `session.overlayRules` and
+/// captures the plan's sha256. The plan is dropped (overlay cleared + auto-approve
+/// relocked) when:
+///   1. The agent issues Write/Edit/MultiEdit on the tracked plan path.
+///   2. The plan file's sha256 differs from the hash captured at engage time.
+///   3. The plan file is deleted.
+///   4. The user drops it manually via the UI.
 ///
 /// Discovery is via `session.lastPlanPath`, stamped by HookRouter when an
 /// approved Write/Edit/MultiEdit lands on ~/.claude/plans/**/*.md. This
 /// avoids coupling to session-label/folder conventions.
-enum YoloMode {
+enum PlanPolicy {
     private static let planPathRegex: NSRegularExpression = {
         try! NSRegularExpression(pattern: #".*/\.claude/plans/[^/]+/[^/]+\.md$"#)
     }()
@@ -38,12 +38,12 @@ enum YoloMode {
         let hash = sha256(ofFileAt: path)
         let overlay = (try? String(contentsOfFile: path, encoding: .utf8)).map(PlanPolicyParser.parse) ?? []
         session.overlayRules = overlay
-        session.setYoloActive(true)
+        session.setPlanPolicyEngaged(true)
         DispatchQueue.main.async {
-            session.yoloEngagedAt = Date()
-            session.yoloPlanPath = path
-            session.yoloPlanHash = hash
-            session.yoloDisabledReason = nil
+            session.planEngagedAt = Date()
+            session.engagedPlanPath = path
+            session.engagedPlanHash = hash
+            session.planPolicyDroppedReason = nil
             session.isSubAgentInheritEnabled = true
             session.isAutoApproveEnabled = true
         }
@@ -52,7 +52,7 @@ enum YoloMode {
 
     /// Returns disengage reason or nil. Read-only — safe from any thread.
     static func shouldHalt(session: Session, payload: PreToolUsePayload) -> String? {
-        guard let trackedPath = session.yoloPlanPath else { return nil }
+        guard let trackedPath = session.engagedPlanPath else { return nil }
 
         if ["Write", "Edit", "MultiEdit"].contains(payload.toolName),
            let path = payload.filePath,
@@ -63,22 +63,22 @@ enum YoloMode {
         guard let currentHash = sha256(ofFileAt: trackedPath) else {
             return "plan deleted"
         }
-        if currentHash != session.yoloPlanHash {
+        if currentHash != session.engagedPlanHash {
             return "plan changed on disk"
         }
         return nil
     }
 
-    /// Clears YOLO state and records the reason. Posts a notification.
+    /// Clears plan-policy state and records the reason. Posts a notification.
     /// Caller is responsible for calling `SessionManager.saveActiveSessions()` after.
     static func disengage(session: Session, reason: String) {
-        session.setYoloActive(false)
+        session.setPlanPolicyEngaged(false)
         session.overlayRules = []
         DispatchQueue.main.async {
-            session.yoloEngagedAt = nil
-            session.yoloPlanPath = nil
-            session.yoloPlanHash = nil
-            session.yoloDisabledReason = reason
+            session.planEngagedAt = nil
+            session.engagedPlanPath = nil
+            session.engagedPlanHash = nil
+            session.planPolicyDroppedReason = reason
             session.isAutoApproveEnabled = false
         }
         GavelNotifications.notify(title: "Gavel — plan policy dropped", body: reason)

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -149,11 +149,11 @@ final class HookRouter {
             return
         }
 
-        // Stage 0.7: YOLO halt — agent touched the tracked plan or the plan changed.
-        // The disengage flips isYoloActive sync, so the engine call below sees normal chain.
-        // This call itself is routed to interactive dialog so the user sees the halt context.
-        if session.isYoloActive, let haltReason = YoloMode.shouldHalt(session: session, payload: payload) {
-            YoloMode.disengage(session: session, reason: haltReason)
+        // Stage 0.7: Plan invalidation — agent touched the tracked plan or the plan changed.
+        // The drop flips isPlanPolicyEngaged sync, so the engine call below sees the normal chain.
+        // This call itself is routed to interactive dialog so the user sees the drop context.
+        if session.isPlanPolicyEngaged, let haltReason = PlanPolicy.shouldHalt(session: session, payload: payload) {
+            PlanPolicy.disengage(session: session, reason: haltReason)
             sessionManager.saveActiveSessions()
             emitFeed(.system("Plan dropped: \(haltReason)", pid: session.pid, at: timestamp))
             emitFeed(.decision(badge: .block, reason: "Plan dropped: \(haltReason)", pid: session.pid, at: timestamp))
@@ -175,7 +175,7 @@ final class HookRouter {
             return
         }
 
-        // Stage 1: Check engine (dangerous patterns, persistent deny/allow, pause, YOLO branch)
+        // Stage 1: Check engine (dangerous patterns, deny/allow, pause, plan overlay)
         let engineDecision = approvalEngine.evaluate(payload: payload, session: session)
         if engineDecision.verdict == .block {
             if engineDecision.askUser {
@@ -229,11 +229,11 @@ final class HookRouter {
                 return
             }
         }
-        // Persistent allow rules and the YOLO branch both return allow with a reason.
-        // Yolo gets its own badge so the feed and the UI distinguish "user rule allowed" from "yolo bypassed".
+        // Persistent allow rules and plan overlay-allow both return allow with a reason.
+        // Plan-authorized allows get the PLAN badge so the feed distinguishes them from a plain user-rule allow.
         if engineDecision.reason != nil {
             session.stats.incrementAllow()
-            let badge: DecisionBadge = session.isYoloActive ? .yolo : .allow
+            let badge: DecisionBadge = session.isPlanPolicyEngaged ? .planPolicy : .allow
             emitFeed(.decision(badge: badge, reason: engineDecision.reason, pid: session.pid, at: timestamp))
             sendResponse(engineDecision, payload: payload, session: session, respond: respond)
             return
@@ -318,13 +318,13 @@ final class HookRouter {
         respond: ((Data) -> Void)?
     ) {
         // Capture-on-write: stamp lastPlanPath whenever an approved Write/Edit/MultiEdit
-        // lands on ~/.claude/plans/**/*.md. Decouples YOLO plan discovery from session
+        // lands on ~/.claude/plans/**/*.md. Decouples plan discovery from session
         // labels and folder conventions — propose can write the plan anywhere.
         if decision.verdict == .allow,
            let payload = payload, let session = session,
            ["Write", "Edit", "MultiEdit"].contains(payload.toolName),
            let path = payload.filePath,
-           YoloMode.isPlanPath(path) {
+           PlanPolicy.isPlanPath(path) {
             DispatchQueue.main.async {
                 session.lastPlanPath = path
             }

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -231,10 +231,10 @@ final class SessionManager: ObservableObject {
         let endedAt: Date?
         let agent: AgentKind?
         let lastPlanPath: String?
-        let yoloEngagedAt: Date?
-        let yoloPlanPath: String?
-        let yoloPlanHash: String?
-        let yoloDisabledReason: String?
+        let planEngagedAt: Date?
+        let engagedPlanPath: String?
+        let engagedPlanHash: String?
+        let planPolicyDroppedReason: String?
     }
 
     private struct PersistedState: Codable {
@@ -275,10 +275,10 @@ final class SessionManager: ObservableObject {
             endedAt: session.endedAt,
             agent: session.agent,
             lastPlanPath: session.lastPlanPath,
-            yoloEngagedAt: session.yoloEngagedAt,
-            yoloPlanPath: session.yoloPlanPath,
-            yoloPlanHash: session.yoloPlanHash,
-            yoloDisabledReason: session.yoloDisabledReason
+            planEngagedAt: session.planEngagedAt,
+            engagedPlanPath: session.engagedPlanPath,
+            engagedPlanHash: session.engagedPlanHash,
+            planPolicyDroppedReason: session.planPolicyDroppedReason
         )
     }
 
@@ -321,38 +321,38 @@ final class SessionManager: ObservableObject {
             session.label = label
         }
         session.lastPlanPath = snap.lastPlanPath
-        rehydrateYolo(snap, into: session)
+        rehydratePlanPolicy(snap, into: session)
         sessions[snap.pid] = session
         tryJsonlSeed(session: session)
     }
 
-    /// Restore YOLO state across daemon restarts. If the plan's content drifted
-    /// while we were down, disengage on load with a clear reason — preserves the
-    /// invariant that an engaged YOLO session always reflects the original plan.
-    private func rehydrateYolo(_ snap: PersistedSession, into session: Session) {
-        guard let engagedAt = snap.yoloEngagedAt,
-              let path = snap.yoloPlanPath,
-              let originalHash = snap.yoloPlanHash else {
-            session.yoloDisabledReason = snap.yoloDisabledReason
+    /// Restore plan-policy state across daemon restarts. If the plan's content drifted
+    /// while we were down, drop it on load with a clear reason — preserves the
+    /// invariant that an engaged session always reflects the original plan.
+    private func rehydratePlanPolicy(_ snap: PersistedSession, into session: Session) {
+        guard let engagedAt = snap.planEngagedAt,
+              let path = snap.engagedPlanPath,
+              let originalHash = snap.engagedPlanHash else {
+            session.planPolicyDroppedReason = snap.planPolicyDroppedReason
             return
         }
-        let currentHash = YoloMode.sha256(ofFileAt: path)
+        let currentHash = PlanPolicy.sha256(ofFileAt: path)
         if currentHash == nil {
-            session.yoloDisabledReason = "plan deleted during daemon restart"
+            session.planPolicyDroppedReason = "plan deleted during daemon restart"
             return
         }
         if currentHash != originalHash {
-            session.yoloDisabledReason = "plan changed during daemon restart"
+            session.planPolicyDroppedReason = "plan changed during daemon restart"
             return
         }
-        session.yoloEngagedAt = engagedAt
-        session.yoloPlanPath = path
-        session.yoloPlanHash = originalHash
-        session.yoloDisabledReason = snap.yoloDisabledReason
+        session.planEngagedAt = engagedAt
+        session.engagedPlanPath = path
+        session.engagedPlanHash = originalHash
+        session.planPolicyDroppedReason = snap.planPolicyDroppedReason
         if let text = try? String(contentsOfFile: path, encoding: .utf8) {
             session.overlayRules = PlanPolicyParser.parse(text)
         }
-        session.setYoloActive(true)
+        session.setPlanPolicyEngaged(true)
     }
 
     private func rehydrateTombstone(_ snap: PersistedSession, sessionId: String) {

--- a/Sources/Gavel/Models/Decision.swift
+++ b/Sources/Gavel/Models/Decision.swift
@@ -85,7 +85,7 @@ enum DecisionBadge: String {
     case allow = "ALLOW"
     case autoApprove = "AUTO"
     case sandbox = "SANDBOX"
-    case yolo = "PLAN"
+    case planPolicy = "PLAN"
     case block = "BLOCK"
     case paused = "PAUSED"
 }

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -38,43 +38,43 @@ final class Session: ObservableObject, Identifiable {
     @Published var suppressedRuleIds: Set<UUID> = []
 
     /// Absolute path of the most recent approved Write/Edit/MultiEdit that landed
-    /// under ~/.claude/plans/**/*.md. Captured by HookRouter post-decision so YOLO
-    /// can find the plan without depending on session-label/folder conventions.
+    /// under ~/.claude/plans/**/*.md. Captured by HookRouter post-decision so plan
+    /// engage can find the plan without depending on session-label/folder conventions.
     @Published var lastPlanPath: String?
 
-    // YOLO mode — bypasses user rules between engage and halt. See YoloMode.swift.
-    // Worker threads gate the yolo branch on `isYoloActive`, which is backed by a
-    // lock-protected non-@Published flag for synchronous visibility. The matching
-    // @Published fields below carry UI-display state and are updated on main.
-    @Published var yoloEngagedAt: Date?
+    // Plan policy — overlay + auto-approve while a plan is engaged. See PlanPolicy.swift.
+    // Worker threads read `isPlanPolicyEngaged`, backed by a lock-protected non-@Published
+    // flag for synchronous visibility. The matching @Published fields below carry
+    // UI-display state and are updated on main.
+    @Published var planEngagedAt: Date?
     /// Frozen at engage time. New plan writes update lastPlanPath but NOT this.
-    @Published var yoloPlanPath: String?
-    @Published var yoloPlanHash: String?
-    @Published var yoloDisabledReason: String?
+    @Published var engagedPlanPath: String?
+    @Published var engagedPlanHash: String?
+    @Published var planPolicyDroppedReason: String?
 
-    private var _yoloActive: Bool = false
-    private let yoloLock = NSLock()
+    private var _planPolicyEngaged: Bool = false
+    private let planPolicyLock = NSLock()
 
-    var isYoloActive: Bool {
-        yoloLock.lock()
-        defer { yoloLock.unlock() }
-        return _yoloActive
+    var isPlanPolicyEngaged: Bool {
+        planPolicyLock.lock()
+        defer { planPolicyLock.unlock() }
+        return _planPolicyEngaged
     }
 
-    func setYoloActive(_ value: Bool) {
-        yoloLock.lock()
-        _yoloActive = value
-        yoloLock.unlock()
+    func setPlanPolicyEngaged(_ value: Bool) {
+        planPolicyLock.lock()
+        _planPolicyEngaged = value
+        planPolicyLock.unlock()
     }
 
     private var _overlayRules: [PlanPolicyRule] = []
 
     /// Plan-declared allow/deny rules, layered while a plan is engaged. Guarded by
-    /// `yoloLock` because it's set on engage (main) and read by the socket worker
+    /// `planPolicyLock` because it's set on engage (main) and read by the socket worker
     /// on every PreToolUse. Empty when no plan is engaged.
     var overlayRules: [PlanPolicyRule] {
-        get { yoloLock.lock(); defer { yoloLock.unlock() }; return _overlayRules }
-        set { yoloLock.lock(); _overlayRules = newValue; yoloLock.unlock() }
+        get { planPolicyLock.lock(); defer { planPolicyLock.unlock() }; return _overlayRules }
+        set { planPolicyLock.lock(); _overlayRules = newValue; planPolicyLock.unlock() }
     }
 
     // Worker-mutable state. NOT @Published on purpose — both are touched on
@@ -130,12 +130,12 @@ final class Session: ObservableObject, Identifiable {
         autoApproveUntil = nil
         sessionRules.removeAll()
         suppressedRuleIds.removeAll()
-        setYoloActive(false)
+        setPlanPolicyEngaged(false)
         overlayRules = []
-        yoloEngagedAt = nil
-        yoloPlanPath = nil
-        yoloPlanHash = nil
-        yoloDisabledReason = nil
+        planEngagedAt = nil
+        engagedPlanPath = nil
+        engagedPlanHash = nil
+        planPolicyDroppedReason = nil
     }
 
     /// Check if a tool call matches any session allow rule.

--- a/Sources/Gavel/Monitor/FeedView.swift
+++ b/Sources/Gavel/Monitor/FeedView.swift
@@ -108,7 +108,7 @@ struct FeedRow: View {
         case .allow: return .green
         case .autoApprove: return .purple
         case .sandbox: return .orange
-        case .yolo: return .red
+        case .planPolicy: return .red
         case .block: return .red
         case .paused: return .yellow
         }

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -391,7 +391,7 @@ private struct SessionRow: View {
             }
             .frame(width: 76, alignment: .leading)
 
-            yoloControl
+            planControl
 
             Button("Prompt") {
                 viewModel.promptSession(session)
@@ -428,9 +428,9 @@ private struct SessionRow: View {
     }
 
     @ViewBuilder
-    private var yoloControl: some View {
+    private var planControl: some View {
         Group {
-            if session.isYoloActive {
+            if session.isPlanPolicyEngaged {
                 disengageButton
             } else {
                 HStack(spacing: 4) {
@@ -444,22 +444,22 @@ private struct SessionRow: View {
 
     private var engageButton: some View {
         Button("Plan") {
-            if YoloMode.engage(session: session) {
+            if PlanPolicy.engage(session: session) {
                 viewModel.sessionManager.saveActiveSessions()
                 viewModel.noteInteraction()
             }
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
-        .tint(yoloDisabledReasonTint)
+        .tint(planPolicyDroppedReasonTint)
         .frame(width: 76)
         .disabled(session.lastPlanPath == nil)
-        .help(yoloIdleHelp)
+        .help(planIdleHelp)
     }
 
     private var disengageButton: some View {
         Button(action: {
-            YoloMode.disengage(session: session, reason: "manual")
+            PlanPolicy.disengage(session: session, reason: "manual")
             viewModel.sessionManager.saveActiveSessions()
             viewModel.noteInteraction()
         }) {
@@ -474,11 +474,11 @@ private struct SessionRow: View {
         .controlSize(.small)
         .tint(.red)
         .frame(width: 76)
-        .help(yoloActiveHelp)
+        .help(planActiveHelp)
     }
 
     private var planPickerMenu: some View {
-        let plans = YoloMode.recentPlans()
+        let plans = PlanPolicy.recentPlans()
         return Menu {
             if plans.isEmpty {
                 Text("No plans found")
@@ -521,18 +521,18 @@ private struct SessionRow: View {
         panel.allowsMultipleSelection = false
         panel.title = "Select Plan to Engage"
         panel.message = "Pick a plan markdown file to engage for this session."
-        panel.directoryURL = YoloMode.plansDirectory()
+        panel.directoryURL = PlanPolicy.plansDirectory()
         guard panel.runModal() == .OK, let url = panel.url else { return }
         armPlan(url.path)
     }
 
-    private var yoloActiveHelp: String {
-        let planName = (session.yoloPlanPath as NSString?)?.lastPathComponent ?? "unknown plan"
+    private var planActiveHelp: String {
+        let planName = (session.engagedPlanPath as NSString?)?.lastPathComponent ?? "unknown plan"
         return "Plan engaged — \(planName). Auto-approve is on for routine work; commit/infra still prompt and the plan's allow/deny apply. Click to drop."
     }
 
-    private var yoloIdleHelp: String {
-        if let reason = session.yoloDisabledReason {
+    private var planIdleHelp: String {
+        if let reason = session.planPolicyDroppedReason {
             return "Plan dropped: \(reason). Click to re-engage with the current plan."
         }
         if let plan = session.lastPlanPath {
@@ -542,8 +542,8 @@ private struct SessionRow: View {
         return "No plan armed — pick one from the menu, or run /propose."
     }
 
-    private var yoloDisabledReasonTint: Color {
-        session.yoloDisabledReason != nil ? .orange : .red
+    private var planPolicyDroppedReasonTint: Color {
+        session.planPolicyDroppedReason != nil ? .orange : .red
     }
 
     /// Width must match actionCluster so live and dead rows align.

--- a/Tests/GavelTests/PlanPolicyApprovalEngineTests.swift
+++ b/Tests/GavelTests/PlanPolicyApprovalEngineTests.swift
@@ -5,7 +5,7 @@ import XCTest
 /// Engaging a plan is NOT a bypass: user rules, standing checkpoints, sensitive
 /// paths, and hard blocks all still apply. The plan layers an allow/deny overlay
 /// and turns on auto-approve for the inner loop.
-final class YoloApprovalEngineTests: XCTestCase {
+final class PlanPolicyApprovalEngineTests: XCTestCase {
     var engine: ApprovalEngine!
     var ruleStore: RuleStore!
     var session: Session!
@@ -14,19 +14,19 @@ final class YoloApprovalEngineTests: XCTestCase {
     var tmpDir: URL!
 
     override func setUp() {
-        ruleStorePath = NSTemporaryDirectory() + "yolo-engine-\(UUID().uuidString).json"
+        ruleStorePath = NSTemporaryDirectory() + "plan-engine-\(UUID().uuidString).json"
         ruleStore = RuleStore(configPath: ruleStorePath)
         engine = ApprovalEngine(patternMatcher: PatternMatcher(), ruleStore: ruleStore)
 
         tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(".claude/plans/yolo-eng-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent(".claude/plans/plan-eng-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
         planPath = tmpDir.appendingPathComponent("plan.md").path
         try? "# plan\n".write(toFile: planPath, atomically: true, encoding: .utf8)
 
         session = Session(pid: 99999)
         session.lastPlanPath = planPath
-        YoloMode.engage(session: session)
+        PlanPolicy.engage(session: session)
         drainMain()
     }
 
@@ -49,8 +49,8 @@ final class YoloApprovalEngineTests: XCTestCase {
     private func engageWithPolicy(_ lines: [String]) {
         let block = "```gavel-policy\n" + lines.joined(separator: "\n") + "\n```\n"
         try? ("# plan\n\n" + block).write(toFile: planPath, atomically: true, encoding: .utf8)
-        YoloMode.disengage(session: session, reason: "re-engage")
-        YoloMode.engage(session: session)
+        PlanPolicy.disengage(session: session, reason: "re-engage")
+        PlanPolicy.engage(session: session)
         drainMain()
     }
 
@@ -64,14 +64,14 @@ final class YoloApprovalEngineTests: XCTestCase {
     // MARK: - Engaging a plan turns on / relocks auto-approve
 
     func testEngageEnablesAutoApprove() {
-        XCTAssertTrue(session.isYoloActive)
+        XCTAssertTrue(session.isPlanPolicyEngaged)
         XCTAssertTrue(session.isAutoApproveEnabled, "engaging a plan turns on auto-approve for the inner loop")
     }
 
     func testDisengageRelocksAutoApprove() {
-        YoloMode.disengage(session: session, reason: "test")
+        PlanPolicy.disengage(session: session, reason: "test")
         drainMain()
-        XCTAssertFalse(session.isYoloActive)
+        XCTAssertFalse(session.isPlanPolicyEngaged)
         XCTAssertFalse(session.isAutoApproveEnabled, "dropping the plan relocks auto-approve (fail-safe)")
     }
 
@@ -106,7 +106,7 @@ final class YoloApprovalEngineTests: XCTestCase {
         let decision = engine.evaluate(payload: PreToolUsePayload(toolName: "CronCreate", toolInput: input), session: session)
         XCTAssertEqual(decision.verdict, .block)
         XCTAssertTrue(decision.askUser)
-        XCTAssertTrue(session.isYoloActive, "scheduler prompt doesn't drop the plan")
+        XCTAssertTrue(session.isPlanPolicyEngaged, "scheduler prompt doesn't drop the plan")
     }
 
     // MARK: - Standing commit checkpoint can't be silenced by the overlay
@@ -205,7 +205,7 @@ final class YoloApprovalEngineTests: XCTestCase {
     // MARK: - Normal chain when no plan is engaged
 
     func testNormalChainWhenPlanDropped() {
-        YoloMode.disengage(session: session, reason: "test")
+        PlanPolicy.disengage(session: session, reason: "test")
         drainMain()
         let decision = engine.evaluate(payload: payload(command: "ls"), session: session)
         XCTAssertEqual(decision.verdict, .allow)

--- a/Tests/GavelTests/PlanPolicyTests.swift
+++ b/Tests/GavelTests/PlanPolicyTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import Gavel
 
-final class YoloModeTests: XCTestCase {
+final class PlanPolicyTests: XCTestCase {
     var session: Session!
     var tmpDir: URL!
     var planPath: String!
@@ -9,7 +9,7 @@ final class YoloModeTests: XCTestCase {
     override func setUp() {
         session = Session(pid: 12345)
         tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(".claude/plans/yolo-test-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent(".claude/plans/plan-policy-test-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
         planPath = tmpDir.appendingPathComponent("2026-05-21_plan.md").path
         try? "# Initial plan\n".write(toFile: planPath, atomically: true, encoding: .utf8)
@@ -37,14 +37,14 @@ final class YoloModeTests: XCTestCase {
     // MARK: - canEngage / engage
 
     func testCanEngageReturnsFalseWhenNoPlan() {
-        let (ok, reason) = YoloMode.canEngage(session: session)
+        let (ok, reason) = PlanPolicy.canEngage(session: session)
         XCTAssertFalse(ok)
         XCTAssertNotNil(reason)
     }
 
     func testCanEngageReturnsTrueWhenPlanExists() {
         session.lastPlanPath = planPath
-        let (ok, reason) = YoloMode.canEngage(session: session)
+        let (ok, reason) = PlanPolicy.canEngage(session: session)
         XCTAssertTrue(ok)
         XCTAssertNil(reason)
     }
@@ -52,89 +52,89 @@ final class YoloModeTests: XCTestCase {
     func testCanEngageReturnsFalseWhenPlanFileDeleted() {
         session.lastPlanPath = planPath
         try? FileManager.default.removeItem(atPath: planPath)
-        let (ok, reason) = YoloMode.canEngage(session: session)
+        let (ok, reason) = PlanPolicy.canEngage(session: session)
         XCTAssertFalse(ok)
         XCTAssertNotNil(reason)
     }
 
     func testEngageCapturesPathAndHashAndFlipsSyncFlag() {
         session.lastPlanPath = planPath
-        XCTAssertTrue(YoloMode.engage(session: session))
-        XCTAssertTrue(session.isYoloActive, "sync flag must flip immediately on engage")
+        XCTAssertTrue(PlanPolicy.engage(session: session))
+        XCTAssertTrue(session.isPlanPolicyEngaged, "sync flag must flip immediately on engage")
         waitForMain()
-        XCTAssertEqual(session.yoloPlanPath, planPath)
-        XCTAssertNotNil(session.yoloPlanHash)
-        XCTAssertNotNil(session.yoloEngagedAt)
+        XCTAssertEqual(session.engagedPlanPath, planPath)
+        XCTAssertNotNil(session.engagedPlanHash)
+        XCTAssertNotNil(session.planEngagedAt)
         XCTAssertTrue(session.isSubAgentInheritEnabled, "engage opts into sub-agent inheritance")
     }
 
     func testEngageFailsWithoutPlan() {
-        XCTAssertFalse(YoloMode.engage(session: session))
-        XCTAssertFalse(session.isYoloActive)
+        XCTAssertFalse(PlanPolicy.engage(session: session))
+        XCTAssertFalse(session.isPlanPolicyEngaged)
     }
 
     // MARK: - shouldHalt
 
     func testShouldHaltReturnsNilWhenNotEngaged() {
-        let result = YoloMode.shouldHalt(session: session, payload: payload(tool: "Write", filePath: planPath))
+        let result = PlanPolicy.shouldHalt(session: session, payload: payload(tool: "Write", filePath: planPath))
         XCTAssertNil(result)
     }
 
     func testShouldHaltOnWriteToTrackedPlan() {
         session.lastPlanPath = planPath
-        YoloMode.engage(session: session)
+        PlanPolicy.engage(session: session)
         waitForMain()
-        let result = YoloMode.shouldHalt(session: session, payload: payload(tool: "Write", filePath: planPath))
+        let result = PlanPolicy.shouldHalt(session: session, payload: payload(tool: "Write", filePath: planPath))
         XCTAssertEqual(result, "plan modified by agent")
     }
 
     func testShouldHaltOnEditToTrackedPlan() {
         session.lastPlanPath = planPath
-        YoloMode.engage(session: session)
+        PlanPolicy.engage(session: session)
         waitForMain()
-        let result = YoloMode.shouldHalt(session: session, payload: payload(tool: "Edit", filePath: planPath))
+        let result = PlanPolicy.shouldHalt(session: session, payload: payload(tool: "Edit", filePath: planPath))
         XCTAssertEqual(result, "plan modified by agent")
     }
 
     func testShouldHaltOnMultiEditToTrackedPlan() {
         session.lastPlanPath = planPath
-        YoloMode.engage(session: session)
+        PlanPolicy.engage(session: session)
         waitForMain()
-        let result = YoloMode.shouldHalt(session: session, payload: payload(tool: "MultiEdit", filePath: planPath))
+        let result = PlanPolicy.shouldHalt(session: session, payload: payload(tool: "MultiEdit", filePath: planPath))
         XCTAssertEqual(result, "plan modified by agent")
     }
 
     func testReadOnTrackedPlanDoesNotHalt() {
         session.lastPlanPath = planPath
-        YoloMode.engage(session: session)
+        PlanPolicy.engage(session: session)
         waitForMain()
-        let result = YoloMode.shouldHalt(session: session, payload: payload(tool: "Read", filePath: planPath))
+        let result = PlanPolicy.shouldHalt(session: session, payload: payload(tool: "Read", filePath: planPath))
         XCTAssertNil(result)
     }
 
     func testUnrelatedToolCallDoesNotHalt() {
         session.lastPlanPath = planPath
-        YoloMode.engage(session: session)
+        PlanPolicy.engage(session: session)
         waitForMain()
-        let result = YoloMode.shouldHalt(session: session, payload: payload(command: "ls"))
+        let result = PlanPolicy.shouldHalt(session: session, payload: payload(command: "ls"))
         XCTAssertNil(result)
     }
 
     func testShouldHaltOnHashDrift() {
         session.lastPlanPath = planPath
-        YoloMode.engage(session: session)
+        PlanPolicy.engage(session: session)
         waitForMain()
         try? "# Mutated plan\n".write(toFile: planPath, atomically: true, encoding: .utf8)
-        let result = YoloMode.shouldHalt(session: session, payload: payload(command: "ls"))
+        let result = PlanPolicy.shouldHalt(session: session, payload: payload(command: "ls"))
         XCTAssertEqual(result, "plan changed on disk")
     }
 
     func testShouldHaltOnPlanDeleted() {
         session.lastPlanPath = planPath
-        YoloMode.engage(session: session)
+        PlanPolicy.engage(session: session)
         waitForMain()
         try? FileManager.default.removeItem(atPath: planPath)
-        let result = YoloMode.shouldHalt(session: session, payload: payload(command: "ls"))
+        let result = PlanPolicy.shouldHalt(session: session, payload: payload(command: "ls"))
         XCTAssertEqual(result, "plan deleted")
     }
 
@@ -142,43 +142,43 @@ final class YoloModeTests: XCTestCase {
 
     func testDisengageClearsStateAndSetsReason() {
         session.lastPlanPath = planPath
-        YoloMode.engage(session: session)
+        PlanPolicy.engage(session: session)
         waitForMain()
-        YoloMode.disengage(session: session, reason: "test reason")
-        XCTAssertFalse(session.isYoloActive, "sync flag must flip immediately on disengage")
+        PlanPolicy.disengage(session: session, reason: "test reason")
+        XCTAssertFalse(session.isPlanPolicyEngaged, "sync flag must flip immediately on disengage")
         waitForMain()
-        XCTAssertNil(session.yoloEngagedAt)
-        XCTAssertNil(session.yoloPlanPath)
-        XCTAssertNil(session.yoloPlanHash)
-        XCTAssertEqual(session.yoloDisabledReason, "test reason")
+        XCTAssertNil(session.planEngagedAt)
+        XCTAssertNil(session.engagedPlanPath)
+        XCTAssertNil(session.engagedPlanHash)
+        XCTAssertEqual(session.planPolicyDroppedReason, "test reason")
     }
 
-    func testRevokeAutoApproveClearsYoloIncludingReason() {
+    func testRevokeAutoApproveClearsPlanPolicyIncludingReason() {
         session.lastPlanPath = planPath
-        YoloMode.engage(session: session)
+        PlanPolicy.engage(session: session)
         waitForMain()
-        YoloMode.disengage(session: session, reason: "halt")
+        PlanPolicy.disengage(session: session, reason: "halt")
         waitForMain()
-        XCTAssertEqual(session.yoloDisabledReason, "halt")
+        XCTAssertEqual(session.planPolicyDroppedReason, "halt")
         session.revokeAutoApprove()
-        XCTAssertNil(session.yoloDisabledReason, "revoke is a full reset — reason cleared too")
-        XCTAssertFalse(session.isYoloActive)
+        XCTAssertNil(session.planPolicyDroppedReason, "revoke is a full reset — reason cleared too")
+        XCTAssertFalse(session.isPlanPolicyEngaged)
     }
 
     // MARK: - isPlanPath
 
     func testIsPlanPathMatchesStandardPlan() {
         let home = NSHomeDirectory()
-        XCTAssertTrue(YoloMode.isPlanPath("\(home)/.claude/plans/yolo-mode/2026-05-21_plan.md"))
-        XCTAssertTrue(YoloMode.isPlanPath("\(home)/.claude/plans/anything/whatever.md"))
+        XCTAssertTrue(PlanPolicy.isPlanPath("\(home)/.claude/plans/plan-mode/2026-05-21_plan.md"))
+        XCTAssertTrue(PlanPolicy.isPlanPath("\(home)/.claude/plans/anything/whatever.md"))
     }
 
     func testIsPlanPathRejectsNonPlanPaths() {
         let home = NSHomeDirectory()
-        XCTAssertFalse(YoloMode.isPlanPath("\(home)/.claude/plans/foo.md"), "must be in a sub-folder")
-        XCTAssertFalse(YoloMode.isPlanPath("\(home)/.claude/plans/folder/file.txt"), "must be .md")
-        XCTAssertFalse(YoloMode.isPlanPath("\(home)/.claude/settings.json"))
-        XCTAssertFalse(YoloMode.isPlanPath("/tmp/whatever.md"))
+        XCTAssertFalse(PlanPolicy.isPlanPath("\(home)/.claude/plans/foo.md"), "must be in a sub-folder")
+        XCTAssertFalse(PlanPolicy.isPlanPath("\(home)/.claude/plans/folder/file.txt"), "must be .md")
+        XCTAssertFalse(PlanPolicy.isPlanPath("\(home)/.claude/settings.json"))
+        XCTAssertFalse(PlanPolicy.isPlanPath("/tmp/whatever.md"))
     }
 
     // MARK: - recentPlans
@@ -203,7 +203,7 @@ final class YoloModeTests: XCTestCase {
         try fm.setAttributes([.modificationDate: Date(timeIntervalSince1970: 1000)], ofItemAtPath: older.path)
         try fm.setAttributes([.modificationDate: Date()], ofItemAtPath: newer.path)
 
-        let plans = YoloMode.recentPlans(in: base)
+        let plans = PlanPolicy.recentPlans(in: base)
         XCTAssertEqual(plans.map { $0.filename }, ["new-plan.md", "old-plan.md"], "newest-modified first, one level only")
         XCTAssertEqual(plans.first?.folder, "beta")
         XCTAssertFalse(plans.contains { $0.filename == "notes.txt" }, "non-.md excluded")
@@ -220,22 +220,22 @@ final class YoloModeTests: XCTestCase {
         for i in 0..<5 {
             try "p".write(to: folder.appendingPathComponent("plan-\(i).md"), atomically: true, encoding: .utf8)
         }
-        XCTAssertEqual(YoloMode.recentPlans(in: base, limit: 3).count, 3)
+        XCTAssertEqual(PlanPolicy.recentPlans(in: base, limit: 3).count, 3)
     }
 
     func testRecentPlansEmptyWhenDirMissing() {
         let missing = FileManager.default.temporaryDirectory
             .appendingPathComponent("does-not-exist-\(UUID().uuidString)", isDirectory: true)
-        XCTAssertTrue(YoloMode.recentPlans(in: missing).isEmpty)
+        XCTAssertTrue(PlanPolicy.recentPlans(in: missing).isEmpty)
     }
 
     func testEngageAfterManualArmFreezesPlanAndHaltsOnWrite() {
         session.lastPlanPath = planPath
-        XCTAssertTrue(YoloMode.engage(session: session))
+        XCTAssertTrue(PlanPolicy.engage(session: session))
         waitForMain()
-        XCTAssertEqual(session.yoloPlanPath, planPath, "manually-armed path is frozen identically to auto-detect")
+        XCTAssertEqual(session.engagedPlanPath, planPath, "manually-armed path is frozen identically to auto-detect")
         XCTAssertEqual(
-            YoloMode.shouldHalt(session: session, payload: payload(tool: "Write", filePath: planPath)),
+            PlanPolicy.shouldHalt(session: session, payload: payload(tool: "Write", filePath: planPath)),
             "plan modified by agent"
         )
     }


### PR DESCRIPTION
## What

Pure identifier rename — **no behavior change**. After the bypass was retired in #97, the "YOLO" naming no longer described the feature, which is now a plan-policy overlay. This finishes the "drop YOLO entirely" decision by removing the name from the code.

## Renames
- `YoloMode` → `PlanPolicy` (`YoloMode.swift` → `PlanPolicy.swift`)
- `Session`: `isYoloActive`→`isPlanPolicyEngaged`, `setYoloActive`→`setPlanPolicyEngaged`, `_yoloActive`→`_planPolicyEngaged`, `yoloLock`→`planPolicyLock`, `yoloEngagedAt`→`planEngagedAt`, `yoloPlanPath`→`engagedPlanPath`, `yoloPlanHash`→`engagedPlanHash`, `yoloDisabledReason`→`planPolicyDroppedReason`
- `DecisionBadge.yolo` → `.planPolicy` (display string already "PLAN")
- `MonitorWindow`: `yoloControl`/`yoloActiveHelp`/`yoloIdleHelp`/`yoloDisabledReasonTint` → `plan*`
- `SessionManager.rehydrateYolo` → `rehydratePlanPolicy`
- Tests: `YoloModeTests`→`PlanPolicyTests`, `YoloApprovalEngineTests`→`PlanPolicyApprovalEngineTests`
- Rewrote comments/doc strings that still described the removed bypass.

`grep -rn 'YOLO\|[Yy]olo' Sources/ Tests/` → no matches.

## One persistence nuance (flagged)
The `PersistedSession` JSON keys for engage state were renamed too, so a session that is **engaged at the exact moment of this upgrade's daemon restart** won't auto-re-engage — you'd re-click **Plan**. One-time and self-healing; engage state is ephemeral process state, not user data. Called out explicitly since this PR is otherwise behavior-preserving. (Happy to add `CodingKeys` to preserve the old keys instead if you'd rather zero behavior delta.)

## Tests
372 tests green; build clean.