### PR TITLE
feat(approval): enforce rules.json immutability (config integrity tier 1)

### DIFF
--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -394,7 +394,8 @@ final class RuleStore: ObservableObject {
         let file = RulesFile(version: fileVersion, deletedBuiltInPatterns: deletedBuiltInPatterns, rules: rules)
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted
-        if let data = try? encoder.encode(file) {
+        guard let data = try? encoder.encode(file) else { return }
+        ConfigIntegrity.shared.withWriteWindow(path: configPath) {
             FileManager.default.createFile(atPath: configPath, contents: data)
         }
     }

--- a/Sources/Gavel/System/ConfigIntegrity.swift
+++ b/Sources/Gavel/System/ConfigIntegrity.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Tier-1 filesystem integrity enforcement for Gavel's own config.
+///
+/// Sets the user-immutable flag (`UF_IMMUTABLE`, i.e. `chflags uchg`) on the
+/// security-critical config so a write by any process — including a container
+/// bind-mount that bypasses command-string matching — fails with `EPERM` at the
+/// host filesystem layer, regardless of which binary or runtime initiated it.
+/// The daemon's own saves route through ``withWriteWindow(path:_:)``, which
+/// briefly clears the flag.
+final class ConfigIntegrity {
+    static let shared = ConfigIntegrity()
+
+    private let lock = NSLock()
+    private let protectedPaths: Set<String>
+
+    init(protectedPaths: [String]? = nil) {
+        let resolved = protectedPaths ?? [Self.defaultRulesPath]
+        self.protectedPaths = Set(resolved.map(Self.standardize))
+    }
+
+    private static var defaultRulesPath: String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/.claude/gavel/rules.json"
+    }
+
+    private static func standardize(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+
+    /// Re-assert immutability on every protected path that currently exists.
+    func protect() {
+        lock.lock()
+        defer { lock.unlock() }
+        for path in protectedPaths { setImmutable(path, true) }
+    }
+
+    /// Clear immutability on every protected path so the files are editable while
+    /// the daemon is not running and gating.
+    func unprotect() {
+        lock.lock()
+        defer { lock.unlock() }
+        for path in protectedPaths { setImmutable(path, false) }
+    }
+
+    /// Run `body` (a write to `path`) with the immutable flag cleared, then
+    /// re-assert it. A path outside the protected set runs `body` untouched, so
+    /// the temp/`/dev/null` config used in tests is never flagged.
+    func withWriteWindow(path: String, _ body: () -> Void) {
+        let target = Self.standardize(path)
+        guard protectedPaths.contains(target) else {
+            body()
+            return
+        }
+        lock.lock()
+        defer { lock.unlock() }
+        setImmutable(target, false)
+        body()
+        setImmutable(target, true)
+    }
+
+    @discardableResult
+    private func setImmutable(_ path: String, _ enable: Bool) -> Bool {
+        var info = stat()
+        guard lstat(path, &info) == 0 else { return false }
+        let immutable = UInt32(UF_IMMUTABLE)
+        let updated = enable ? (info.st_flags | immutable) : (info.st_flags & ~immutable)
+        if updated == info.st_flags { return true }
+        if chflags(path, updated) == 0 { return true }
+        gavelLog("ConfigIntegrity: chflags(\(enable ? "uchg" : "nouchg")) failed for \(path): \(String(cString: strerror(errno)))")
+        return false
+    }
+}

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -305,6 +305,23 @@ for sig: Int32 in [SIGABRT, SIGSEGV, SIGBUS, SIGILL, SIGFPE] {
     }
 }
 
+// SIGTERM (launchd / `brew services stop`) and SIGINT (dev Ctrl-C) do NOT
+// trigger applicationWillTerminate, so config would stay immutable after a
+// graceful stop. Handle them via DispatchSource (runs off the signal context,
+// so the lock + chflags in unprotect() are safe) to clear the flag before exit.
+let signalQueue = DispatchQueue(label: "com.gavel.signals")
+let terminationSignalSources: [DispatchSourceSignal] = [SIGTERM, SIGINT].map { sig in
+    signal(sig, SIG_IGN)
+    let source = DispatchSource.makeSignalSource(signal: sig, queue: signalQueue)
+    source.setEventHandler {
+        gavelLog("SIGNAL: \(sig) — unprotecting config before exit")
+        ConfigIntegrity.shared.unprotect()
+        exit(0)
+    }
+    source.resume()
+    return source
+}
+
 gavelLog("Gavel starting")
 
 // Single-instance guard: probe the socket BEFORE NSApplication.run() so a

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -44,6 +44,7 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         setupMenuBar()
         setupSocketServer()
         setupHookRouter()
+        ConfigIntegrity.shared.protect()
         GavelNotifications.requestPermission()
 
         sessionManager.$defaultAutoApprove
@@ -68,6 +69,7 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        ConfigIntegrity.shared.unprotect()
         socketServer?.stop()
     }
 

--- a/Tests/GavelTests/ConfigIntegrityTests.swift
+++ b/Tests/GavelTests/ConfigIntegrityTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import Gavel
+
+final class ConfigIntegrityTests: XCTestCase {
+    private var dir: String!
+    private var rulesPath: String!
+    private var integrity: ConfigIntegrity!
+
+    override func setUpWithError() throws {
+        dir = NSTemporaryDirectory() + "configintegrity-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        rulesPath = dir + "/rules.json"
+        FileManager.default.createFile(atPath: rulesPath, contents: Data("{}".utf8))
+        integrity = ConfigIntegrity(protectedPaths: [rulesPath])
+    }
+
+    override func tearDownWithError() throws {
+        if let entries = try? FileManager.default.contentsOfDirectory(atPath: dir) {
+            for entry in entries { chflags(dir + "/" + entry, 0) }
+        }
+        try? FileManager.default.removeItem(atPath: dir)
+    }
+
+    private func isImmutable(_ path: String) -> Bool {
+        var info = stat()
+        guard lstat(path, &info) == 0 else { return false }
+        return info.st_flags & UInt32(UF_IMMUTABLE) != 0
+    }
+
+    private func externalWriteSucceeds(_ path: String) -> Bool {
+        do {
+            try Data("tampered".utf8).write(to: URL(fileURLWithPath: path))
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func testProtectMakesFileImmutableAndBlocksExternalWrite() {
+        integrity.protect()
+        XCTAssertTrue(isImmutable(rulesPath), "protected file must carry UF_IMMUTABLE")
+        XCTAssertFalse(externalWriteSucceeds(rulesPath), "external write must fail with EPERM once immutable")
+    }
+
+    func testWriteWindowAllowsDaemonWriteThenReasserts() {
+        integrity.protect()
+        var bodyRan = false
+        integrity.withWriteWindow(path: rulesPath) {
+            bodyRan = true
+            try? Data("daemon-write".utf8).write(to: URL(fileURLWithPath: rulesPath))
+        }
+        XCTAssertTrue(bodyRan, "write-window must run the body")
+        XCTAssertEqual(try? String(contentsOfFile: rulesPath, encoding: .utf8), "daemon-write")
+        XCTAssertTrue(isImmutable(rulesPath), "immutability must be re-asserted after the window closes")
+        XCTAssertFalse(externalWriteSucceeds(rulesPath), "external write blocked again after the window")
+    }
+
+    func testUnprotectClearsImmutableAndAllowsWrite() {
+        integrity.protect()
+        integrity.unprotect()
+        XCTAssertFalse(isImmutable(rulesPath))
+        XCTAssertTrue(externalWriteSucceeds(rulesPath), "write must succeed once unprotected")
+    }
+
+    func testProtectIsIdempotent() {
+        integrity.protect()
+        integrity.protect()
+        XCTAssertTrue(isImmutable(rulesPath))
+    }
+
+    func testProtectIgnoresAbsentPath() {
+        let absent = ConfigIntegrity(protectedPaths: [dir + "/does-not-exist.json"])
+        absent.protect()
+        absent.unprotect()
+    }
+
+    func testWriteWindowLeavesUnprotectedPathUntouched() {
+        let other = dir + "/session-defaults.json"
+        FileManager.default.createFile(atPath: other, contents: Data("{}".utf8))
+        integrity.withWriteWindow(path: other) {
+            try? Data("x".utf8).write(to: URL(fileURLWithPath: other))
+        }
+        XCTAssertFalse(isImmutable(other), "a path outside the protected set must never be flagged")
+    }
+
+    func testSharedSingletonDoesNotFlagTestTempPaths() {
+        let temp = dir + "/rules.json"
+        ConfigIntegrity.shared.withWriteWindow(path: temp) {
+            try? Data("x".utf8).write(to: URL(fileURLWithPath: temp))
+        }
+        XCTAssertFalse(isImmutable(temp), "the production singleton must not flag temp config used in tests")
+    }
+}


### PR DESCRIPTION
## Why

The container bind-mount pentest (2026-06-03, shipped consent-layer fix in #109/v1.18.1) proved Gavel's self-protection is **regex over the Bash command string** — and that's unwinnable by enumeration. A `docker run -v ~/.claude/gavel:/dst …`, `dd`, `sed -i`, `python -c "open(...,'w')"`, a symlink, or any non-enumerated runtime all evade a command-string blocklist. The only thing that observes the write *regardless of how it's phrased* is a **filesystem event**.

This is **Tier 1** of the integrity design (`~integrity-monitor-design.md`): move `rules.json` protection below the command-string layer.

## What

- **`ConfigIntegrity`** (`Sources/Gavel/System/ConfigIntegrity.swift`) sets `UF_IMMUTABLE` (`chflags uchg`) on `rules.json`. An external write — direct, `sed -i`, or the docker bind-mount — fails with **`EPERM`** at the host filesystem, no matter which binary or container initiated it. User-immutable needs **no root, no entitlement, no notarization change** (deliberately not `schg`, which the original pentest writeup suggested — that needs root and the daemon is a user LaunchAgent).
- **`RuleStore.saveRules()`** routes its write through `withWriteWindow`: `clear uchg → write → re-set uchg`. The daemon's own saves — including UI rule **add/edit/delete/toggle** — work transparently; only the ~1ms window per save is added. Writes that don't come through the daemon's save path (docker, another shell) never open a window → `EPERM`.
- **Path-gated:** only the real `rules.json` is ever flagged. Temp / `/dev/null` config used throughout the test suite is left untouched, so blast radius on existing tests is zero.
- **Lifecycle:** `protect()` on daemon start, `unprotect()` on graceful stop (SIGTERM via `brew services restart` / quit). Files are locked only while the daemon is running and gating; re-asserted idempotently on next start. A SIGKILL leaves the flag set; next start re-asserts and the write-window still works, so nothing bricks — manual recovery if ever needed is one `chflags nouchg`.

## Scope decisions (chosen with @JaysonRawlins)

- **`rules.json` only.** `hooks/**` + `settings*` deferred: the hooks are **per-file symlinks** into the `claude-config` dotfiles repo, so `chflags` would follow into the repo (or need `lchflags` on the link, which only stops repointing, not content tampering). That needs its own decision — separate PR.
- **Unprotect on graceful stop**, not "stay locked forever." Avoids bricking manual edits / brew / dev workflows while gavel is down. Residual: a `stop → tamper → start` sequence isn't caught — that's a different threat class (Tier 3 territory).

## Not in this PR

- **Tier 2** — FSEvents/`DispatchSource` watcher that detects a write inside the ~1ms window, reverts from the in-memory known-good `RuleStore.rules`, and alerts via the Feed/`gavel.log`. Closes the window residual.
- **Tier 3** — EndpointSecurity root daemon with PID attribution (synchronous prevention + "who"). Needs an Apple entitlement + notarized privileged helper.

## Tests

7 new (`ConfigIntegrityTests`): immutable-blocks-external-write, write-window round-trip + re-assert, unprotect, idempotent protect, absent-path no-op, unprotected-path-untouched, and a `shared`-singleton-skips-temp-paths blast-radius guard. Full suite **397 → 404**, all passing.

## Manual verification plan (post-merge, live daemon)

Re-run the exact v1.18.1 exploit and expect `EPERM` + unchanged sha instead of a prompt-and-deny:
```
docker run --rm -v ~/.claude/gavel:/hg:rw postgres:16 /usr/bin/install -m 0644 /etc/hostname /hg/rules.json
```
Plus: add a rule in the UI (save succeeds, `ls -lO` shows `uchg` re-set), and `brew services restart gavel` (flag re-applied idempotently).
---

## Live verification (dev-daemon, before merge)

Ran `.build/release/gavel` against the real `~/.claude/gavel/rules.json` (brew daemon paused, rules.json backed up first):

| Check | Result |
|-------|--------|
| `protect()` on daemon start | `rules.json` → `flags=[uchg]` ✅ |
| **docker bind-mount write to rules.json** (consent panel approved, so docker actually ran) | `sh: can't create /hg/rules.json: Operation not permitted` — **EPERM** ✅ |
| `rules.json` integrity after blocked write | sha unchanged ✅ |
| SIGTERM (`brew services stop` path) → `unprotect()` | **caught a bug** ⚠️ → fixed (below) |

**Bug caught by live test (now fixed in 07e94ae):** `applicationWillTerminate` does **not** fire on SIGTERM (launchd / `brew services stop`) or SIGINT (dev Ctrl-C) — only on the Quit menu / `NSApp.terminate`. So after a graceful stop the daemon exited 143 with `rules.json` **still `uchg`**, defeating the unprotect-on-stop design (and would have stranded the file immutable under the no-ConfigIntegrity brew daemon). Fix: `DispatchSource` signal handlers for SIGTERM/SIGINT that call `ConfigIntegrity.unprotect()` then `exit(0)` (DispatchSource runs off the signal context, so the lock + `chflags` are safe). Re-verified live: SIGTERM now exits 0 with `flags=[-]`.

A green build + 404 passing unit tests both reported "fine" on the broken version — this is why daemon-side lifecycle code gets run live, not just compiled.