### PR TITLE
feat(monitor): collapse to top-most compact bar on deactivate instead of hiding

### DIFF
--- a/Sources/Gavel/Monitor/AlwaysActivePanel.swift
+++ b/Sources/Gavel/Monitor/AlwaysActivePanel.swift
@@ -1,6 +1,0 @@
-import AppKit
-
-/// Custom NSPanel for the monitor window.
-/// Uses utilityWindow style to stay visible across spaces.
-class AlwaysActivePanel: NSPanel {
-}

--- a/Sources/Gavel/Monitor/FirstMouseHostingView.swift
+++ b/Sources/Gavel/Monitor/FirstMouseHostingView.swift
@@ -1,0 +1,7 @@
+import AppKit
+import SwiftUI
+
+/// Hosting view whose controls respond to the first click even when gavel is not the active app.
+final class FirstMouseHostingView<Content: View>: NSHostingView<Content> {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+}

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -24,6 +24,21 @@ struct MonitorWindow: View {
             }
         }
         .frame(minWidth: isCompact ? 320 : 600, minHeight: isCompact ? 28 : 400)
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)) { _ in
+            collapseOnDeactivate()
+        }
+    }
+
+    private func collapseOnDeactivate() {
+        guard !isCompact, !isPinned else { return }
+        guard let window = monitorWindow(), window.isVisible else { return }
+        setCompact(true)
+    }
+
+    private func expandFromCompact() {
+        NSApp.activate(ignoringOtherApps: true)
+        setCompact(false)
+        monitorWindow()?.makeKeyAndOrderFront(nil)
     }
 
     private var compactBar: some View {
@@ -36,7 +51,7 @@ struct MonitorWindow: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
             Spacer(minLength: 4)
-            Button(action: { setCompact(false) }) {
+            Button(action: { expandFromCompact() }) {
                 Image(systemName: "arrow.up.left.and.arrow.down.right")
             }
             .buttonStyle(.plain)
@@ -45,6 +60,8 @@ struct MonitorWindow: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
         .background(Color(nsColor: .controlBackgroundColor))
+        .contentShape(Rectangle())
+        .onTapGesture { expandFromCompact() }
     }
 
     private var fullBody: some View {
@@ -68,7 +85,9 @@ struct MonitorWindow: View {
                         .foregroundColor(isPinned ? .orange : .secondary)
                 }
                 .buttonStyle(.plain)
-                .help(isPinned ? "Unpin window" : "Pin window on top")
+                .help(isPinned
+                      ? "Unpin — clicking another app collapses the monitor to the compact bar"
+                      : "Pin the full window on top — stays expanded when you click another app")
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -190,7 +190,7 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
                 defer: false
             )
             window.title = "Gavel — Claude Code Monitor"
-            window.contentView = NSHostingView(rootView: contentView)
+            window.contentView = FirstMouseHostingView(rootView: contentView)
             window.center()
             window.isReleasedWhenClosed = false
             monitorWindow = window


### PR DESCRIPTION
## Problem

The monitor is a normal-level `NSWindow` in an `.accessory` app. Clicking any other app buried it behind everything — and with no Dock icon or Cmd-Tab entry, the only way back was the menu bar's Show Monitor. Effectively it disappeared.

## Change

The monitor now has exactly two states:

- **Full window** — while gavel is active.
- **Compact top-most bar** — on `NSApplication.didResignActiveNotification` the window auto-collapses to the existing compact floating bar (top-right, `.floating` level), so it stays visible over other apps. Clicking anywhere on the bar reactivates gavel and restores the full window at its saved frame.

Supporting changes:

- **Pin gets a real meaning**: pinned = stay expanded and on top when clicking away (no auto-collapse). Unpinned = collapse on deactivate. Help text updated.
- **`FirstMouseHostingView`** (new) — `NSHostingView` subclass overriding `acceptsFirstMouse` so the compact bar expands on the first click while gavel is inactive, instead of click-to-activate-then-click-again.
- **Deleted `AlwaysActivePanel.swift`** — dead code, never referenced.

The title-bar ✕ still fully closes the window (recoverable via menu bar → Show Monitor) as a deliberate escape hatch.

## Testing

- `swift test`: 416/416 pass on this base.
- Verified live via `just dev-daemon`: clicking another app collapses to the floating pill; clicking the pill restores the full window; pinned window stays expanded on top.