### PR TITLE
fix(approval): catch git global-option commit forms at the commit checkpoint

### DIFF
--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -15,7 +15,14 @@ final class RuleStore: ObservableObject {
     private let configPath: String
 
     /// Current seed version — bump when adding new default rules.
-    private static let seedVersion = 8
+    private static let seedVersion = 9
+
+    /// Built-in patterns replaced by a corrected/broadened seeded rule. On re-seed
+    /// these are dropped from existing rules.json so a pattern fix swaps cleanly
+    /// instead of leaving the old (narrower) rule behind as a duplicate.
+    private static let supersededBuiltInPatterns: Set<String> = [
+        "\\bgit\\s+commit\\b"  // broadened to catch `git -C <path> commit` etc.
+    ]
 
     init(configPath: String? = nil) {
         self.configPath = configPath ?? Self.defaultConfigPath
@@ -252,9 +259,11 @@ final class RuleStore: ObservableObject {
         ),
 
         // ── Commit checkpoint (non-overridable: a broad allow rule can't silence it) ──
+        // Tolerates git global options before the subcommand (`-C <path>`, `-c k=v`,
+        // `--no-pager`) so `git -C /repo commit` can't slip past the bare-form pattern.
         PersistentRule(
             toolName: "Bash",
-            pattern: "\\bgit\\s+commit\\b",
+            pattern: "\\bgit\\b(\\s+-{1,2}\\S+(\\s+\\S+)?)*\\s+commit\\b",
             isRegex: true,
             verdict: .prompt,
             explanation: "Commit checkpoint — review staged changes before recording history",
@@ -329,10 +338,10 @@ final class RuleStore: ObservableObject {
     }
 
     private func seedDefaults(existingRules: [PersistentRule], version: Int, deleted: [String]) {
-        let existingPatterns = Set(existingRules.map(\.pattern))
+        var seeded = existingRules.filter { !($0.builtIn && Self.supersededBuiltInPatterns.contains($0.pattern)) }
+        let existingPatterns = Set(seeded.map(\.pattern))
         let deletedSet = Set(deleted)
 
-        var seeded = existingRules
         for rule in Self.seededDefaults {
             guard !existingPatterns.contains(rule.pattern),
                   !deletedSet.contains(rule.pattern) else { continue }

--- a/Tests/GavelTests/ApprovalEngineTests.swift
+++ b/Tests/GavelTests/ApprovalEngineTests.swift
@@ -80,6 +80,44 @@ final class ApprovalEngineTests: XCTestCase {
         XCTAssertTrue(decision.askUser)
     }
 
+    func testCommitCheckpointCatchesGitGlobalOptionForms() {
+        session.autoApproveUntil = Date().addingTimeInterval(300)
+        for cmd in [
+            "git commit -m \"wip\"",
+            "git -C /repo commit -m \"deploy\"",
+            "git -c user.email=x@y.z commit -m wip",
+            "git --no-pager commit",
+        ] {
+            let decision = engine.evaluate(payload: payload(command: cmd), session: session)
+            XCTAssertEqual(decision.verdict, .block, "commit checkpoint should catch: \(cmd)")
+            XCTAssertTrue(decision.askUser, "expected dialog for: \(cmd)")
+        }
+    }
+
+    func testCommitCheckpointDoesNotFireOnNonCommitGit() {
+        session.autoApproveUntil = Date().addingTimeInterval(300)
+        for cmd in ["git -C /repo log --oneline", "git status", "git -c core.pager=cat diff"] {
+            let decision = engine.evaluate(payload: payload(command: cmd), session: session)
+            XCTAssertEqual(decision.verdict, .allow, "non-commit git must not trip the commit checkpoint: \(cmd)")
+        }
+    }
+
+    func testSeedMigrationReplacesSupersededCommitPattern() {
+        let path = NSTemporaryDirectory() + "seed-migrate-\(UUID().uuidString).json"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let oldNarrow = "\\bgit\\s+commit\\b"
+        let oldRule = PersistentRule(toolName: "Bash", pattern: oldNarrow, isRegex: true,
+                                     verdict: .prompt, explanation: "old", builtIn: true, overridable: false)
+        let data = try! JSONEncoder().encode(RulesFile(version: 8, deletedBuiltInPatterns: [], rules: [oldRule]))
+        FileManager.default.createFile(atPath: path, contents: data)
+
+        let store = RuleStore(configPath: path)
+        let commitPatterns = store.rules.map(\.pattern).filter { $0.contains("commit") }
+        XCTAssertEqual(commitPatterns.count, 1, "exactly one commit checkpoint after re-seed (no duplicate)")
+        XCTAssertFalse(commitPatterns.contains(oldNarrow), "old narrow commit pattern dropped on re-seed")
+        XCTAssertTrue(commitPatterns.first?.contains("-{1,2}") ?? false, "broadened pattern seeded")
+    }
+
     func testInfraApplyPromptsUnderAutoApprove() {
         session.autoApproveUntil = Date().addingTimeInterval(300)
         for cmd in ["cdk deploy MyStack", "terraform apply", "aws cloudformation deploy --template-file t.yaml --stack-name s"] {


### PR DESCRIPTION
## Problem

The commit checkpoint pattern `\bgit\s+commit\b` only matches the **bare** form. Git global options before the subcommand break it, so these slipped past a *non-overridable* checkpoint with **no prompt**:

- `git -C /path commit -m …`  (commit in another repo -- also how an agent commits without `cd`)
- `git -c user.email=x commit …`
- `git --no-pager commit`

Found while committing from a pinned-cwd session: the commit went through unprompted.

## Fix

Broaden the seeded pattern to allow git global options before the subcommand:

```
\bgit\b(\s+-{1,2}\S+(\s+\S+)?)*\s+commit\b
```

- Catches the `-C` / `-c` / `--no-pager` forms.
- Non-commit git (`git -C /repo log`, `git status`, `git -c … diff`) does **not** trip it.
- Bump `seedVersion` 8 → 9 and add a `supersededBuiltInPatterns` cleanup so existing `rules.json` files **swap** the old narrow rule for the broadened one on re-seed, rather than keeping both as duplicates.

## Tests

- `testCommitCheckpointCatchesGitGlobalOptionForms` -- the global-option forms now prompt.
- `testCommitCheckpointDoesNotFireOnNonCommitGit` -- no false positives on log/status/diff.
- `testSeedMigrationReplacesSupersededCommitPattern` -- re-seed leaves exactly one commit checkpoint rule.

Full suite green (375).