### PR TITLE
feat(monitor): collapsible compact monitor bar

### DIFF
--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -91,6 +91,21 @@ final class MonitorViewModel: ObservableObject {
         approvalCoordinator.ruleStore?.rules.count ?? 0
     }
 
+    var compactSummary: String {
+        let live = sessionManager.sessions.count
+        let asleep = sessionManager.deadSessions.count
+        var tools = 0, block = 0
+        for session in sessionManager.sessions.values {
+            tools += session.toolCallCount
+            block += session.blockCount
+        }
+        var parts = ["Gavel", "\(live) live"]
+        if asleep > 0 { parts.append("\(asleep) asleep") }
+        parts.append("Tools \(tools)")
+        parts.append("Block \(block)")
+        return parts.joined(separator: " · ")
+    }
+
     var persistentRules: [PersistentRule] {
         approvalCoordinator.ruleStore?.rules ?? []
     }

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -5,6 +5,8 @@ import UniformTypeIdentifiers
 struct MonitorWindow: View {
     @ObservedObject var viewModel: MonitorViewModel
     @State private var isPinned: Bool = false
+    @State private var isCompact: Bool = false
+    @State private var savedFrame: NSRect?
     @State private var selectedTab: MonitorTab = .feed
     @State private var sessionFilter: String = ""
     @State private var hideTombstones: Bool = false
@@ -14,14 +16,51 @@ struct MonitorWindow: View {
     }
 
     var body: some View {
+        Group {
+            if isCompact {
+                compactBar
+            } else {
+                fullBody
+            }
+        }
+        .frame(minWidth: isCompact ? 320 : 600, minHeight: isCompact ? 28 : 400)
+    }
+
+    private var compactBar: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(viewModel.sessionManager.sessions.isEmpty ? Color.secondary : Color.green)
+                .frame(width: 7, height: 7)
+            Text(viewModel.compactSummary)
+                .font(.system(.caption, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Spacer(minLength: 4)
+            Button(action: { setCompact(false) }) {
+                Image(systemName: "arrow.up.left.and.arrow.down.right")
+            }
+            .buttonStyle(.plain)
+            .help("Expand the monitor")
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    private var fullBody: some View {
         VStack(spacing: 0) {
-            // Status bar with pin toggle
             HStack {
                 StatusView(viewModel: viewModel)
                 Spacer()
+                Button(action: { setCompact(true) }) {
+                    Image(systemName: "rectangle.compress.vertical")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Collapse to a compact bar")
                 Button(action: {
                     isPinned.toggle()
-                    if let window = NSApp.windows.first(where: { $0.title.contains("Monitor") }) {
+                    if let window = monitorWindow() {
                         window.level = isPinned ? .floating : .normal
                     }
                 }) {
@@ -75,7 +114,36 @@ struct MonitorWindow: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 6)
         }
-        .frame(minWidth: 600, minHeight: 400)
+    }
+
+    private func monitorWindow() -> NSWindow? {
+        NSApp.windows.first { $0.title.contains("Monitor") }
+    }
+
+    private func setCompact(_ compact: Bool) {
+        isCompact = compact
+        guard let window = monitorWindow() else { return }
+        if compact {
+            savedFrame = window.frame
+            window.level = .floating
+            let area = (window.screen ?? NSScreen.main)?.visibleFrame
+            if let area {
+                let size = NSSize(width: 420, height: 64)
+                let rect = NSRect(
+                    x: area.maxX - size.width - 16,
+                    y: area.maxY - size.height - 16,
+                    width: size.width,
+                    height: size.height
+                )
+                window.setFrame(rect, display: true, animate: true)
+            }
+        } else {
+            window.level = isPinned ? .floating : .normal
+            if let savedFrame {
+                window.setFrame(savedFrame, display: true, animate: true)
+            }
+        }
+        viewModel.noteInteraction()
     }
 
     private var sessionControls: some View {

--- a/Tests/GavelTests/SessionLifecycleTests.swift
+++ b/Tests/GavelTests/SessionLifecycleTests.swift
@@ -221,4 +221,20 @@ final class SessionLifecycleTests: XCTestCase {
         XCTAssertEqual(reloaded.sessions[livePid]?.sessionId, "legacy-sid")
         XCTAssertTrue(reloaded.deadSessions.isEmpty, "Legacy format has no tombstones")
     }
+
+    // MARK: - Compact summary
+
+    func testCompactSummaryReflectsLiveAndAsleepCounts() {
+        let vm = MonitorViewModel(sessionManager: manager, approvalCoordinator: ApprovalCoordinator())
+
+        _ = manager.session(for: Int(getpid()))
+        let dead = manager.session(for: deadPid)
+        dead.sessionId = "compact-summary-uuid"
+        manager.cleanupDeadSessions()
+
+        let summary = vm.compactSummary
+        XCTAssertTrue(summary.hasPrefix("Gavel"), summary)
+        XCTAssertTrue(summary.contains("1 live"), summary)
+        XCTAssertTrue(summary.contains("1 asleep"), summary)
+    }
 }


### PR DESCRIPTION
## Problem

The monitor was all-or-nothing: a full 720×520 window or closed. No way to keep a small glanceable presence while working — "a giant section of screen or disappear."

## Change

Add a collapse toggle (⊟ in the status bar) that shrinks the monitor to a **floating one-line bar** anchored top-right:

```
Gavel · 3 live · 1 asleep · Tools 0 · Block 0     [ expand ]
```

Mirrors the approval panel's collapse mechanic: saves the full frame, animates to a ~420×64 bar, sets `.floating` level. Expand restores the saved frame and the prior window level (respecting the Pin toggle). `MonitorViewModel.compactSummary` provides the live/asleep + tool/block counts, refreshed by the existing 2s stats tick.

## Tests

`testCompactSummaryReflectsLiveAndAsleepCounts` covers the count/format logic. The window resize/float is AppKit verified live (toggle → floating bar top-right → expand restores).

## Follow-ups (not in this PR)

- Keeps the normal title bar (compact ≈ title bar + one line). Chromeless strip is a possible follow-up.
- `savedFrame` is view state — restores within a session, not across a full daemon restart.