### PR TITLE
feat(approval): watch rules.json and revert out-of-band writes (config integrity tier 2)

### DIFF
--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -387,14 +387,34 @@ final class RuleStore: ObservableObject {
         saveRules()
     }
 
+    var filePath: String { configPath }
+
+    func onDiskMatchesMemory() -> Bool {
+        guard let raw = FileManager.default.contents(atPath: configPath),
+              let onDisk = try? JSONDecoder().decode(RulesFile.self, from: raw) else { return false }
+        let memory = RulesFile(version: fileVersion, deletedBuiltInPatterns: deletedBuiltInPatterns, rules: rules)
+        let canonical = JSONEncoder()
+        canonical.outputFormatting = .sortedKeys
+        guard let a = try? canonical.encode(onDisk), let b = try? canonical.encode(memory) else { return false }
+        return a == b
+    }
+
+    func reassertOnDisk() {
+        saveRules()
+    }
+
+    private func encodedRules() -> Data? {
+        let file = RulesFile(version: fileVersion, deletedBuiltInPatterns: deletedBuiltInPatterns, rules: rules)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        return try? encoder.encode(file)
+    }
+
     private func saveRules() {
         let dir = (configPath as NSString).deletingLastPathComponent
         try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
 
-        let file = RulesFile(version: fileVersion, deletedBuiltInPatterns: deletedBuiltInPatterns, rules: rules)
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
-        guard let data = try? encoder.encode(file) else { return }
+        guard let data = encodedRules() else { return }
         ConfigIntegrity.shared.withWriteWindow(path: configPath) {
             FileManager.default.createFile(atPath: configPath, contents: data)
         }

--- a/Sources/Gavel/System/ConfigWatcher.swift
+++ b/Sources/Gavel/System/ConfigWatcher.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Tier-2 integrity watcher: detects an out-of-band write to a config file and
+/// reverts it from the daemon's in-memory known-good copy, then alerts.
+///
+/// Complements ``ConfigIntegrity`` (Tier 1): the immutable flag blocks most
+/// external writes outright, and this watcher closes the brief clear→write→set
+/// window — any change that does land and does not match memory is reverted.
+/// The daemon's own saves are ignored automatically because their on-disk bytes
+/// match the in-memory re-encoding `isIntact` checks.
+final class ConfigWatcher {
+    private let path: String
+    private let isIntact: () -> Bool
+    private let restore: () -> Void
+    private let onTamper: () -> Void
+    private let queue: DispatchQueue
+
+    private var fileHandle: FileHandle?
+    private var source: DispatchSourceFileSystemObject?
+
+    init(path: String,
+         isIntact: @escaping () -> Bool,
+         restore: @escaping () -> Void,
+         onTamper: @escaping () -> Void) {
+        self.path = path
+        self.isIntact = isIntact
+        self.restore = restore
+        self.onTamper = onTamper
+        self.queue = DispatchQueue(label: "gavel.config-watcher", qos: .utility)
+    }
+
+    func start() {
+        queue.async { [weak self] in self?.openAndSubscribe() }
+    }
+
+    func stop() {
+        queue.async { [weak self] in self?.tearDown() }
+    }
+
+    func evaluateOnce() {
+        guard !isIntact() else { return }
+        restore()
+        onTamper()
+    }
+
+    private func openAndSubscribe() {
+        let url = URL(fileURLWithPath: path)
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
+            evaluateOnce()
+            queue.asyncAfter(deadline: .now() + 1.0) { [weak self] in self?.openAndSubscribe() }
+            return
+        }
+        fileHandle = handle
+
+        let src = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: handle.fileDescriptor,
+            eventMask: [.write, .delete, .rename],
+            queue: queue
+        )
+        src.setEventHandler { [weak self] in self?.handleFsEvent() }
+        src.resume()
+        source = src
+
+        evaluateOnce()
+    }
+
+    private func handleFsEvent() {
+        guard let source = source else { return }
+        let mask = source.data
+        if mask.contains(.delete) || mask.contains(.rename) {
+            reopenAfterRotation()
+            return
+        }
+        if mask.contains(.write) {
+            evaluateOnce()
+        }
+    }
+
+    private func reopenAfterRotation() {
+        tearDown()
+        queue.asyncAfter(deadline: .now() + 0.2) { [weak self] in self?.openAndSubscribe() }
+    }
+
+    private func tearDown() {
+        source?.cancel()
+        source = nil
+        try? fileHandle?.close()
+        fileHandle = nil
+    }
+}

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -33,6 +33,7 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         approvalCoordinator: approvalCoordinator
     )
     var socketServer: SocketServer?
+    var configWatcher: ConfigWatcher?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Disable macOS smart dashes/quotes — gavel needs exact ASCII for patterns
@@ -45,6 +46,7 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         setupSocketServer()
         setupHookRouter()
         ConfigIntegrity.shared.protect()
+        setupConfigWatcher()
         GavelNotifications.requestPermission()
 
         sessionManager.$defaultAutoApprove
@@ -69,8 +71,26 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        configWatcher?.stop()
         ConfigIntegrity.shared.unprotect()
         socketServer?.stop()
+    }
+
+    private func setupConfigWatcher() {
+        let ruleStore = approvalEngine.ruleStore
+        configWatcher = ConfigWatcher(
+            path: ruleStore.filePath,
+            isIntact: { ruleStore.onDiskMatchesMemory() },
+            restore: { ruleStore.reassertOnDisk() },
+            onTamper: { [weak self] in
+                let message = "rules.json modified out-of-band — reverted from in-memory rules"
+                gavelLog("ConfigWatcher: \(message)")
+                DispatchQueue.main.async {
+                    self?.viewModel.appendFeedEntry(.system("⚠️ \(message)", pid: Int(getpid()), at: Date()))
+                }
+            }
+        )
+        configWatcher?.start()
     }
 
     // MARK: - Main Menu (needed for Cmd+V/C/X/A in text fields)

--- a/Tests/GavelTests/ConfigWatcherTests.swift
+++ b/Tests/GavelTests/ConfigWatcherTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import Gavel
+
+final class ConfigWatcherTests: XCTestCase {
+    func testEvaluateRevertsAndAlertsWhenTampered() {
+        var restored = 0
+        var alerted = 0
+        let watcher = ConfigWatcher(
+            path: "/tmp/unused",
+            isIntact: { false },
+            restore: { restored += 1 },
+            onTamper: { alerted += 1 }
+        )
+        watcher.evaluateOnce()
+        XCTAssertEqual(restored, 1, "a mismatched file must be restored")
+        XCTAssertEqual(alerted, 1, "a tamper must raise exactly one alert")
+    }
+
+    func testEvaluateIsNoOpWhenIntact() {
+        var restored = 0
+        var alerted = 0
+        let watcher = ConfigWatcher(
+            path: "/tmp/unused",
+            isIntact: { true },
+            restore: { restored += 1 },
+            onTamper: { alerted += 1 }
+        )
+        watcher.evaluateOnce()
+        XCTAssertEqual(restored, 0, "an intact file must not be rewritten")
+        XCTAssertEqual(alerted, 0, "an intact file must not alert (no false positive on the daemon's own write)")
+    }
+}
+
+final class RuleStoreIntegrityTests: XCTestCase {
+    private var path: String!
+
+    override func setUpWithError() throws {
+        path = NSTemporaryDirectory() + "rulestore-integrity-\(UUID().uuidString).json"
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    func testOnDiskMatchesMemoryAfterSave() {
+        let store = RuleStore(configPath: path)
+        store.addRule(PersistentRule(toolName: "Bash", pattern: "tier2-marker", verdict: .allow))
+        XCTAssertTrue(store.onDiskMatchesMemory(), "on-disk must match memory right after a save")
+    }
+
+    func testOnDiskMismatchAfterExternalTamper() {
+        let store = RuleStore(configPath: path)
+        store.addRule(PersistentRule(toolName: "Bash", pattern: "tier2-marker", verdict: .allow))
+        try? Data("CORRUPTED".utf8).write(to: URL(fileURLWithPath: path))
+        XCTAssertFalse(store.onDiskMatchesMemory(), "an out-of-band write must read as a mismatch")
+    }
+
+    func testReassertRestoresFromMemory() {
+        let store = RuleStore(configPath: path)
+        store.addRule(PersistentRule(toolName: "Bash", pattern: "tier2-marker", verdict: .allow))
+        try? Data("CORRUPTED".utf8).write(to: URL(fileURLWithPath: path))
+        XCTAssertFalse(store.onDiskMatchesMemory())
+
+        store.reassertOnDisk()
+
+        XCTAssertTrue(store.onDiskMatchesMemory(), "reassert must rewrite the file from memory")
+        let reloaded = RuleStore(configPath: path)
+        XCTAssertTrue(reloaded.rules.contains { $0.pattern == "tier2-marker" }, "restored file must decode back to the known-good rules")
+    }
+
+    func testOnDiskMismatchWhenFileMissing() {
+        let store = RuleStore(configPath: path)
+        try? FileManager.default.removeItem(atPath: path)
+        XCTAssertFalse(store.onDiskMatchesMemory(), "a deleted file must read as a mismatch so the watcher recreates it")
+    }
+
+    func testOnDiskMatchesMemoryIgnoresFormattingAndKeyOrder() {
+        let store = RuleStore(configPath: path)
+        store.addRule(PersistentRule(toolName: "Bash", pattern: "fmt-marker", verdict: .allow))
+
+        let raw = FileManager.default.contents(atPath: path)!
+        let decoded = try! JSONDecoder().decode(RulesFile.self, from: raw)
+        let reformatted = try! JSONEncoder().encode(decoded)
+        try! reformatted.write(to: URL(fileURLWithPath: path))
+
+        XCTAssertNotEqual(reformatted, raw, "precondition: a different encoder produces different bytes")
+        XCTAssertTrue(store.onDiskMatchesMemory(), "same data with different formatting/key order must NOT read as tamper")
+    }
+}


### PR DESCRIPTION
## Why

Tier 1 (#111, v1.19.0) makes `rules.json` `uchg`-immutable — an external write hits EPERM regardless of phrasing. But the daemon's own saves must briefly clear the flag (`clear → write → re-set`), leaving a ~1ms window. Tier 2 closes that window and also catches any write that lands while the flag is cleared out-of-band.

This is **Tier 2** of `~integrity-monitor-design.md`: detect → revert → alert.

## What

- **`ConfigWatcher`** (`Sources/Gavel/System/ConfigWatcher.swift`) — a `DispatchSource` file watcher on `rules.json`, mirroring the existing `JsonlWatcher` house pattern (`[.write, .delete, .rename]`, utility queue, reopen-after-rotation). On any event it re-checks integrity; a mismatch triggers revert + alert. Closures (`isIntact`/`restore`/`onTamper`) keep it decoupled from `RuleStore` and unit-testable without real FS events.
- **`RuleStore.onDiskMatchesMemory()`** — compares **semantically**: decode the on-disk file and the in-memory rules, re-encode **both** with sorted keys, compare. The daemon's own saves are ignored automatically (on-disk decodes equal to memory), so there's no race-prone "expecting write" flag.
- **`RuleStore.reassertOnDisk()`** — rewrites from the in-memory known-good rules through the Tier-1 write-window, which also re-locks `uchg`.
- **`main.swift`** — `setupConfigWatcher()` after `protect()`; alert = `gavel.log` line + a `⚠️` Feed entry.

## The bug live testing caught (fixed before this PR's first commit)

My first cut compared **raw bytes**. `JSONEncoder` output is **not byte-stable across processes** (key order differs), so a byte compare reports "tamper" on any file written by a *different* binary — including a perfectly valid one. The dev daemon **false-reverted + alerted on startup**. A green build + unit tests missed it (the unit tests stub `isIntact` with closures and never exercise cross-process encoding). Fix: semantic decode/re-encode-sorted comparison, plus a regression test asserting same-data/different-formatting must **not** read as tamper.

## Scope

Detect/revert **while running**. `stop → tamper → start` is **not** covered — the daemon adopts on-disk truth on load; catching that needs a persisted integrity baseline (Tier 3 territory). Called out so it isn't oversold.

## Tests

7 new (`ConfigWatcherTests` + `RuleStoreIntegrityTests`): revert+alert on mismatch, no-op when intact, save↔memory match, mismatch after tamper, mismatch when file missing, reassert restores from memory, and the formatting/key-order regression guard. Full suite **404 → 411**.

## Live verification (dev-daemon)

- Startup with a file written by another binary → **no** false revert (sha + ConfigWatcher log count unchanged).
- `chflags nouchg rules.json && echo TIER2_REAL_TAMPER > rules.json` → reverted to valid rules, `uchg` re-set, **exactly one** Feed/log alert, rules semantically intact.
- System restored: brew 1.19.0 live, `rules.json` byte-identical to pre-test.