### PR TITLE
fix(session): detect PID reuse via cwd so stale sessions sleep correctly

### DIFF
--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -33,11 +33,13 @@ final class SessionManager: ObservableObject {
     init(
         homeDir: URL = FileManager.default.homeDirectoryForCurrentUser,
         autoStartTimers: Bool = true,
-        autoDiscover: Bool = true
+        autoDiscover: Bool = true,
+        liveness: @escaping (Int, String?) -> Bool = SessionManager.defaultLiveness
     ) {
         let base = homeDir.path + "/.claude/gavel"
         self.defaultsPath = base + "/session-defaults.json"
         self.sessionsPath = base + "/active-sessions.json"
+        self.livenessCheck = liveness
         try? FileManager.default.createDirectory(atPath: base, withIntermediateDirectories: true)
 
         loadDefaults()
@@ -204,7 +206,7 @@ final class SessionManager: ObservableObject {
     func clearDeadSessions() {
         lock.lock()
         let strayPids = sessions.compactMap { (pid, session) -> Int? in
-            (!session.isAlive || !isProcessAlive(pid: pid)) ? pid : nil
+            (!session.isAlive || !isProcessAlive(pid: pid, cwd: session.cwd)) ? pid : nil
         }
         for pid in strayPids {
             sessions.removeValue(forKey: pid)
@@ -300,7 +302,7 @@ final class SessionManager: ObservableObject {
         }
 
         for snap in live + dead {
-            if isProcessAlive(pid: snap.pid) {
+            if isProcessAlive(pid: snap.pid, cwd: snap.cwd) {
                 rehydrateLive(snap)
             } else if let sid = snap.sessionId {
                 rehydrateTombstone(snap, sessionId: sid)
@@ -393,9 +395,20 @@ final class SessionManager: ObservableObject {
         return added
     }
 
-    /// Check if a PID is still alive using kill(0).
-    func isProcessAlive(pid: Int) -> Bool {
-        kill(Int32(pid), 0) == 0 || errno == EPERM
+    /// Liveness predicate for a tracked PID; overridable so tests can fake a live session.
+    var livenessCheck: (Int, String?) -> Bool
+
+    func isProcessAlive(pid: Int, cwd: String?) -> Bool {
+        livenessCheck(pid, cwd)
+    }
+
+    // Match on cwd, not p_comm: Claude Code reports its version string (e.g. "2.1.158")
+    // as p_comm, so a recycled PID can't be ruled out by process name.
+    static func defaultLiveness(pid: Int, cwd expectedCwd: String?) -> Bool {
+        guard kill(Int32(pid), 0) == 0 || errno == EPERM else { return false }
+        guard let expectedCwd else { return true }
+        guard let actual = ProcessTree.cwd(of: Int32(pid)) else { return false }
+        return actual == expectedCwd
     }
 
     // MARK: - Cleanup
@@ -417,7 +430,10 @@ final class SessionManager: ObservableObject {
         let pids = Array(sessions.keys)
         lock.unlock()
         for pid in pids {
-            guard !isProcessAlive(pid: pid) else { continue }
+            lock.lock()
+            let cwd = sessions[pid]?.cwd
+            lock.unlock()
+            guard !isProcessAlive(pid: pid, cwd: cwd) else { continue }
             lock.lock()
             guard let session = sessions[pid] else {
                 lock.unlock()

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -416,7 +416,11 @@ private struct SessionRow: View {
             .frame(width: 76)
 
             Button("Sleep") {
-                kill(Int32(session.pid), SIGINT)
+                if viewModel.sessionManager.isProcessAlive(pid: session.pid, cwd: session.cwd) {
+                    kill(Int32(session.pid), SIGINT)
+                } else {
+                    viewModel.sessionManager.cleanupDeadSessions()
+                }
                 viewModel.noteInteraction()
             }
             .buttonStyle(.bordered)

--- a/Tests/GavelTests/SessionLifecycleTests.swift
+++ b/Tests/GavelTests/SessionLifecycleTests.swift
@@ -8,6 +8,11 @@ final class SessionLifecycleTests: XCTestCase {
     private var tmpHome: URL!
     private var manager: SessionManager!
 
+    /// Stands in a live result for the test runner's own PID; everything else uses the real cwd check.
+    private let liveOnOwnPid: (Int, String?) -> Bool = { pid, cwd in
+        pid == Int(getpid()) ? true : SessionManager.defaultLiveness(pid: pid, cwd: cwd)
+    }
+
     /// A PID effectively guaranteed not to exist on macOS. macOS reserves up
     /// to ~99999; anything above that range is unused by any real process.
     private let deadPid = 1_999_999
@@ -17,7 +22,7 @@ final class SessionLifecycleTests: XCTestCase {
         tmpHome = FileManager.default.temporaryDirectory
             .appendingPathComponent("gavel-test-\(UUID().uuidString)")
         try? FileManager.default.createDirectory(at: tmpHome, withIntermediateDirectories: true)
-        manager = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false)
+        manager = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false, liveness: liveOnOwnPid)
     }
 
     override func tearDown() {
@@ -50,6 +55,36 @@ final class SessionLifecycleTests: XCTestCase {
 
         XCTAssertNil(manager.sessions[deadPid], "Live dict should drop")
         XCTAssertTrue(manager.deadSessions.isEmpty, "No sessionId means no tombstone")
+    }
+
+    // MARK: - PID reuse
+
+    func testDefaultLivenessRejectsLivePidWithMismatchedCwd() {
+        let livePid = Int(getpid())
+        let realCwd = ProcessTree.cwd(of: Int32(livePid))
+        XCTAssertNotNil(realCwd, "Test runner must have a readable cwd for this to be meaningful")
+
+        XCTAssertTrue(
+            SessionManager.defaultLiveness(pid: livePid, cwd: realCwd),
+            "A live PID still in its recorded cwd is alive"
+        )
+        XCTAssertFalse(
+            SessionManager.defaultLiveness(pid: livePid, cwd: (realCwd ?? "") + "/somewhere-else"),
+            "A live PID whose cwd drifted from the recorded one was reused — dead"
+        )
+    }
+
+    func testCleanupTombstonesPidReusedUnderDifferentCwd() {
+        manager.livenessCheck = SessionManager.defaultLiveness
+        let sid = "uuid-reused-pid"
+        let session = manager.session(for: Int(getpid()))
+        session.sessionId = sid
+        session.cwd = "/tmp/some-other-recorded-path"
+
+        manager.cleanupDeadSessions()
+
+        XCTAssertNil(manager.sessions[Int(getpid())], "PID whose cwd no longer matches must leave the live dict")
+        XCTAssertNotNil(manager.deadSessions[sid], "It must tombstone so the row flips to asleep")
     }
 
     // MARK: - Removal controls
@@ -137,7 +172,7 @@ final class SessionLifecycleTests: XCTestCase {
         manager.saveActiveSessions()
 
         // Spin up a fresh manager pointing at the same tmp home.
-        let reloaded = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false)
+        let reloaded = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false, liveness: liveOnOwnPid)
 
         XCTAssertNotNil(reloaded.sessions[livePid], "Live session must rehydrate")
         XCTAssertEqual(reloaded.sessions[livePid]?.sessionId, sidLive)
@@ -163,7 +198,7 @@ final class SessionLifecycleTests: XCTestCase {
         manager.recordSessionId("codex-sid", on: session)
         manager.saveActiveSessions()
 
-        let reloaded = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false)
+        let reloaded = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false, liveness: liveOnOwnPid)
         XCTAssertEqual(reloaded.sessions[pid]?.agent, .codex, "Codex agent must survive restart")
     }
 
@@ -181,7 +216,7 @@ final class SessionLifecycleTests: XCTestCase {
         )
         FileManager.default.createFile(atPath: path, contents: data)
 
-        let reloaded = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false)
+        let reloaded = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false, liveness: liveOnOwnPid)
 
         XCTAssertEqual(reloaded.sessions[livePid]?.sessionId, "legacy-sid")
         XCTAssertTrue(reloaded.deadSessions.isEmpty, "Legacy format has no tombstones")


### PR DESCRIPTION
## Problem

A tracked session's liveness was decided with a bare `kill(pid, 0)`. When a Claude/Codex process exits and the kernel **recycles its PID** to an unrelated long-running process (observed: a dead `dotfiles` session whose PID 641 became `/usr/libexec/containermanagerd`), `kill(0)` keeps succeeding. Result:

- The monitor row stays **green/live forever** — the cleanup timer never tombstones it.
- Clicking **Sleep** sends `SIGINT` to whatever process now owns the PID (a system daemon, or any unrelated process), not to a Claude session.

## Why not match on process name

The obvious fix — "is the process at this PID still `claude`?" — doesn't work. Claude Code sets its `p_comm` to its **version string** (e.g. `2.1.158`), not `claude`. An exact-name check tombstones every live session within 5s. (The hook never relied on the name either; it falls back to `getppid()`.)

## Fix

Liveness now requires the process at `pid` to still have the **cwd** gavel recorded for it (`SessionManager.defaultLiveness`). A reused PID has a different — or unreadable, as system daemons give — cwd, so it reads as dead and tombstones. Brand-new sessions with no recorded cwd yet fall back to existence alone, so they're never falsely tombstoned.

- `isProcessAlive(pid:cwd:)` replaces `isProcessAlive(pid:)` at all call sites (cleanup timer, load/rehydrate, clearDead).
- The **Sleep** button re-checks liveness and diverts to `cleanupDeadSessions()` instead of SIGINT-ing a reused PID.
- The predicate is injectable (`livenessCheck`) so tests can stand in a live session on the test runner's own PID.

## Tests

- `testDefaultLivenessRejectsLivePidWithMismatchedCwd` — a live PID whose cwd drifted reads as dead.
- `testCleanupTombstonesPidReusedUnderDifferentCwd` — the cleanup timer tombstones it.
- Existing lifecycle/persistence tests pass via the injected liveness seam. Full suite: 384 passing.

## Real-world verification

Ran the actual `defaultLiveness` against the live daemon's PIDs: the real Claude session read **alive** (cwd matches), and the reused PID 641 (`containermanagerd`, cwd unreadable) read **dead** → tombstoned. End-to-end confirmed in the running monitor (live sessions show, resume works, Sleep flips a real session to asleep, a manufactured invalid session self-heals to asleep within ~5s).