### PR TITLE
feat(approval): show plan-overlay miss context in approval panel

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -32,6 +32,8 @@ final class ApprovalCoordinator: ObservableObject {
         let forceDialog: Bool
         /// Reason from the engine when dialog was forced. Nil for default-tier prompts.
         let triggerReason: String?
+        /// Why an engaged plan's overlay did not authorize this command. Nil when no plan is engaged.
+        let overlayContext: String?
         /// ID of the rule that fired, if any. Drives the "Allow rule for session" affordance.
         let triggeringRuleId: UUID?
         let triggeringRulePattern: String?
@@ -74,6 +76,7 @@ final class ApprovalCoordinator: ObservableObject {
         timestamp: Date,
         forceDialog: Bool = false,
         triggerReason: String? = nil,
+        overlayContext: String? = nil,
         triggeringRuleId: UUID? = nil
     ) -> Decision {
         if !forceDialog && session.isAutoApproveEnabled {
@@ -90,6 +93,7 @@ final class ApprovalCoordinator: ObservableObject {
             timestamp: timestamp,
             forceDialog: forceDialog,
             triggerReason: triggerReason,
+            overlayContext: overlayContext,
             triggeringRuleId: triggeringRuleId,
             triggeringRulePattern: firingRule?.pattern,
             triggeringRuleIsRegex: firingRule?.isRegex ?? false

--- a/Sources/Gavel/Approval/ApprovalEngine.swift
+++ b/Sources/Gavel/Approval/ApprovalEngine.swift
@@ -87,7 +87,7 @@ final class ApprovalEngine {
 
         // 7. User PROMPT rules (builtIn=false) — force dialog, beats allow rules below
         if let decision = ruleStore.evaluateUserPrompt(payload: payload) {
-            return decision
+            return decision.withOverlayContext(overlayMiss(overlay, payload))
         }
 
         // 8. Persistent ALLOW rules
@@ -97,7 +97,7 @@ final class ApprovalEngine {
 
         // 9. Overridable built-in PROMPT rules — overridable by allow rules above
         if let decision = ruleStore.evaluateBuiltInPrompt(payload: payload) {
-            return decision
+            return decision.withOverlayContext(overlayMiss(overlay, payload))
         }
 
         // 10. Timed auto-approve
@@ -107,6 +107,25 @@ final class ApprovalEngine {
 
         // 11. Default: pass through (HookRouter decides: auto-approve, session rules, or dialog)
         return Decision(verdict: .allow, reason: nil)
+    }
+
+    private func overlayMiss(_ overlay: [PlanPolicyRule], _ payload: PreToolUsePayload) -> String? {
+        guard !overlay.isEmpty else { return nil }
+        let allows = overlay.filter { $0.verdict == .allow && $0.appliesTo(toolName: payload.toolName) }
+        guard !allows.isEmpty else {
+            return "Plan engaged — its policy has no allow rules for \(payload.toolName)"
+        }
+        guard payload.toolName == "Bash", let command = payload.command else {
+            return "Plan engaged — no overlay allow matches this \(payload.toolName) call"
+        }
+        let segments = SessionRule.splitCommandSegments(command)
+        guard !segments.isEmpty else {
+            return "Plan engaged — no overlay allow matches this command"
+        }
+        if let unmatched = segments.first(where: { segment in !allows.contains { $0.matchesSegment(segment) } }) {
+            return "Plan engaged — overlay does not authorize this command. Unmatched segment: \(unmatched)"
+        }
+        return "Plan engaged — segments match different allow rules, but no single allow covers the whole chain"
     }
 
     private func overlayProhibition(_ overlay: [PlanPolicyRule], _ payload: PreToolUsePayload) -> Decision? {

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -111,7 +111,7 @@ struct ApprovalPanelView: View {
         VStack(spacing: 0) {
             toolHeader(approval)
             if let reason = approval.triggerReason, !reason.isEmpty {
-                triggerBanner(reason)
+                triggerBanner(reason, overlayContext: approval.overlayContext)
             }
             Divider()
             toolDetails(approval)
@@ -267,7 +267,7 @@ struct ApprovalPanelView: View {
     // MARK: - Trigger Banner
 
     @ViewBuilder
-    private func triggerBanner(_ reason: String) -> some View {
+    private func triggerBanner(_ reason: String, overlayContext: String? = nil) -> some View {
         HStack(alignment: .top, spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundColor(.orange)
@@ -280,6 +280,12 @@ struct ApprovalPanelView: View {
                     .font(.system(.callout, design: .monospaced))
                     .foregroundColor(.primary)
                     .textSelection(.enabled)
+                if let overlayContext {
+                    Text(overlayContext)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .textSelection(.enabled)
+                }
             }
             Spacer()
         }

--- a/Sources/Gavel/Approval/PlanPolicyParser.swift
+++ b/Sources/Gavel/Approval/PlanPolicyParser.swift
@@ -32,6 +32,15 @@ struct PlanPolicyRule {
         self.regex = PatternCompiler.compilePattern(pattern, isRegex: isRegex)
     }
 
+    func appliesTo(toolName: String) -> Bool {
+        self.toolName == toolName || self.toolName == "*"
+    }
+
+    func matchesSegment(_ segment: String) -> Bool {
+        guard let regex else { return false }
+        return PatternCompiler.matches(regex, in: Self.sanitize(segment))
+    }
+
     func matches(toolName: String, command: String?, filePath: String?) -> Bool {
         guard self.toolName == toolName || self.toolName == "*", let regex else { return false }
         if toolName == "Bash" {

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -208,6 +208,7 @@ final class HookRouter {
                     payload: payload, session: session, timestamp: timestamp,
                     forceDialog: true,
                     triggerReason: engineDecision.reason,
+                    overlayContext: engineDecision.overlayContext,
                     triggeringRuleId: engineDecision.triggeringRuleId
                 )
                 switch decision.verdict {

--- a/Sources/Gavel/Models/Decision.swift
+++ b/Sources/Gavel/Models/Decision.swift
@@ -23,14 +23,31 @@ struct Decision: Codable {
     let askUser: Bool
     /// Set when a persistent prompt rule fired — used by per-session rule suppression.
     let triggeringRuleId: UUID?
+    /// Set when a plan was engaged but its overlay did not authorize the command — shown in the approval panel so the gap is legible.
+    let overlayContext: String?
 
-    init(verdict: DecisionVerdict, reason: String?, additionalContext: String? = nil, updatedInput: [String: AnyCodable]? = nil, askUser: Bool = false, triggeringRuleId: UUID? = nil) {
+    init(verdict: DecisionVerdict, reason: String?, additionalContext: String? = nil, updatedInput: [String: AnyCodable]? = nil, askUser: Bool = false, triggeringRuleId: UUID? = nil, overlayContext: String? = nil) {
         self.verdict = verdict
         self.reason = reason
         self.additionalContext = additionalContext
         self.updatedInput = updatedInput
         self.askUser = askUser
         self.triggeringRuleId = triggeringRuleId
+        self.overlayContext = overlayContext
+    }
+
+    /// Returns a copy annotated with an engaged plan's miss explanation; self when context is nil.
+    func withOverlayContext(_ context: String?) -> Decision {
+        guard let context else { return self }
+        return Decision(
+            verdict: verdict,
+            reason: reason,
+            additionalContext: additionalContext,
+            updatedInput: updatedInput,
+            askUser: askUser,
+            triggeringRuleId: triggeringRuleId,
+            overlayContext: context
+        )
     }
 
     /// Internal protocol JSON sent to the gavel-hook shim via socket.

--- a/Tests/GavelTests/PlanPolicyApprovalEngineTests.swift
+++ b/Tests/GavelTests/PlanPolicyApprovalEngineTests.swift
@@ -209,6 +209,65 @@ final class PlanPolicyApprovalEngineTests: XCTestCase {
                           "a chained command must not ride the overlay allow")
     }
 
+    func testOverlayMissContextNamesUnmatchedSegment() {
+        ruleStore.addRule(PersistentRule(toolName: "Bash", pattern: "doppler secrets*", verdict: .prompt, explanation: "user prompt"))
+        engageWithPolicy([
+            "allow Bash: doppler secrets set CONFLUENCE_URL*",
+            "allow Bash: doppler secrets set CONFLUENCE_USERNAME*",
+        ])
+        let decision = engine.evaluate(
+            payload: payload(command: "doppler secrets set CONFLUENCE_URL=x --silent && doppler secrets get JIRA_USERNAME --plain | doppler secrets set CONFLUENCE_USERNAME --silent"),
+            session: session
+        )
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertTrue(decision.askUser)
+        XCTAssertTrue(decision.overlayContext?.contains("doppler secrets get JIRA_USERNAME") ?? false,
+                      "the panel context should name the segment the overlay didn't cover, got: \(decision.overlayContext ?? "nil")")
+    }
+
+    func testOverlayMissContextWhenNoSingleRuleCoversChain() {
+        ruleStore.addRule(PersistentRule(toolName: "Bash", pattern: "*", verdict: .prompt, explanation: "prompt everything"))
+        engageWithPolicy(["allow Bash: echo*", "allow Bash: ls*"])
+        let decision = engine.evaluate(payload: payload(command: "echo hi && ls"), session: session)
+        XCTAssertTrue(decision.askUser)
+        XCTAssertTrue(decision.overlayContext?.contains("no single allow covers") ?? false,
+                      "union coverage across rules must be called out, got: \(decision.overlayContext ?? "nil")")
+    }
+
+    func testOverlayMissContextWhenPolicyHasNoAllowsForTool() {
+        ruleStore.addRule(PersistentRule(toolName: "Bash", pattern: "rm *", verdict: .prompt, explanation: "user prompt"))
+        engageWithPolicy(["deny Bash: cdk destroy*"])
+        let decision = engine.evaluate(payload: payload(command: "rm /tmp/foo"), session: session)
+        XCTAssertTrue(decision.askUser)
+        XCTAssertTrue(decision.overlayContext?.contains("no allow rules") ?? false)
+    }
+
+    func testBuiltInPromptCarriesOverlayContext() {
+        engageWithPolicy(["allow Bash: ls*"])
+        let decision = engine.evaluate(
+            payload: payload(command: #"python3 -c "print(1)""#),
+            session: session
+        )
+        XCTAssertTrue(decision.askUser)
+        XCTAssertNotNil(decision.overlayContext, "stage-9 built-in prompts under an engaged plan should carry the miss context")
+    }
+
+    func testNoOverlayContextWithoutEngagedPlan() {
+        PlanPolicy.disengage(session: session, reason: "test")
+        drainMain()
+        ruleStore.addRule(PersistentRule(toolName: "Bash", pattern: "rm *", verdict: .prompt, explanation: "user prompt"))
+        let decision = engine.evaluate(payload: payload(command: "rm /tmp/foo"), session: session)
+        XCTAssertTrue(decision.askUser)
+        XCTAssertNil(decision.overlayContext, "no plan engaged — nothing to explain")
+    }
+
+    func testOverlayAllowedCommandHasNoMissContext() {
+        engageWithPolicy(["allow Bash: cdk deploy GreenfieldStack*"])
+        let decision = engine.evaluate(payload: payload(command: "cdk deploy GreenfieldStack-Api"), session: session)
+        XCTAssertEqual(decision.verdict, .allow)
+        XCTAssertNil(decision.overlayContext)
+    }
+
     // MARK: - Sensitive paths, hard blocks, pause still apply
 
     func testSensitivePathPromptsWithPlanEngaged() {


### PR DESCRIPTION
When a plan is engaged but its overlay doesn't authorize a command, the panel showed only the firing rule -- which reads as "my prompt rule superseded the plan" when the real story is "the overlay declined this command, then the rule caught it." Found this debugging exactly that misread on a live run.

The engine now attaches a one-line explanation to stage-7 (user prompt) and stage-9 (built-in prompt) decisions, rendered as a caption under the trigger banner:

- **Unmatched segment named:** `Plan engaged -- overlay does not authorize this command. Unmatched segment: doppler secrets get JIRA_USERNAME …`
- **Union coverage:** `Plan engaged -- segments match different allow rules, but no single allow covers the whole chain` (chaining-safe allSatisfy semantics, now legible)
- **No allows for tool:** `Plan engaged -- its policy has no allow rules for <Tool>`

Scoping: deliberately NOT attached to the commit checkpoint or sensitive-path dialogs (stages 4-5) -- the overlay can't authorize those, so a "plan didn't cover this" line there would mislead. `Plan prohibits` dialogs also stay bare: a deny is the plan speaking, not a miss.

Plumbing: `Decision.overlayContext` (daemon-internal, not serialized to the hook shim), threaded through `requestApproval` → `PendingApproval` → trigger banner. `PlanPolicyRule` gains `appliesTo(toolName:)` / `matchesSegment(_:)` reusing the same sanitize + PatternCompiler path as `matches`.

Testing: 6 new engine tests (477 total, all green) covering all three message shapes, the stage-9 path, nil without an engaged plan, and nil on an overlay-authorized allow. Also verified live against the dev daemon -- 8/8 scenarios: PLAN-badge silent allow beating a standing prompt rule, both miss shapes on the panel, built-in script-eval carrying the line, plan-deny without it, hash-lock drop on edit attempt, and bare banner once the plan dropped.