### PR TITLE
feat(monitor): auto-name sessions, open cwd in editor/Tower, forget unnamed

### DIFF
--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -121,7 +121,7 @@ final class SessionManager: ObservableObject {
             }
             self?.tryJsonlSeed(session: session)
         }
-        if !currentLabel.isEmpty && savedLabel != currentLabel {
+        if !currentLabel.isEmpty && !session.labelIsDerived && savedLabel != currentLabel {
             sessionLabels[sid] = currentLabel
             saveDefaults()
         }
@@ -153,9 +153,16 @@ final class SessionManager: ObservableObject {
         guard session.label.isEmpty, !jsonlSeedTriedPids.contains(session.pid) else { return }
         guard let sid = session.sessionId, let cwd = session.cwd else { return }
         jsonlSeedTriedPids.insert(session.pid)
-        guard let seeded = JsonlRenameReader.latestRename(cwd: cwd, sessionId: sid) else { return }
-        session.label = seeded
-        setLabel(seeded, for: sid)
+        if let seeded = JsonlRenameReader.latestRename(cwd: cwd, sessionId: sid) {
+            session.labelIsDerived = false
+            session.label = seeded
+            setLabel(seeded, for: sid)
+            return
+        }
+        guard let derived = JsonlRenameReader.firstPromptTitle(cwd: cwd, sessionId: sid) else { return }
+        session.labelIsDerived = true
+        session.label = derived
+        saveActiveSessions()
     }
 
     /// Apply an externally-sourced label update (e.g., from JSONL watcher); no-op on empty or unchanged input.
@@ -165,6 +172,7 @@ final class SessionManager: ObservableObject {
         let currentLabel = session.label
         guard currentLabel != trimmed else { return }
         DispatchQueue.main.async {
+            session.labelIsDerived = false
             session.label = trimmed
         }
         if let sid = sessionId ?? session.sessionId {
@@ -214,6 +222,19 @@ final class SessionManager: ObservableObject {
         lock.unlock()
     }
 
+    /// Forget only the tombstones that still have no name (derived or explicit).
+    func clearUnnamedDeadSessions() {
+        lock.lock()
+        let unnamed = deadSessions.filter { $0.value.label.isEmpty }.map(\.key)
+        for sid in unnamed {
+            deadSessions.removeValue(forKey: sid)
+        }
+        if !unnamed.isEmpty {
+            saveActiveSessionsLocked()
+        }
+        lock.unlock()
+    }
+
     func clearDeadSessions() {
         lock.lock()
         let strayPids = sessions.compactMap { (pid, session) -> Int? in
@@ -241,6 +262,7 @@ final class SessionManager: ObservableObject {
         let isSubAgentInheritEnabled: Bool?
         let isPaused: Bool?
         let label: String?
+        let labelIsDerived: Bool?
         let endedAt: Date?
         let agent: AgentKind?
         let lastPlanPath: String?
@@ -285,6 +307,7 @@ final class SessionManager: ObservableObject {
             isSubAgentInheritEnabled: session.isSubAgentInheritEnabled,
             isPaused: session.isPaused,
             label: session.label.isEmpty ? nil : session.label,
+            labelIsDerived: session.labelIsDerived ? true : nil,
             endedAt: session.endedAt,
             agent: session.agent,
             lastPlanPath: session.lastPlanPath,
@@ -332,6 +355,7 @@ final class SessionManager: ObservableObject {
             session.label = savedLabel
         } else if let label = snap.label {
             session.label = label
+            session.labelIsDerived = snap.labelIsDerived ?? false
         }
         session.lastPlanPath = snap.lastPlanPath
         rehydratePlanPolicy(snap, into: session)
@@ -377,6 +401,11 @@ final class SessionManager: ObservableObject {
             session.label = savedLabel
         } else if let label = snap.label {
             session.label = label
+            session.labelIsDerived = snap.labelIsDerived ?? false
+        } else if let cwd = snap.cwd,
+                  let derived = JsonlRenameReader.firstPromptTitle(cwd: cwd, sessionId: sessionId) {
+            session.label = derived
+            session.labelIsDerived = true
         }
         deadSessions[sessionId] = session
     }

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -16,6 +16,12 @@ final class Session: ObservableObject, Identifiable {
     @Published var cwd: String?
     @Published var model: String?
     @Published var label: String = ""
+
+    /// True when `label` was auto-derived from the session's first prompt rather
+    /// than set explicitly (UI rename, `/rename`, or `--name`). An explicit name
+    /// always overrides a derived one and clears this flag.
+    @Published var labelIsDerived: Bool = false
+
     @Published var isPaused: Bool = false
     @Published var isAlive: Bool = true
     @Published var endedAt: Date?

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -213,6 +213,14 @@ struct MonitorWindow: View {
                 .tint(.gray)
                 .help("Remove every sleeping (tombstoned) session from the monitor.")
 
+                Button("Forget Unnamed") {
+                    viewModel.sessionManager.clearUnnamedDeadSessions()
+                    viewModel.noteInteraction()
+                }
+                .buttonStyle(.bordered)
+                .tint(.gray)
+                .help("Remove only the sleeping sessions that still have no name.")
+
                 Button("Discover") {
                     viewModel.sessionManager.discoverRunningSessions()
                     viewModel.noteInteraction()
@@ -380,10 +388,36 @@ private struct SessionRow: View {
                 .strikethrough(!session.isAlive)
 
             if let cwd = session.cwd {
-                Text(cwd.split(separator: "/").suffix(2).joined(separator: "/"))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .lineLimit(1)
+                HStack(spacing: 4) {
+                    Button {
+                        EditorPreference.open(URL(fileURLWithPath: cwd))
+                        viewModel.noteInteraction()
+                    } label: {
+                        HStack(spacing: 3) {
+                            Image(systemName: "folder")
+                                .font(.caption2)
+                            Text(cwd.split(separator: "/").suffix(2).joined(separator: "/"))
+                                .font(.caption)
+                                .lineLimit(1)
+                        }
+                        .foregroundColor(.secondary)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .help("Open \(cwd) in your editor")
+
+                    Button {
+                        RepoBrowser.open(cwd: cwd)
+                        viewModel.noteInteraction()
+                    } label: {
+                        Image(systemName: "arrow.triangle.branch")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .help("Open in Tower — staged, unstaged & untracked changes")
+                }
             }
 
             SessionLabelField(session: session) { newVal in
@@ -714,7 +748,8 @@ private struct SessionLabelField: View {
                 Button(action: beginEditing) {
                     Text(session.label.isEmpty ? "Name…" : session.label)
                         .font(.caption)
-                        .foregroundColor(session.label.isEmpty ? .secondary : .primary)
+                        .italic(session.labelIsDerived)
+                        .foregroundColor(labelColor)
                         .lineLimit(1)
                         .truncationMode(.tail)
                         .frame(width: 130, alignment: .leading)
@@ -733,7 +768,19 @@ private struct SessionLabelField: View {
                 .buttonStyle(.plain)
             }
         }
-        .help(session.sessionId.map { "Session ID: \($0)" } ?? "Click to name this session")
+        .help(helpText)
+    }
+
+    private var labelColor: Color {
+        if session.label.isEmpty { return .secondary }
+        return session.labelIsDerived ? .secondary : .primary
+    }
+
+    private var helpText: String {
+        if session.labelIsDerived {
+            return "Auto-named from the first prompt — click to rename"
+        }
+        return session.sessionId.map { "Session ID: \($0)" } ?? "Click to name this session"
     }
 
     private func beginEditing() {
@@ -744,6 +791,7 @@ private struct SessionLabelField: View {
 
     private func commit() {
         let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        session.labelIsDerived = false
         session.label = trimmed
         onCommit(trimmed)
         isEditing = false

--- a/Sources/Gavel/System/EditorPreference.swift
+++ b/Sources/Gavel/System/EditorPreference.swift
@@ -21,6 +21,7 @@ enum EditorPreference {
             "com.sublimetext.4",
             "com.sublimetext.3",
             "com.jetbrains.intellij",
+            "com.jetbrains.CLion",
             "com.apple.dt.Xcode",
             "com.apple.TextEdit",
         ]
@@ -29,6 +30,15 @@ enum EditorPreference {
         for url in appURLs {
             guard let bundle = Bundle(url: url),
                   let bundleID = bundle.bundleIdentifier else { continue }
+            let name = FileManager.default.displayName(atPath: url.path)
+            editors.append((name: name, bundleID: bundleID, url: url))
+        }
+
+        // Project-folder IDEs (e.g. CLion) may not advertise .md support, so
+        // they're absent from the type lookup above. Add any that are installed.
+        let alreadyListed = Set(editors.map(\.bundleID))
+        for bundleID in priorityBundles where !alreadyListed.contains(bundleID) {
+            guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else { continue }
             let name = FileManager.default.displayName(atPath: url.path)
             editors.append((name: name, bundleID: bundleID, url: url))
         }

--- a/Sources/Gavel/System/JsonlRenameReader.swift
+++ b/Sources/Gavel/System/JsonlRenameReader.swift
@@ -1,18 +1,13 @@
 import Foundation
 
-/// Reads the latest session title from a Claude Code JSONL transcript. Catches
-/// both `/rename` events and `--name`-set titles. Best-effort: read errors,
-/// missing files, and malformed lines all return nil.
+/// Reads a session title from a Claude Code JSONL transcript. `latestRename`
+/// catches explicit titles (`/rename`, `--name`); `firstPromptTitle` derives a
+/// best-effort name from the opening user prompt when no explicit title exists.
+/// Best-effort throughout: read errors, missing files, and malformed lines all
+/// return nil.
 enum JsonlRenameReader {
     static func latestRename(cwd: String, sessionId: String) -> String? {
-        let encoded = cwd
-            .replacingOccurrences(of: "/", with: "-")
-            .replacingOccurrences(of: ".", with: "-")
-        let path = (NSHomeDirectory() as NSString)
-            .appendingPathComponent(".claude/projects")
-            .appending("/\(encoded)/\(sessionId).jsonl")
-        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
-              let text = String(data: data, encoding: .utf8) else { return nil }
+        guard let text = transcript(cwd: cwd, sessionId: sessionId) else { return nil }
 
         let patterns = [
             #"<command-message>rename</command-message>[\s\S]*?<command-args>(.+?)</command-args>"#,
@@ -37,5 +32,65 @@ enum JsonlRenameReader {
         guard let value = latestValue?.trimmingCharacters(in: .whitespacesAndNewlines),
               !value.isEmpty else { return nil }
         return value
+    }
+
+    /// Derive a short title from the first real user prompt in the transcript.
+    static func firstPromptTitle(cwd: String, sessionId: String) -> String? {
+        guard let text = transcript(cwd: cwd, sessionId: sessionId) else { return nil }
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let prompt = userPromptText(fromLine: String(line)) else { continue }
+            if let title = condense(prompt) { return title }
+        }
+        return nil
+    }
+
+    private static let maxTitleLength = 60
+
+    private static func transcript(cwd: String, sessionId: String) -> String? {
+        let encoded = cwd
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+        let path = (NSHomeDirectory() as NSString)
+            .appendingPathComponent(".claude/projects")
+            .appending("/\(encoded)/\(sessionId).jsonl")
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func userPromptText(fromLine line: String) -> String? {
+        guard let data = line.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              (obj["type"] as? String) == "user",
+              (obj["isMeta"] as? Bool) != true,
+              let message = obj["message"] as? [String: Any] else { return nil }
+
+        let text: String
+        if let str = message["content"] as? String {
+            text = str
+        } else if let parts = message["content"] as? [[String: Any]] {
+            text = parts
+                .compactMap { ($0["type"] as? String) == "text" ? $0["text"] as? String : nil }
+                .joined(separator: " ")
+        } else {
+            return nil
+        }
+
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("<") else { return nil }
+        return trimmed
+    }
+
+    private static func condense(_ prompt: String) -> String? {
+        let collapsed = prompt
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespaces)
+        guard !collapsed.isEmpty else { return nil }
+        guard collapsed.count > maxTitleLength else { return collapsed }
+
+        let clipped = collapsed.prefix(maxTitleLength)
+        if let lastSpace = clipped.lastIndex(of: " ") {
+            return String(clipped[..<lastSpace]) + "…"
+        }
+        return String(clipped) + "…"
     }
 }

--- a/Sources/Gavel/System/RepoBrowser.swift
+++ b/Sources/Gavel/System/RepoBrowser.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Opens a repository's working copy in Git Tower for a pre-commit spot check —
+/// staged, unstaged, and untracked changes in one view, with Kaleidoscope a
+/// click away. Detached and best-effort: failures surface as a notification.
+enum RepoBrowser {
+    static func open(cwd: String) {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["gittower", cwd]
+        task.standardOutput = FileHandle.nullDevice
+        task.standardError = FileHandle.nullDevice
+        // The LaunchAgent inherits a minimal PATH; the gittower CLI lives here.
+        var environment = ProcessInfo.processInfo.environment
+        let toolPaths = "/usr/local/bin:/opt/homebrew/bin"
+        environment["PATH"] = toolPaths + ":" + (environment["PATH"] ?? "/usr/bin:/bin")
+        task.environment = environment
+        task.terminationHandler = { proc in
+            guard proc.terminationStatus != 0 else { return }
+            GavelNotifications.notify(
+                title: "Gavel — Couldn't open Tower",
+                body: "Is Git Tower installed and is this a git repo?\n\(cwd)"
+            )
+        }
+        do {
+            try task.run()
+        } catch {
+            GavelNotifications.notify(title: "Gavel — Couldn't open Tower", body: "gittower CLI not found")
+        }
+    }
+}

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -110,9 +110,9 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
 
         let menu = NSMenu()
         menu.addItem(NSMenuItem(title: "Show Monitor", action: #selector(showMonitor), keyEquivalent: ""))
-        let contextItem = NSMenuItem(title: "Edit Session Context", action: nil, keyEquivalent: "")
-        contextItem.submenu = buildEditorSubmenu()
-        menu.addItem(contextItem)
+        let editorItem = NSMenuItem(title: "Editor Preference", action: nil, keyEquivalent: "")
+        editorItem.submenu = buildEditorSubmenu()
+        menu.addItem(editorItem)
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Pause All Sessions", action: #selector(togglePauseAll), keyEquivalent: ""))
         let promptAllItem = NSMenuItem(title: "Prompt All Sessions", action: #selector(promptAll), keyEquivalent: "P")
@@ -168,7 +168,7 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         let preferred = EditorPreference.preferredBundleID
 
         for editor in editors {
-            let item = NSMenuItem(title: editor.name, action: #selector(openContextWithEditor(_:)), keyEquivalent: "")
+            let item = NSMenuItem(title: editor.name, action: #selector(selectPreferredEditor(_:)), keyEquivalent: "")
             item.representedObject = editor.bundleID
             item.target = self
             if editor.bundleID == preferred {
@@ -184,53 +184,13 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         return submenu
     }
 
-    @objc private func openContextWithEditor(_ sender: NSMenuItem) {
+    @objc private func selectPreferredEditor(_ sender: NSMenuItem) {
         guard let bundleID = sender.representedObject as? String else { return }
         EditorPreference.preferredBundleID = bundleID
 
-        // Rebuild submenu to update checkmark
-        if let contextItem = statusItem.menu?.items.first(where: { $0.title == "Edit Session Context" }) {
-            contextItem.submenu = buildEditorSubmenu()
+        if let editorItem = statusItem.menu?.items.first(where: { $0.title == "Editor Preference" }) {
+            editorItem.submenu = buildEditorSubmenu()
         }
-
-        let contextPath = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude/gavel/session-context.md")
-        if !FileManager.default.fileExists(atPath: contextPath.path) {
-            seedSessionContext()
-        }
-        EditorPreference.open(contextPath)
-    }
-
-    /// Copy the default session-context.md if none exists.
-    private func seedSessionContext() {
-        let dest = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude/gavel/session-context.md")
-        guard !FileManager.default.fileExists(atPath: dest.path) else { return }
-        let fallback = """
-        # Session Context — Gavel Performance Tuning
-
-        These instructions are injected into every Claude Code session at startup.
-        Edit this file to customize how Claude behaves in your projects.
-
-        ## Engineering Principles
-
-        - Orthogonal design: single responsibility per component, changes don't cascade
-        - Fail fast, fail loud: validate early, surface errors immediately, never swallow exceptions
-        - Minimal coupling: depend on interfaces not implementations, composition over inheritance
-
-        ## Code Quality
-
-        - Functions under 30 lines, files under 300: if it's longer, split it
-        - Name things for the reader: variable names explain WHY not WHAT
-        - One level of abstraction per function
-        - Reduce nesting: early returns > deeply nested if/else
-
-        ## Verification
-
-        - A successful build proves syntax, not behavior. Run the actual feature path.
-        - If something fails: read the error and trace it. Don't guess-and-retry.
-        """
-        FileManager.default.createFile(atPath: dest.path, contents: Data(fallback.utf8))
     }
 
     @objc private func togglePauseAll() {

--- a/Tests/GavelTests/JsonlTitleDerivationTests.swift
+++ b/Tests/GavelTests/JsonlTitleDerivationTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import Gavel
+
+/// Covers the first-prompt title derivation that seeds an auto-name when a
+/// session has no explicit `/rename` or `--name` title.
+final class JsonlTitleDerivationTests: XCTestCase {
+
+    private var writtenPaths: [String] = []
+
+    override func tearDown() {
+        for path in writtenPaths {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+        writtenPaths.removeAll()
+        super.tearDown()
+    }
+
+    func testDerivesTitleFromPlainFirstPrompt() {
+        let (cwd, sid) = writeTranscript(lines: [
+            #"{"type":"user","message":{"content":"Help me refactor the parser"}}"#
+        ])
+        XCTAssertEqual(JsonlRenameReader.firstPromptTitle(cwd: cwd, sessionId: sid),
+                       "Help me refactor the parser")
+    }
+
+    func testExtractsTextFromContentParts() {
+        let (cwd, sid) = writeTranscript(lines: [
+            #"{"type":"user","message":{"content":[{"type":"text","text":"Add a dark mode toggle"}]}}"#
+        ])
+        XCTAssertEqual(JsonlRenameReader.firstPromptTitle(cwd: cwd, sessionId: sid),
+                       "Add a dark mode toggle")
+    }
+
+    func testSkipsMetaReminderAndToolResultLines() {
+        let (cwd, sid) = writeTranscript(lines: [
+            #"{"type":"user","isMeta":true,"message":{"content":"injected session context"}}"#,
+            #"{"type":"user","message":{"content":"<system-reminder>noise</system-reminder>"}}"#,
+            #"{"type":"assistant","message":{"content":"hi"}}"#,
+            #"{"type":"user","message":{"content":[{"type":"tool_result","content":"output"}]}}"#,
+            #"{"type":"user","message":{"content":"The real first question"}}"#
+        ])
+        XCTAssertEqual(JsonlRenameReader.firstPromptTitle(cwd: cwd, sessionId: sid),
+                       "The real first question")
+    }
+
+    func testTruncatesLongPromptAtWordBoundary() {
+        let prompt = "Please investigate why the daemon keeps the old in-memory image after a brew upgrade"
+        let (cwd, sid) = writeTranscript(lines: [
+            #"{"type":"user","message":{"content":"\#(prompt)"}}"#
+        ])
+        let title = JsonlRenameReader.firstPromptTitle(cwd: cwd, sessionId: sid)
+        XCTAssertNotNil(title)
+        XCTAssertTrue(title!.hasSuffix("…"), "Long prompt should be ellipsized")
+        XCTAssertLessThanOrEqual(title!.count, 61, "Title stays near the cap")
+        XCTAssertFalse(title!.dropLast().hasSuffix(" "), "Should clip at a word boundary, not mid-space")
+    }
+
+    func testReturnsNilWhenNoUsablePrompt() {
+        let (cwd, sid) = writeTranscript(lines: [
+            #"{"type":"user","isMeta":true,"message":{"content":"only meta"}}"#,
+            #"{"type":"assistant","message":{"content":"hi"}}"#
+        ])
+        XCTAssertNil(JsonlRenameReader.firstPromptTitle(cwd: cwd, sessionId: sid))
+    }
+
+    func testReturnsNilWhenTranscriptMissing() {
+        let cwd = "/tmp/gavel-title-missing-\(UUID().uuidString)"
+        XCTAssertNil(JsonlRenameReader.firstPromptTitle(cwd: cwd, sessionId: UUID().uuidString))
+    }
+
+    func testUnnamedTombstoneIsBackfilledOnLoad() {
+        let (cwd, sid) = writeTranscript(lines: [
+            #"{"type":"user","message":{"content":"Wire up the new monitor bar"}}"#
+        ])
+        let deadPid = 1_999_999
+        let tmpHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gavel-title-mgr-\(UUID().uuidString)")
+        let gavelDir = tmpHome.appendingPathComponent(".claude/gavel")
+        try? FileManager.default.createDirectory(at: gavelDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpHome) }
+
+        let state = #"{"live":[],"dead":[{"pid":\#(deadPid),"sessionId":"\#(sid)","cwd":"\#(cwd)"}]}"#
+        try? state.write(to: gavelDir.appendingPathComponent("active-sessions.json"),
+                         atomically: true, encoding: .utf8)
+
+        let manager = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false)
+
+        let tombstone = manager.deadSessions[sid]
+        XCTAssertEqual(tombstone?.label, "Wire up the new monitor bar")
+        XCTAssertEqual(tombstone?.labelIsDerived, true)
+    }
+
+    private func writeTranscript(lines: [String]) -> (cwd: String, sessionId: String) {
+        let cwd = "/tmp/gavel-title-test-\(UUID().uuidString)"
+        let sid = UUID().uuidString
+        let encoded = cwd
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+        let dir = (NSHomeDirectory() as NSString)
+            .appendingPathComponent(".claude/projects")
+            .appending("/\(encoded)")
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let path = dir + "/\(sid).jsonl"
+        let body = lines.joined(separator: "\n") + "\n"
+        try? body.write(toFile: path, atomically: true, encoding: .utf8)
+        writtenPaths.append(path)
+        return (cwd, sid)
+    }
+}


### PR DESCRIPTION
## What

Reduce the number of blank, unidentifiable session rows and tighten the fix → test → commit loop from the monitor.

### Session auto-naming
- Derive a best-effort label from a session's first user prompt when no explicit `/rename` or `--name` title exists.
- Seed live sessions on discovery and backfill unnamed sleeping tombstones on daemon load (their transcripts are still on disk).
- Auto-derived names are tracked separately (`labelIsDerived`) so an explicit rename always wins; they render dimmed + italic in the monitor.
- New "Forget Unnamed" button clears only the sleeping sessions that still have no name.

### Row tooling
- The cwd path in each row opens that folder in the preferred editor.
- New Tower button opens the repo's working copy for a pre-commit spot check (staged / unstaged / untracked, with Kaleidoscope a click away).
- Editor discovery now lists installed priority IDEs (e.g. CLion) even when they don't advertise `.md` support.
- Menu's "Edit Session Context" renamed to "Editor Preference" — picking an editor only sets the preference, no longer opens the context file.

## Tests
- New `JsonlTitleDerivationTests` cover first-prompt extraction (plain text, content parts, skip meta/reminder/tool-result lines, truncation, empty/missing transcript) and a tombstone backfill round-trip.
- Full suite: 393 passing.