### PR TITLE
feat(monitor): log session appear/disappear to gavel.log and the Feed

### DIFF
--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -27,6 +27,9 @@ final class SessionManager: ObservableObject {
 
     private var lastInteraction: Date = Date()
 
+    /// Fired on session create / tombstone / discover; the daemon mirrors it to gavel.log + the Feed.
+    var onLifecycle: ((_ message: String, _ pid: Int, _ at: Date) -> Void)?
+
     private let defaultsPath: String
     private let sessionsPath: String
 
@@ -60,8 +63,8 @@ final class SessionManager: ObservableObject {
     /// New sessions inherit the default Auto/Sub settings.
     func session(for pid: Int, agent: AgentKind = .claude) -> Session {
         lock.lock()
-        defer { lock.unlock() }
         if let existing = sessions[pid] {
+            lock.unlock()
             return existing
         }
         let session = Session(pid: pid, agent: agent)
@@ -70,7 +73,15 @@ final class SessionManager: ObservableObject {
         session.isPaused = defaultPaused
         sessions[pid] = session
         saveActiveSessionsLocked()
+        lock.unlock()
+        noteLifecycle("session appeared (\(agent.rawValue))", pid: pid)
         return session
+    }
+
+    // Call outside `lock` — does file IO and forwards to a main-thread sink.
+    private func noteLifecycle(_ message: String, pid: Int, at: Date = Date()) {
+        gavelLog("[session] \(message) pid=\(pid)")
+        onLifecycle?(message, pid, at)
     }
 
     /// Save current defaults to disk (called when user toggles).
@@ -377,7 +388,7 @@ final class SessionManager: ObservableObject {
     @discardableResult
     func discoverRunningSessions() -> Int {
         let discovered = ProcessTree.findClaudeCliSessions()
-        var added = 0
+        var addedPids: [Int] = []
         lock.lock()
         for (pid, cwd) in discovered {
             let pidInt = Int(pid)
@@ -388,11 +399,12 @@ final class SessionManager: ObservableObject {
             session.isSubAgentInheritEnabled = defaultSubAgentInherit
             session.isPaused = defaultPaused
             sessions[pidInt] = session
-            added += 1
+            addedPids.append(pidInt)
         }
-        if added > 0 { saveActiveSessionsLocked() }
+        if !addedPids.isEmpty { saveActiveSessionsLocked() }
         lock.unlock()
-        return added
+        for pid in addedPids { noteLifecycle("session discovered (already running)", pid: pid) }
+        return addedPids.count
     }
 
     /// Liveness predicate for a tracked PID; overridable so tests can fake a live session.
@@ -440,6 +452,7 @@ final class SessionManager: ObservableObject {
                 continue
             }
             let now = Date()
+            let resumable = session.sessionId != nil
             sessions.removeValue(forKey: pid)
             if let sid = session.sessionId {
                 deadSessions[sid] = session
@@ -447,6 +460,7 @@ final class SessionManager: ObservableObject {
             saveActiveSessionsLocked()
             lock.unlock()
             stopWatcher(forPid: pid)
+            noteLifecycle(resumable ? "session asleep (process exited)" : "session disappeared (process exited)", pid: pid, at: now)
             // @Published mutations need main thread; this runs on a utility queue.
             DispatchQueue.main.async {
                 session.isAlive = false

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -290,6 +290,12 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        sessionManager.onLifecycle = { [weak self] message, pid, at in
+            DispatchQueue.main.async {
+                self?.viewModel.appendFeedEntry(.system(message, pid: pid, at: at))
+            }
+        }
+
         socketServer?.onEvent = { [weak self] data, respond in
             self?.hookRouter.handle(data: data, respond: respond)
         }

--- a/Tests/GavelTests/SessionLifecycleTests.swift
+++ b/Tests/GavelTests/SessionLifecycleTests.swift
@@ -57,6 +57,37 @@ final class SessionLifecycleTests: XCTestCase {
         XCTAssertTrue(manager.deadSessions.isEmpty, "No sessionId means no tombstone")
     }
 
+    // MARK: - Lifecycle events
+
+    func testLifecycleCallbackFiresOnAppearAndTeardown() {
+        var events: [(message: String, pid: Int)] = []
+        manager.onLifecycle = { msg, pid, _ in events.append((msg, pid)) }
+
+        let resumablePid = deadPid
+        let resumable = manager.session(for: resumablePid)
+        resumable.sessionId = "uuid-lifecycle"
+
+        let droppedPid = deadPid + 1
+        _ = manager.session(for: droppedPid)
+
+        XCTAssertEqual(
+            events.filter { $0.message.contains("appeared") }.map { $0.pid }.sorted(),
+            [resumablePid, droppedPid].sorted(),
+            "Both new sessions must emit an 'appeared' event"
+        )
+
+        manager.cleanupDeadSessions()
+
+        XCTAssertTrue(
+            events.contains { $0.pid == resumablePid && $0.message.contains("asleep") },
+            "A dead session with a sessionId tombstones → 'asleep'"
+        )
+        XCTAssertTrue(
+            events.contains { $0.pid == droppedPid && $0.message.contains("disappeared") },
+            "A dead session without a sessionId is dropped → 'disappeared'"
+        )
+    }
+
     // MARK: - PID reuse
 
     func testDefaultLivenessRejectsLivePidWithMismatchedCwd() {


### PR DESCRIPTION
## Problem

Session rows could flap in and out — appear on a new PID's first hook, disappear when the cleanup timer tombstoned them — with **nothing recorded anywhere**. `gavel.log` and the Feed only got the explicit `SessionStart` hook, so transient/unexpected lifecycle churn (e.g. the PID-reuse flapping during the v1.16.0 liveness bug) left no trace.

## Change

Add `SessionManager.onLifecycle`, fired on:
- **create** — `session(for:)` for a new PID → `session appeared`
- **teardown** — `cleanupDeadSessions()` → `session asleep` (had a sessionId → tombstoned) or `session disappeared` (no sessionId → dropped)
- **discover** — `discoverRunningSessions()` at startup → `session discovered`

Every event is written to `gavel.log` via `noteLifecycle` and forwarded to the Feed as a `.system` entry (wired in `setupHookRouter`).

## Tests

`testLifecycleCallbackFiresOnAppearAndTeardown` covers appear + the asleep/disappeared branches. Full suite green.

## Note

The `gavelLog` file-write half isn't exercised by `swift test` (the harness doesn't run the executable's top-level init), but it's the same `gavelLog` that writes every existing `[socket]`/`[hook]` line. Confirmed live: `tail -f ~/.claude/gavel/gavel.log | grep '[session]'` shows the events as sessions start/sleep.