### PR TITLE
fix(approval): normalize line-continuations in PersistentRule bash matching

### DIFF
--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -609,7 +609,7 @@ struct PersistentRule: Codable, Identifiable {
         let raw: String
         switch toolName {
         case "Bash":
-            raw = command ?? ""
+            raw = PatternMatcher.joinLineContinuations(command ?? "")
         case "Edit", "MultiEdit", "Write", "Read", "Glob", "Grep":
             raw = filePath ?? command ?? ""
         default:

--- a/Tests/GavelTests/PersistentRuleLineContinuationTests.swift
+++ b/Tests/GavelTests/PersistentRuleLineContinuationTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import Gavel
+
+/// PersistentRule (deny/prompt rules) must normalize shell line-continuations
+/// the same way PatternMatcher does — otherwise a `\<newline>` splits a flag
+/// from its command and slips past a single-line anchored deny rule.
+final class PersistentRuleLineContinuationTests: XCTestCase {
+
+    private func denyRule(_ pattern: String) -> PersistentRule {
+        PersistentRule(toolName: "Bash", pattern: pattern, isRegex: true, verdict: .block)
+    }
+
+    func testRegexDenyControlMatches() {
+        var rule = denyRule("git\\s+push\\b.*--force")
+        XCTAssertTrue(rule.matches(toolName: "Bash", command: "git push origin main --force", filePath: nil))
+    }
+
+    func testRegexDenyNotEvadedByContinuation() {
+        var rule = denyRule("git\\s+push\\b.*--force")
+        let split = "git push origin main \\\n  --force"
+        XCTAssertTrue(rule.matches(toolName: "Bash", command: split, filePath: nil),
+                      "Line-continuation must not split push from --force")
+    }
+
+    func testRegexDenyNotEvadedByCRLFContinuation() {
+        var rule = denyRule("git\\s+push\\b.*--force")
+        let split = "git push origin main \\\r\n  --force"
+        XCTAssertTrue(rule.matches(toolName: "Bash", command: split, filePath: nil))
+    }
+
+    func testDopplerLookaheadAcrossContinuation() {
+        var rule = denyRule("doppler\\s+secrets\\b(?!.*--only-names)")
+        let split = "doppler secrets \\\n  download --no-file"
+        XCTAssertTrue(rule.matches(toolName: "Bash", command: split, filePath: nil),
+                      "Continuation between secrets and download must still block")
+    }
+
+    func testPromptRuleNotEvadedByContinuation() {
+        var rule = PersistentRule(toolName: "Bash", pattern: "rm\\s+-rf\\b.*/", isRegex: true, verdict: .prompt)
+        let split = "rm -rf \\\n  /important/path"
+        XCTAssertTrue(rule.matches(toolName: "Bash", command: split, filePath: nil))
+    }
+
+    func testContinuationComposesWithSegmentSplitting() {
+        // The dangerous segment is itself line-split AND followed by a safe
+        // segment whose token would otherwise suppress the lookahead.
+        var rule = denyRule("doppler\\s+secrets\\b(?!.*--only-names)")
+        let cmd = "doppler secrets \\\n  download --no-file && doppler secrets --only-names"
+        XCTAssertTrue(rule.matches(toolName: "Bash", command: cmd, filePath: nil))
+    }
+
+    func testNoFalsePositiveOnGenuineMultiline() {
+        // No backslash — push and --force are in separate commands; must not block.
+        var rule = denyRule("git\\s+push\\b.*--force")
+        let multiline = "git push origin main\necho done\nmytool --force"
+        XCTAssertFalse(rule.matches(toolName: "Bash", command: multiline, filePath: nil),
+                       "Genuine command boundaries must not be bridged")
+    }
+}


### PR DESCRIPTION
## Follow-up to #121 -- line-continuation evasion, one layer down

#121 normalized `PatternMatcher`'s hard-block and dialog patterns. But the
deny/prompt **rules** layer (`PersistentRule.matches`) was still single-line:
regex rules compile with `.caseInsensitive` only, and the per-segment split
(#119) breaks on `&&`/`||`/`;`/`|`, not newlines. So a user or seeded deny rule
was still evadable:

```
git push origin main \
  --force          ← a `git push … --force` deny rule did NOT fire
```

Empirically confirmed (control matches, continuation form did not) before fixing.

### Fix
`matches()` joins shell line-continuations at the single Bash normalization
point (reusing `PatternMatcher.joinLineContinuations`), so the whole-string,
variable-expansion, and per-segment checks all see the shell-joined command.
Genuine multiline command boundaries (no backslash) are left intact.

### Tests
`PersistentRuleLineContinuationTests` (7): regex deny across LF/CRLF
continuations, the Doppler lookahead across a continuation, a prompt-verdict
rule, composition with #119 segment-splitting, and a precision check that
genuine command boundaries are not bridged. Full suite 466 passing.

## Context
Follow-up from the matcher-hardening sweep (#119/#120/#121). Closes the
line-continuation class in the rules layer that #121 closed in the matcher.
