### PR TITLE
feat(approval): verify rules.json integrity on load via keyed baseline (tier 2.5)

### DIFF
--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -14,6 +14,15 @@ final class RuleStore: ObservableObject {
     private var fileVersion: Int = 0
     private let configPath: String
 
+    enum IntegrityStatus { case intact, established, restoredFromBackup, resetToDefaults }
+    private(set) var lastLoadIntegrityStatus: IntegrityStatus = .intact
+
+    private var signaturePath: String { configPath + ".integrity" }
+    private var backupPath: String { configPath + ".bak" }
+    private lazy var baseline = ConfigBaseline(
+        keyPath: (configPath as NSString).deletingLastPathComponent + "/.integrity-key"
+    )
+
     /// Current seed version — bump when adding new default rules.
     private static let seedVersion = 10
 
@@ -365,8 +374,12 @@ final class RuleStore: ObservableObject {
             deletedBuiltInPatterns = []
         }
 
+        let needsPersist = validateOrRecover()
+
         if fileVersion < Self.seedVersion {
             seedDefaults(existingRules: rules, version: fileVersion, deleted: deletedBuiltInPatterns)
+        } else if needsPersist || !baseline.signatureExists(at: signaturePath) || !FileManager.default.fileExists(atPath: backupPath) {
+            saveRules()
         }
     }
 
@@ -391,11 +404,8 @@ final class RuleStore: ObservableObject {
 
     func onDiskMatchesMemory() -> Bool {
         guard let raw = FileManager.default.contents(atPath: configPath),
-              let onDisk = try? JSONDecoder().decode(RulesFile.self, from: raw) else { return false }
-        let memory = RulesFile(version: fileVersion, deletedBuiltInPatterns: deletedBuiltInPatterns, rules: rules)
-        let canonical = JSONEncoder()
-        canonical.outputFormatting = .sortedKeys
-        guard let a = try? canonical.encode(onDisk), let b = try? canonical.encode(memory) else { return false }
+              let onDisk = try? JSONDecoder().decode(RulesFile.self, from: raw),
+              let a = canonical(onDisk), let b = canonicalRules() else { return false }
         return a == b
     }
 
@@ -403,11 +413,55 @@ final class RuleStore: ObservableObject {
         saveRules()
     }
 
+    func canonicalRules() -> Data? {
+        canonical(currentRulesFile())
+    }
+
+    private func currentRulesFile() -> RulesFile {
+        RulesFile(version: fileVersion, deletedBuiltInPatterns: deletedBuiltInPatterns, rules: rules)
+    }
+
+    private func canonical(_ file: RulesFile) -> Data? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        return try? encoder.encode(file)
+    }
+
     private func encodedRules() -> Data? {
-        let file = RulesFile(version: fileVersion, deletedBuiltInPatterns: deletedBuiltInPatterns, rules: rules)
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted
-        return try? encoder.encode(file)
+        return try? encoder.encode(currentRulesFile())
+    }
+
+    private func validateOrRecover() -> Bool {
+        guard baseline.signatureExists(at: signaturePath) else {
+            lastLoadIntegrityStatus = .established
+            return true
+        }
+        if let canon = canonicalRules(), baseline.isValid(canon, against: signaturePath) {
+            lastLoadIntegrityStatus = .intact
+            return false
+        }
+        if let recovered = trustedBackup() {
+            rules = recovered.rules
+            fileVersion = recovered.version
+            deletedBuiltInPatterns = recovered.deletedBuiltInPatterns
+            lastLoadIntegrityStatus = .restoredFromBackup
+            return true
+        }
+        rules = []
+        fileVersion = 0
+        deletedBuiltInPatterns = []
+        lastLoadIntegrityStatus = .resetToDefaults
+        return true
+    }
+
+    private func trustedBackup() -> RulesFile? {
+        guard let data = FileManager.default.contents(atPath: backupPath),
+              let file = try? JSONDecoder().decode(RulesFile.self, from: data),
+              let canon = canonical(file),
+              baseline.isValid(canon, against: signaturePath) else { return nil }
+        return file
     }
 
     private func saveRules() {
@@ -417,6 +471,10 @@ final class RuleStore: ObservableObject {
         guard let data = encodedRules() else { return }
         ConfigIntegrity.shared.withWriteWindow(path: configPath) {
             FileManager.default.createFile(atPath: configPath, contents: data)
+        }
+        try? data.write(to: URL(fileURLWithPath: backupPath))
+        if let canon = canonicalRules() {
+            baseline.recordSignature(of: canon, to: signaturePath)
         }
     }
 }

--- a/Sources/Gavel/System/ConfigBaseline.swift
+++ b/Sources/Gavel/System/ConfigBaseline.swift
@@ -1,0 +1,58 @@
+import CryptoKit
+import Foundation
+
+/// Tier 2.5: a keyed signature over the last-known-good config, so a change made
+/// while the daemon was NOT running (stop → tamper → start) is detected on load
+/// instead of being silently adopted as truth.
+///
+/// The HMAC key lives in a separate 0600 file. This stops non-targeted tampering
+/// (a script/installer/confused-deputy that rewrites the file without re-signing
+/// it) — it does NOT stop an attacker who reads the key and forges the signature.
+/// Only kernel enforcement (EndpointSecurity, Tier 3) crosses that line.
+final class ConfigBaseline {
+    private let keyPath: String
+
+    init(keyPath: String) {
+        self.keyPath = keyPath
+    }
+
+    func recordSignature(of data: Data, to path: String) {
+        let hex = hexSignature(of: data)
+        try? Data(hex.utf8).write(to: URL(fileURLWithPath: path))
+    }
+
+    func isValid(_ data: Data, against path: String) -> Bool {
+        guard let stored = try? String(contentsOfFile: path, encoding: .utf8) else { return false }
+        return constantTimeEquals(stored, hexSignature(of: data))
+    }
+
+    func signatureExists(at path: String) -> Bool {
+        FileManager.default.fileExists(atPath: path)
+    }
+
+    private func hexSignature(of data: Data) -> String {
+        let mac = HMAC<SHA256>.authenticationCode(for: data, using: loadOrCreateKey())
+        return mac.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func loadOrCreateKey() -> SymmetricKey {
+        if let existing = FileManager.default.contents(atPath: keyPath), existing.count == 32 {
+            return SymmetricKey(data: existing)
+        }
+        let key = SymmetricKey(size: .bits256)
+        let bytes = key.withUnsafeBytes { Data(Array($0)) }
+        let dir = (keyPath as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: keyPath, contents: bytes, attributes: [.posixPermissions: 0o600])
+        return key
+    }
+
+    private func constantTimeEquals(_ a: String, _ b: String) -> Bool {
+        let lhs = Array(a.utf8)
+        let rhs = Array(b.utf8)
+        guard lhs.count == rhs.count else { return false }
+        var diff: UInt8 = 0
+        for i in lhs.indices { diff |= lhs[i] ^ rhs[i] }
+        return diff == 0
+    }
+}

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -47,6 +47,7 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         setupHookRouter()
         ConfigIntegrity.shared.protect()
         setupConfigWatcher()
+        reportLoadIntegrity()
         GavelNotifications.requestPermission()
 
         sessionManager.$defaultAutoApprove
@@ -74,6 +75,20 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         configWatcher?.stop()
         ConfigIntegrity.shared.unprotect()
         socketServer?.stop()
+    }
+
+    private func reportLoadIntegrity() {
+        let message: String
+        switch approvalEngine.ruleStore.lastLoadIntegrityStatus {
+        case .intact, .established:
+            return
+        case .restoredFromBackup:
+            message = "rules.json was modified while gavel was stopped — restored from verified backup"
+        case .resetToDefaults:
+            message = "rules.json failed integrity check on load with no valid backup — reset to built-in defaults"
+        }
+        gavelLog("ConfigBaseline: \(message)")
+        viewModel.appendFeedEntry(.system("⚠️ \(message)", pid: Int(getpid()), at: Date()))
     }
 
     private func setupConfigWatcher() {

--- a/Tests/GavelTests/ConfigBaselineTests.swift
+++ b/Tests/GavelTests/ConfigBaselineTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import Gavel
+
+final class ConfigBaselineTests: XCTestCase {
+    private var dir: String!
+    private var path: String!
+
+    override func setUpWithError() throws {
+        dir = NSTemporaryDirectory() + "baseline-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        path = dir + "/rules.json"
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(atPath: dir)
+    }
+
+    func testIntactAcrossRestart() {
+        let first = RuleStore(configPath: path)
+        first.addRule(PersistentRule(toolName: "Bash", pattern: "baseline-marker", verdict: .allow))
+
+        let restart = RuleStore(configPath: path)
+        XCTAssertEqual(restart.lastLoadIntegrityStatus, .intact)
+        XCTAssertTrue(restart.rules.contains { $0.pattern == "baseline-marker" })
+    }
+
+    func testTamperWhileStoppedRestoresFromBackup() {
+        let first = RuleStore(configPath: path)
+        first.addRule(PersistentRule(toolName: "Bash", pattern: "baseline-marker", verdict: .allow))
+
+        try! Data("{\"version\":10,\"deletedBuiltInPatterns\":[],\"rules\":[]}".utf8)
+            .write(to: URL(fileURLWithPath: path))
+
+        let restart = RuleStore(configPath: path)
+        XCTAssertEqual(restart.lastLoadIntegrityStatus, .restoredFromBackup)
+        XCTAssertTrue(restart.rules.contains { $0.pattern == "baseline-marker" }, "the rule deleted by the tamper must be restored")
+        XCTAssertTrue(restart.onDiskMatchesMemory(), "the restored file must be written back to disk")
+    }
+
+    func testTamperWithGarbageRestoresFromBackup() {
+        let first = RuleStore(configPath: path)
+        first.addRule(PersistentRule(toolName: "Bash", pattern: "baseline-marker", verdict: .allow))
+
+        try! Data("NOT JSON AT ALL".utf8).write(to: URL(fileURLWithPath: path))
+
+        let restart = RuleStore(configPath: path)
+        XCTAssertEqual(restart.lastLoadIntegrityStatus, .restoredFromBackup)
+        XCTAssertTrue(restart.rules.contains { $0.pattern == "baseline-marker" })
+    }
+
+    func testTamperWithNoValidBackupResetsToDefaults() {
+        let first = RuleStore(configPath: path)
+        first.addRule(PersistentRule(toolName: "Bash", pattern: "baseline-marker", verdict: .allow))
+
+        try! Data("{\"version\":10,\"deletedBuiltInPatterns\":[],\"rules\":[]}".utf8)
+            .write(to: URL(fileURLWithPath: path))
+        try? FileManager.default.removeItem(atPath: path + ".bak")
+
+        let restart = RuleStore(configPath: path)
+        XCTAssertEqual(restart.lastLoadIntegrityStatus, .resetToDefaults)
+        XCTAssertFalse(restart.rules.contains { $0.pattern == "baseline-marker" }, "an unrecoverable tamper must not adopt the tampered rules")
+        XCTAssertTrue(restart.rules.contains { $0.builtIn }, "reset must fall back to safe built-in defaults")
+    }
+
+    func testForgedRulesWithoutValidSignatureIsNotTrusted() {
+        let first = RuleStore(configPath: path)
+        first.addRule(PersistentRule(toolName: "Bash", pattern: "baseline-marker", verdict: .allow))
+
+        try! Data("{\"version\":10,\"deletedBuiltInPatterns\":[],\"rules\":[{\"id\":\"\(UUID().uuidString)\",\"toolName\":\"Bash\",\"pattern\":\"*\",\"isRegex\":false,\"verdict\":\"allow\",\"builtIn\":false,\"isDisabled\":false,\"name\":\"evil\",\"createdAt\":1.0}]}".utf8)
+            .write(to: URL(fileURLWithPath: path))
+
+        let restart = RuleStore(configPath: path)
+        XCTAssertNotEqual(restart.lastLoadIntegrityStatus, .intact, "an injected allow-all rule with no valid signature must be rejected")
+        XCTAssertFalse(restart.rules.contains { $0.name == "evil" }, "the forged rule must not survive load")
+    }
+}


### PR DESCRIPTION
## Why

Tiers 1 (`uchg`, #111) and 2 (watcher, #113) protect `rules.json` **while the daemon runs**. But on a graceful stop the daemon unprotects (clears `uchg`), so a `stop → tamper → start` sequence slips through: an edit made while gavel is down is read on the next load and **adopted as truth** — Tier 2 can't catch it because the tampered content *becomes* the in-memory baseline. This PR closes that gap.

## What

- **`ConfigBaseline`** (`Sources/Gavel/System/ConfigBaseline.swift`) — HMAC-SHA256 over the canonical (sorted-key) rules, key in a separate `0600` file. `saveRules` now also writes a `.bak` copy and records the signature.
- **`RuleStore.loadRules` → `validateOrRecover()`**:
  - signature **valid** → intact.
  - signature **absent** → establish baseline (first run / upgrade), silent.
  - signature **present but mismatched** → tamper: **restore from the verified `.bak`**; if no valid backup, **reset to safe built-in defaults** (fail-safe — it never adopts tampered rules). Exposes `lastLoadIntegrityStatus`.
- **`main.swift reportLoadIntegrity()`** — logs + Feed-alerts on restore/reset.
- The canonical (sorted-key) encoding is now **shared** by the baseline and Tier 2's `onDiskMatchesMemory`, so neither false-positives on cross-process key ordering (the bug Tier 2's live test caught).

## Honest scope / ceiling

The key is a `0600` file. This stops **non-targeted** tampering — scripts, installers, confused-deputies that rewrite `rules.json` without re-signing it. An attacker who **reads the key and forges the HMAC** defeats it. On a single-user machine, no userspace scheme beats a same-uid attacker who specifically targets it — only kernel enforcement (**EndpointSecurity, Tier 3**) crosses that line. Keychain-backed key is a cheap follow-up that raises this bar.

Fail-safe direction matters: an unrecoverable tamper resets to **built-in defaults** (which include the security deny/prompt rules), never fail-open.

## Tests

5 new (`ConfigBaselineTests`): intact-across-restart, tamper→restore-from-backup, garbage→restore, no-valid-backup→reset-to-defaults, and **forged-allow-all-rule rejected**. Full suite **411 → 416**.

## Live verification (dev-daemon)

1. First run → baseline **established silently** (no false alert; `.bak`/`.integrity`/`0600` key created; `rules.json` sha unchanged-in-content).
2. Stop daemon (SIGTERM unprotects) → **wipe all rules** while down (hook fails open with no daemon — that's exactly the gap) → start daemon → restored the full **73-rule** set from the verified backup, re-locked `uchg`, logged **one** alert: `ConfigBaseline: rules.json was modified while gavel was stopped — restored from verified backup`.
3. System restored; test baseline files removed so they can't false-trigger a future shipped daemon.