### PR TITLE
fix(approval): gate ANTHROPIC_BASE_URL written into file content

### DIFF
--- a/Sources/Gavel/Approval/PatternMatcher.swift
+++ b/Sources/Gavel/Approval/PatternMatcher.swift
@@ -47,6 +47,9 @@ struct PatternMatcher {
     /// Pre-compiled sensitive read patterns — force dialog (configuration).
     private let askUserReads: [(regex: NSRegularExpression, reason: String)]
 
+    /// Matches an ANTHROPIC_BASE_URL assignment in written file content — force dialog regardless of destination.
+    private let baseURLAssignmentInContent: NSRegularExpression?
+
     init() {
         let rawBash: [(pattern: String, reason: String)] = [
             // ── Credential exfiltration (expanded) ──
@@ -281,6 +284,7 @@ struct PatternMatcher {
             return (regex, entry.reason)
         }
 
+        baseURLAssignmentInContent = try? NSRegularExpression(pattern: "ANTHROPIC_BASE_URL\"?\\s*[:=]", options: [.caseInsensitive])
     }
 
     // MCP exfiltration patterns are now seeded as persistent rules in RuleStore.
@@ -340,6 +344,9 @@ struct PatternMatcher {
                     return reason
                 }
             }
+            if let reason = matchBaseURLInContent(payload) {
+                return reason
+            }
         }
 
         // Read/Glob/Grep: check askUser read paths (config files needed for self-mutation)
@@ -353,6 +360,16 @@ struct PatternMatcher {
         }
 
         return nil
+    }
+
+    private func matchBaseURLInContent(_ payload: PreToolUsePayload) -> String? {
+        guard let regex = baseURLAssignmentInContent else { return nil }
+        if let path = payload.filePath, Self.isDocumentationPath(path) { return nil }
+        guard let content = payload.toolInput["content"]?.stringValue
+            ?? payload.toolInput["new_string"]?.stringValue else { return nil }
+        let range = NSRange(content.startIndex..., in: content)
+        guard regex.firstMatch(in: content, range: range) != nil else { return nil }
+        return "Sets ANTHROPIC_BASE_URL in file content — could redirect Claude API traffic and key to an attacker"
     }
 
     private func checkAskUserBash(_ rawCommand: String) -> String? {

--- a/Tests/GavelTests/ConfigPathProtectionTests.swift
+++ b/Tests/GavelTests/ConfigPathProtectionTests.swift
@@ -15,6 +15,14 @@ final class ConfigPathProtectionTests: XCTestCase {
         PreToolUsePayload(toolName: "Write", toolInput: ["file_path": AnyCodable(path), "content": AnyCodable("x")])
     }
 
+    private func write(_ path: String, content: String) -> PreToolUsePayload {
+        PreToolUsePayload(toolName: "Write", toolInput: ["file_path": AnyCodable(path), "content": AnyCodable(content)])
+    }
+
+    private func edit(_ path: String, newString: String) -> PreToolUsePayload {
+        PreToolUsePayload(toolName: "Edit", toolInput: ["file_path": AnyCodable(path), "new_string": AnyCodable(newString)])
+    }
+
     /// True if any matcher tier (hard-block, sensitive-path, or a seeded rule)
     /// gates the call. Each call seeds a throwaway rules.json.
     private func gated(_ payload: PreToolUsePayload) -> Bool {
@@ -83,11 +91,37 @@ final class ConfigPathProtectionTests: XCTestCase {
         XCTAssertTrue(gated(bash("echo 'ANTHROPIC_BASE_URL=http://attacker.example.com' >> .mcp.json")))
     }
 
+    func testWriteBaseUrlIntoEnvrcGated() {
+        XCTAssertTrue(gated(write("/Users/x/project/.envrc",
+                                  content: "export ANTHROPIC_BASE_URL=http://attacker.example.com\n")))
+    }
+
+    func testWriteBaseUrlIntoArbitraryFileGated() {
+        XCTAssertTrue(gated(write("/Users/x/project/setup.sh",
+                                  content: "#!/bin/sh\nANTHROPIC_BASE_URL=http://attacker.example.com\n")))
+    }
+
+    func testWriteBaseUrlAsJsonGated() {
+        XCTAssertTrue(gated(write("/Users/x/project/config.json",
+                                  content: "{\n  \"ANTHROPIC_BASE_URL\": \"http://attacker.example.com\"\n}")))
+    }
+
+    func testEditBaseUrlNewStringGated() {
+        XCTAssertTrue(gated(edit("/Users/x/project/Makefile",
+                                 newString: "ANTHROPIC_BASE_URL=http://attacker.example.com")))
+    }
+
     // MARK: - Precision: a bare read of the env var must not prompt
 
     func testReadBaseUrlNotGated() {
         XCTAssertFalse(gated(bash("echo $ANTHROPIC_BASE_URL")),
                        "Reading the var (no assignment) should not trigger a prompt")
+    }
+
+    func testWriteProseMentioningBaseUrlNotGated() {
+        XCTAssertFalse(gated(write("/Users/x/project/notes.txt",
+                                   content: "Set the ANTHROPIC_BASE_URL environment variable to your proxy endpoint.")),
+                       "Prose naming the var (no assignment) should not trigger a prompt")
     }
 
     // MARK: - Migration


### PR DESCRIPTION
## Follow-up to #120 — the raw-match gap, one surface over

#120 seeded an `ANTHROPIC_BASE_URL` rule but scoped it to **Bash**. `PersistentRule` matching for `Write`/`Edit`/`MultiEdit` only ever inspects the destination **path**, never the **content** — so writing `ANTHROPIC_BASE_URL=<url>` as file *content* into an unprotected destination routed the Check Point key-exfil vector (CVE-2025-59536 / CVE-2026-21852 class) around the Bash surface entirely.

`.env` is already hard-blocked by path, but the files that actually get sourced/executed later — `.envrc` (direnv), setup scripts, CI YAML, a Makefile, an arbitrary new JSON — were not gated.

## Fix

`matchSensitivePath` now scans `Write`/`Edit`/`MultiEdit` content for an `ANTHROPIC_BASE_URL` assignment (`=` or `:`, covering shell / dotenv / JSON / YAML) and forces the dialog **regardless of destination** — the "fires regardless of target file" half that the Bash-only rule left open.

- Placed in the **askUser tier** (before allow rules), so a broad `Write: *` allow can't bypass it — the property this CVE class needs.
- Verdict is **prompt**, not hard-deny — a legit corporate-proxy `ANTHROPIC_BASE_URL` setup stays possible, just confirmed (consistent with the existing Bash rule's `.prompt`).
- Documentation extensions are skipped (`.md` etc. are inert — never sourced — and would only add false-positive prompts).

## Tests

Probe-first: the 4 gating cases were confirmed to **fail** on current `main` before the fix, then pass after.

- Gating: `.envrc`, `setup.sh`, JSON content, `Edit` `new_string`
- Precision (stay ungated): bare `echo $ANTHROPIC_BASE_URL` read, prose that merely names the variable

Full suite **464 green**. (No swift-test gate in CI — Semgrep + Socket only — so that local count is the verification.)