### PR TITLE
fix(approval): block container bind-mount bypass of config self-protection

### DIFF
--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -15,13 +15,14 @@ final class RuleStore: ObservableObject {
     private let configPath: String
 
     /// Current seed version — bump when adding new default rules.
-    private static let seedVersion = 9
+    private static let seedVersion = 10
 
     /// Built-in patterns replaced by a corrected/broadened seeded rule. On re-seed
     /// these are dropped from existing rules.json so a pattern fix swaps cleanly
     /// instead of leaving the old (narrower) rule behind as a duplicate.
     private static let supersededBuiltInPatterns: Set<String> = [
-        "\\bgit\\s+commit\\b"  // broadened to catch `git -C <path> commit` etc.
+        "\\bgit\\s+commit\\b",  // broadened to catch `git -C <path> commit` etc.
+        "\\.claude/(gavel/|settings|hooks/)"  // trailing-slash form missed `-v ~/.claude/gavel:/dst` (colon)
     ]
 
     init(configPath: String? = nil) {
@@ -183,12 +184,44 @@ final class RuleStore: ObservableObject {
         ),
 
         // ── Gavel/Claude self-protection: any Bash command referencing config paths ──
+        // The path segment is followed by `\b` (not a literal `/`) so the directory
+        // also matches when it precedes a `:` — the form a container `-v src:dst`
+        // bind-mount produces (`-v ~/.claude/gavel:/dst`), which the older
+        // trailing-slash pattern silently missed.
         PersistentRule(
             toolName: "Bash",
-            pattern: "\\.claude/(gavel/|settings|hooks/)",
+            pattern: "\\.claude/(gavel|settings|hooks)\\b|\\.codex/(config|hooks)\\b",
             isRegex: true,
             verdict: .prompt,
-            explanation: "Bash command references Gavel/Claude config — session allow for legitimate use",
+            explanation: "Bash command references Gavel/Claude/Codex config — session allow for legitimate use",
+            builtIn: true
+        ),
+
+        // ── Container-runtime bind-mount of a config dir ──
+        // A container started by Claude can run as root-in-container and bind-mount
+        // host paths writable; the actual write happens inside the container, so the
+        // protected path only appears as a `-v`/`--mount` source, evading the
+        // path-write rules. Catches mounts of `.claude`/`.codex` even when the mount
+        // is the parent dir (descended to inside the container).
+        PersistentRule(
+            toolName: "Bash",
+            pattern: "\\b(docker|podman|nerdctl|finch|orbctl|lima|colima|ctr|apptainer|singularity)\\b.*(-v|--volume|--mount)\\b[^\\n]*\\.(claude|codex)\\b",
+            isRegex: true,
+            verdict: .prompt,
+            explanation: "Container bind-mounts a Claude/Codex config dir — bypasses path-write protection",
+            builtIn: true
+        ),
+
+        // ── Container-runtime bind-mount of home root or filesystem root ──
+        // Mounting the whole home dir (or `/`) reaches every protected path with no
+        // literal `.claude` token in the command, so the rule above can't see it.
+        // Project-subdir mounts (`-v ~/proj:/app`, `-v $(pwd):/app`) are unaffected.
+        PersistentRule(
+            toolName: "Bash",
+            pattern: "\\b(docker|podman|nerdctl|finch|orbctl|lima|colima|ctr|apptainer|singularity)\\b.*(-v|--volume)\\s*=?\\s*(~|\\$HOME|/Users/[^:/\\s]+|/)\\s*:",
+            isRegex: true,
+            verdict: .prompt,
+            explanation: "Container bind-mounts home or filesystem root — reaches every protected path",
             builtIn: true
         ),
 

--- a/Tests/GavelTests/ApprovalEngineTests.swift
+++ b/Tests/GavelTests/ApprovalEngineTests.swift
@@ -127,6 +127,68 @@ final class ApprovalEngineTests: XCTestCase {
         }
     }
 
+    // MARK: - Container bind-mount self-protection (docker-group bypass class)
+
+    func testContainerBindMountOfConfigPromptsUnderAutoApprove() {
+        session.autoApproveUntil = Date().addingTimeInterval(300)
+        for cmd in [
+            "docker run --rm --pull=never -v ~/.claude/gavel:/hg:rw postgres:16 /usr/bin/install -m 0644 /etc/hostname /hg/rules.json",
+            "docker run --rm -v ~/.claude:/hc:rw postgres:16 find /hc/gavel -name x -delete",
+            "podman run -v ~/.codex:/hc alpine cp /etc/hostname /hc/config.toml",
+            "nerdctl run --mount type=bind,src=$HOME/.claude/hooks,dst=/h busybox true",
+        ] {
+            let decision = engine.evaluate(payload: payload(command: cmd), session: session)
+            XCTAssertEqual(decision.verdict, .block, "container config bind-mount must prompt: \(cmd)")
+            XCTAssertTrue(decision.askUser, "expected dialog for: \(cmd)")
+        }
+    }
+
+    func testContainerBindMountOfHomeOrRootPromptsUnderAutoApprove() {
+        session.autoApproveUntil = Date().addingTimeInterval(300)
+        for cmd in [
+            "docker run -v ~:/h ubuntu:22.04 /usr/bin/install -m 0644 /etc/hostname /h/somefile",
+            "podman run -v $HOME:/h alpine cp /etc/hostname /h/x",
+            "docker run -v /Users/jjrawlins:/host ubuntu touch /host/x",
+            "docker run -v /:/rootfs busybox true",
+        ] {
+            let decision = engine.evaluate(payload: payload(command: cmd), session: session)
+            XCTAssertEqual(decision.verdict, .block, "container home/root bind-mount must prompt: \(cmd)")
+            XCTAssertTrue(decision.askUser, "expected dialog for: \(cmd)")
+        }
+    }
+
+    func testBenignContainerMountsNotFlagged() {
+        session.autoApproveUntil = Date().addingTimeInterval(300)
+        for cmd in [
+            "docker run --rm -v $(pwd):/app -w /app node:20 npm test",
+            "docker run -v ./data:/data postgres:16",
+            "docker run -v ~/projects/myapp:/app golang:1.22 go build",
+            "docker run -v /Users/jjrawlins/code/app:/app ubuntu make",
+            "docker run -v /data:/data postgres:16",
+            "docker compose up -d",
+            "docker ps",
+        ] {
+            let decision = engine.evaluate(payload: payload(command: cmd), session: session)
+            XCTAssertEqual(decision.verdict, .allow, "benign container command must not prompt: \(cmd)")
+        }
+    }
+
+    func testSeedMigrationReplacesSupersededSelfProtectionPattern() {
+        let path = NSTemporaryDirectory() + "seed-selfprotect-\(UUID().uuidString).json"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let oldNarrow = "\\.claude/(gavel/|settings|hooks/)"
+        let oldRule = PersistentRule(toolName: "Bash", pattern: oldNarrow, isRegex: true,
+                                     verdict: .prompt, explanation: "old", builtIn: true)
+        let data = try! JSONEncoder().encode(RulesFile(version: 9, deletedBuiltInPatterns: [], rules: [oldRule]))
+        FileManager.default.createFile(atPath: path, contents: data)
+
+        let store = RuleStore(configPath: path)
+        let selfProtect = store.rules.filter { $0.toolName == "Bash" && $0.pattern.contains("gavel") }.map(\.pattern)
+        XCTAssertEqual(selfProtect.count, 1, "exactly one Bash self-protection rule after re-seed (no duplicate)")
+        XCTAssertFalse(selfProtect.contains(oldNarrow), "old trailing-slash pattern dropped on re-seed")
+        XCTAssertTrue(selfProtect.first?.contains("gavel|settings|hooks") ?? false, "broadened pattern seeded")
+    }
+
     func testCommitCheckpointNotSilencedByAllowRule() {
         engine.ruleStore.addRule(PersistentRule(toolName: "Bash", pattern: "git *", verdict: .allow))
         let decision = engine.evaluate(payload: payload(command: "git commit -m \"wip\""), session: session)

--- a/Tests/GavelTests/PersistentRuleTests.swift
+++ b/Tests/GavelTests/PersistentRuleTests.swift
@@ -185,10 +185,10 @@ final class PersistentRuleTests: XCTestCase {
         let store = RuleStore(configPath: "/dev/null")
         let builtInRules = store.rules.filter { $0.builtIn }
         XCTAssertEqual(builtInRules.count, RuleStore.seededDefaults.count)
-        // v8: 5 MCP exfil + 1 Bash self-protection + 1 apply_patch self-protection
-        //     + 1 scripting + 3 sandbox escape + 2 git safety + 1 commit checkpoint
-        //     + 1 infra apply + 3 scheduler = 18
-        XCTAssertEqual(builtInRules.count, 18)
+        // v10: 5 MCP exfil + 1 Bash self-protection + 1 apply_patch self-protection
+        //      + 2 container bind-mount self-protection + 1 scripting + 3 sandbox escape
+        //      + 2 git safety + 1 commit checkpoint + 1 infra apply + 3 scheduler = 20
+        XCTAssertEqual(builtInRules.count, 20)
     }
 
     func testSeededRulesArePromptVerdict() {


### PR DESCRIPTION
## Problem

Gavel gates Claude's intent as a **command string** — its self-protection is regex over the Bash command text. A pentest (2026-06-03) bypassed it with:

```
docker run --rm -v ~/.claude/gavel:/hg:rw postgres:16 /usr/bin/install -m 0644 /etc/hostname /hg/rules.json
```

This evades the blocklist two ways:
1. The protected path appears only as a `-v` **mount source**, and the write verb (`install`) runs **inside the container** — Docker Desktop maps the container-root write back to the host UID, so `rules.json` is overwritten with no matchable write-to-protected-path token.
2. The seeded catch-all required `gavel/` with a trailing slash; `-v …/gavel:/dst` puts a colon there.

Asymmetry that proves the direction: during the pentest every **delete** attempt was blocked (delete-protection keys on `rm`/`-delete` + path) while **write** got through (write-protection keyed on an incomplete verb allowlist).

## Change (stopgap consent layer)

- Broaden the Bash self-protection pattern to `\.claude/(gavel|settings|hooks)\b` (+ `.codex`) so the dir matches when followed by `:`. Old trailing-slash pattern added to `supersededBuiltInPatterns` so it swaps cleanly on re-seed (no duplicate).
- Two new built-in **PROMPT** rules for the container-runtime bypass class:
  - bind-mount of a `.claude`/`.codex` dir
  - bind-mount of `$HOME`/`~`/`/` (reaches every protected path with no literal `.claude` token)
  - across docker/podman/nerdctl/finch/orbctl/lima/colima/ctr/apptainer/singularity. Project-subdir mounts (`$(pwd)`, `~/proj`) stay allowed.
- Seed v9 → v10; built-in rule count 18 → 20.

## Not in this PR

A command-string blocklist is unwinnable by enumeration (`--mount` syntax, `dd`, `sed -i`, `python -c open(...,'w')`, symlinks all evade it). The structural fix — `uchg` immutable flag + FSEvents detect/revert + optional EndpointSecurity — is captured in a design doc and tracked separately. These deny-rules are the cheap first line (a prompt before the write is attempted), complementary to that enforcement layer.

## Tests

3 new container bind-mount tests + 1 seed-migration dedupe test. Full suite: **397 passing**.