### PR TITLE
feat(approval): telegram remote approval with credential gate

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
             path: "Sources/Gavel",
             linkerSettings: [
                 .linkedFramework("AppKit"),
+                .linkedFramework("Security"),
             ]
         ),
         .executableTarget(

--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -29,7 +29,12 @@ final class ApprovalCoordinator: ObservableObject {
     /// SessionManager reference for recording user-interaction signals (inactivity timer).
     weak var sessionManager: SessionManager?
 
+    /// Optional Telegram bridge. When set and a session is remote-enabled, approvals
+    /// also race against inline phone buttons.
+    var remoteBridge: RemoteApprovalBridge?
+
     struct PendingApproval {
+        let id = UUID()
         let payload: PreToolUsePayload
         let session: Session
         let timestamp: Date
@@ -42,6 +47,7 @@ final class ApprovalCoordinator: ObservableObject {
         let triggeringRuleId: UUID?
         let triggeringRulePattern: String?
         let triggeringRuleIsRegex: Bool
+        let resolvable: ResolvableApproval
         let respond: (Decision) -> Void
     }
 
@@ -90,6 +96,11 @@ final class ApprovalCoordinator: ObservableObject {
         let semaphore = DispatchSemaphore(value: 0)
         var result = Decision(verdict: .block, reason: "Approval timed out — fail closed")
 
+        let resolvable = ResolvableApproval { decision in
+            result = decision
+            semaphore.signal()
+        }
+
         let firingRule = triggeringRuleId.flatMap { ruleStore?.rule(for: $0) }
         let pending = PendingApproval(
             payload: payload,
@@ -100,10 +111,10 @@ final class ApprovalCoordinator: ObservableObject {
             overlayContext: overlayContext,
             triggeringRuleId: triggeringRuleId,
             triggeringRulePattern: firingRule?.pattern,
-            triggeringRuleIsRegex: firingRule?.isRegex ?? false
+            triggeringRuleIsRegex: firingRule?.isRegex ?? false,
+            resolvable: resolvable
         ) { decision in
-            result = decision
-            semaphore.signal()
+            resolvable.resolve(decision, from: .mac)
         }
 
         DispatchQueue.main.async {
@@ -116,14 +127,52 @@ final class ApprovalCoordinator: ObservableObject {
             }
         }
 
+        maybeSendRemote(pending: pending, resolvable: resolvable)
+
         let waitResult = semaphore.wait(timeout: .now() + GavelConstants.approvalTimeoutSeconds)
         if waitResult == .timedOut {
+            resolvable.resolve(result, from: .timeout)
             DispatchQueue.main.async {
                 let sp = self.sessionPanel(for: session.pid)
                 self.dismissCurrent(on: sp)
             }
         }
         return result
+    }
+
+    /// Mirror a pending approval to Telegram when its session is remote-enabled.
+    /// The credential gate suppresses the message entirely for sensitive payloads.
+    private func maybeSendRemote(pending: PendingApproval, resolvable: ResolvableApproval) {
+        guard pending.session.isRemoteApprovalActive, let bridge = remoteBridge else { return }
+        if CredentialGate.blocksRemote(pending.payload) {
+            bridge.notifyWithheld()
+            return
+        }
+        let session = pending.session
+        let payload = pending.payload
+        let pendingId = pending.id
+        let allowSession: () -> Void = {
+            let pattern = payload.command ?? payload.filePath ?? "*"
+            let rule = SessionRule(toolName: payload.toolName, pattern: pattern)
+            DispatchQueue.main.async { session.sessionRules.append(rule) }
+        }
+        resolvable.addCleanup { [weak self] source, _ in
+            guard source == .telegram else { return }
+            DispatchQueue.main.async { self?.dismissPending(id: pendingId, pid: session.pid) }
+        }
+        let text = RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: pending.triggerReason)
+        bridge.notify(resolvable: resolvable, text: text, allowSession: allowSession)
+    }
+
+    /// Remove a pending approval resolved remotely from its session panel.
+    private func dismissPending(id: UUID, pid: Int) {
+        guard let sp = sessionPanels[pid] else { return }
+        if sp.currentApproval?.id == id {
+            advanceQueue(on: sp)
+        } else if let index = sp.pendingQueue.firstIndex(where: { $0.id == id }) {
+            sp.pendingQueue.remove(at: index)
+            sp.queueCount = sp.pendingQueue.count
+        }
     }
 
     /// Handle the user's decision from the approval panel.

--- a/Sources/Gavel/Approval/CredentialGate.swift
+++ b/Sources/Gavel/Approval/CredentialGate.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Non-disableable safety gate for outbound remote-approval messages.
+/// When any payload field is credential-shaped, the message is suppressed entirely.
+enum CredentialGate {
+
+    /// True when the payload must NOT be sent to a remote channel (Telegram).
+    /// Scans every tool-input value, the command, and file path — biased to over-suppress.
+    static func blocksRemote(_ payload: PreToolUsePayload) -> Bool {
+        for text in scannableStrings(payload) {
+            if SecretRedactor.containsKnownSecret(text) { return true }
+            if containsHighEntropyRun(text) { return true }
+        }
+        return false
+    }
+
+    private static func scannableStrings(_ payload: PreToolUsePayload) -> [String] {
+        var out: [String] = []
+        collect(payload.toolInput, into: &out)
+        return out
+    }
+
+    private static func collect(_ value: [String: AnyCodable], into out: inout [String]) {
+        for (_, v) in value { collect(v.value, into: &out) }
+    }
+
+    private static func collect(_ value: Any, into out: inout [String]) {
+        switch value {
+        case let s as String:
+            out.append(s)
+        case let dict as [String: AnyCodable]:
+            collect(dict, into: &out)
+        case let arr as [AnyCodable]:
+            for element in arr { collect(element.value, into: &out) }
+        case let dict as [String: Any]:
+            for v in dict.values { collect(v, into: &out) }
+        case let arr as [Any]:
+            for element in arr { collect(element, into: &out) }
+        default:
+            break
+        }
+    }
+
+    /// A 20+ char key-like run that is not a UUID or ISO-8601 timestamp is
+    /// credential-shaped. `/` is excluded so paths split into short segments.
+    static func containsHighEntropyRun(_ text: String) -> Bool {
+        let range = NSRange(text.startIndex..., in: text)
+        let matches = entropyRegex.matches(in: text, range: range)
+        for match in matches {
+            guard let r = Range(match.range, in: text) else { continue }
+            let token = String(text[r])
+            if isWhitelisted(token) { continue }
+            return true
+        }
+        return false
+    }
+
+    private static func isWhitelisted(_ token: String) -> Bool {
+        let range = NSRange(token.startIndex..., in: token)
+        if uuidRegex.firstMatch(in: token, range: range) != nil { return true }
+        if iso8601Regex.firstMatch(in: token, range: range) != nil { return true }
+        return false
+    }
+
+    private static let entropyRegex = try! NSRegularExpression(
+        pattern: "[A-Za-z0-9_+\\-]{\(GavelConstants.credentialEntropyRunLength),}"
+    )
+
+    private static let uuidRegex = try! NSRegularExpression(
+        pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    )
+
+    private static let iso8601Regex = try! NSRegularExpression(
+        pattern: "^\\d{4}-\\d{2}-\\d{2}([T ]\\d{2}:\\d{2}(:\\d{2})?)?"
+    )
+}

--- a/Sources/Gavel/Approval/ResolvableApproval.swift
+++ b/Sources/Gavel/Approval/ResolvableApproval.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Idempotent resolution guard for an approval that two responders race for
+/// (the on-Mac panel and the Telegram bridge). Exactly one `resolve` wins.
+final class ResolvableApproval {
+
+    enum Source { case mac, telegram, timeout, autoApprove }
+
+    private let lock = NSLock()
+    private var resolved = false
+    private let sink: (Decision) -> Void
+    private var onResolved: [(Source, Decision) -> Void] = []
+
+    init(sink: @escaping (Decision) -> Void) {
+        self.sink = sink
+    }
+
+    var isResolved: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return resolved
+    }
+
+    /// Register a one-shot cleanup hook. Skipped if already resolved.
+    func addCleanup(_ hook: @escaping (Source, Decision) -> Void) {
+        lock.lock(); defer { lock.unlock() }
+        guard !resolved else { return }
+        onResolved.append(hook)
+    }
+
+    /// Returns true iff this call won the race. The sink and every cleanup hook
+    /// fire exactly once, on the winning caller's thread.
+    @discardableResult
+    func resolve(_ decision: Decision, from source: Source) -> Bool {
+        lock.lock()
+        if resolved {
+            lock.unlock()
+            return false
+        }
+        resolved = true
+        let hooks = onResolved
+        onResolved = []
+        lock.unlock()
+
+        sink(decision)
+        for hook in hooks { hook(source, decision) }
+        return true
+    }
+}

--- a/Sources/Gavel/Approval/SecretRedactor.swift
+++ b/Sources/Gavel/Approval/SecretRedactor.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Shared credential regex set used by `SecretHandler` and `CredentialGate`.
+/// Provides recognized-secret detection and labeled-placeholder redaction.
+enum SecretRedactor {
+
+    struct Pattern {
+        let label: String
+        let regex: NSRegularExpression
+    }
+
+    static let patterns: [Pattern] = {
+        let raw: [(String, String)] = [
+            ("AWS access key", #"AKIA[0-9A-Z]{16}"#),
+            ("GitHub PAT", #"ghp_[A-Za-z0-9]{36,}"#),
+            ("GitHub OAuth token", #"gho_[A-Za-z0-9]{36,}"#),
+            ("GitHub server token", #"ghs_[A-Za-z0-9]{36,}"#),
+            ("Anthropic API key", #"sk-ant-[A-Za-z0-9_\-]{40,}"#),
+            ("OpenAI API key", #"sk-[A-Za-z0-9]{40,}"#),
+            ("Slack token", #"xox[bpoa]-[A-Za-z0-9\-]{10,}"#),
+            ("Slack webhook URL", #"https://hooks\.slack\.com/services/[A-Z0-9/]{20,}"#)
+        ]
+        return raw.compactMap { label, pattern in
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+            return Pattern(label: label, regex: regex)
+        }
+    }()
+
+    static func firstMatchLabel(in text: String) -> String? {
+        let range = NSRange(text.startIndex..., in: text)
+        for pattern in patterns where pattern.regex.firstMatch(in: text, range: range) != nil {
+            return pattern.label
+        }
+        return nil
+    }
+
+    static func containsKnownSecret(_ text: String) -> Bool {
+        firstMatchLabel(in: text) != nil
+    }
+
+    static func redact(_ text: String) -> String {
+        var result = text
+        for pattern in patterns {
+            let range = NSRange(result.startIndex..., in: result)
+            result = pattern.regex.stringByReplacingMatches(
+                in: result,
+                range: range,
+                withTemplate: "‹\(pattern.label) redacted›"
+            )
+        }
+        return result
+    }
+}

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -19,6 +19,10 @@ final class SessionManager: ObservableObject {
     /// is revoked across all sessions (walk-away defense).
     @Published var inactivityTimeoutMinutes: Int = 15
 
+    /// Pinned Telegram chat id for remote approval. Not secret; the bot token
+    /// lives in Keychain. Nil until paired via `/start`.
+    @Published var telegramChatId: Int64?
+
     /// User-typed labels keyed by Claude Code session UUID. Survives daemon restarts.
     @Published private var sessionLabels: [String: String] = [:]
 
@@ -86,13 +90,14 @@ final class SessionManager: ObservableObject {
 
     /// Save current defaults to disk (called when user toggles).
     func saveDefaults() {
-        let data: [String: Any] = [
+        var data: [String: Any] = [
             "autoApprove": defaultAutoApprove,
             "subAgentInherit": defaultSubAgentInherit,
             "paused": defaultPaused,
             "inactivityTimeoutMinutes": inactivityTimeoutMinutes,
             "sessionLabels": sessionLabels
         ]
+        if let chatId = telegramChatId { data["telegramChatId"] = chatId }
         if let json = try? JSONSerialization.data(withJSONObject: data, options: .prettyPrinted) {
             FileManager.default.createFile(atPath: defaultsPath, contents: json)
         }
@@ -106,6 +111,7 @@ final class SessionManager: ObservableObject {
         defaultPaused = (json["paused"] as? Bool) ?? false
         inactivityTimeoutMinutes = (json["inactivityTimeoutMinutes"] as? Int) ?? 15
         sessionLabels = (json["sessionLabels"] as? [String: String]) ?? [:]
+        telegramChatId = (json["telegramChatId"] as? Int64) ?? (json["telegramChatId"] as? Int).map(Int64.init)
     }
 
     /// Worker-thread caller; @Published mutations dispatched to main.
@@ -270,6 +276,8 @@ final class SessionManager: ObservableObject {
         let engagedPlanPath: String?
         let engagedPlanHash: String?
         let planPolicyDroppedReason: String?
+        let isRemoteApprovalEnabled: Bool?
+        let remoteApprovalUntil: Date?
     }
 
     private struct PersistedState: Codable {
@@ -314,7 +322,9 @@ final class SessionManager: ObservableObject {
             planEngagedAt: session.planEngagedAt,
             engagedPlanPath: session.engagedPlanPath,
             engagedPlanHash: session.engagedPlanHash,
-            planPolicyDroppedReason: session.planPolicyDroppedReason
+            planPolicyDroppedReason: session.planPolicyDroppedReason,
+            isRemoteApprovalEnabled: session.remoteApprovalSnapshot.enabled ? true : nil,
+            remoteApprovalUntil: session.remoteApprovalSnapshot.until
         )
     }
 
@@ -358,6 +368,10 @@ final class SessionManager: ObservableObject {
             session.labelIsDerived = snap.labelIsDerived ?? false
         }
         session.lastPlanPath = snap.lastPlanPath
+        if snap.isRemoteApprovalEnabled == true,
+           snap.remoteApprovalUntil == nil || (snap.remoteApprovalUntil.map { $0 > Date() } ?? true) {
+            session.setRemoteApprovalEnabled(true, until: snap.remoteApprovalUntil)
+        }
         rehydratePlanPolicy(snap, into: session)
         sessions[snap.pid] = session
         tryJsonlSeed(session: session)
@@ -508,6 +522,7 @@ final class SessionManager: ObservableObject {
             guard let self = self else { return }
             for session in self.sessions.values {
                 session.revokeAutoApprove()
+                session.disableRemoteApproval()
             }
             self.defaultAutoApprove = false
             self.defaultSubAgentInherit = false

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -58,6 +58,42 @@ final class Session: ObservableObject, Identifiable {
     @Published var engagedPlanHash: String?
     @Published var planPolicyDroppedReason: String?
 
+    @Published var isRemoteApprovalEnabledUI: Bool = false
+    @Published var remoteApprovalUntil: Date?
+
+    private var _remoteEnabled = false
+    private var _remoteUntil: Date?
+    private let remoteLock = NSLock()
+
+    var isRemoteApprovalActive: Bool {
+        remoteLock.lock()
+        defer { remoteLock.unlock() }
+        guard _remoteEnabled else { return false }
+        if let until = _remoteUntil { return until > Date() }
+        return true
+    }
+
+    func setRemoteApprovalEnabled(_ enabled: Bool, until: Date?) {
+        remoteLock.lock()
+        _remoteEnabled = enabled
+        _remoteUntil = enabled ? until : nil
+        remoteLock.unlock()
+        DispatchQueue.main.async {
+            self.isRemoteApprovalEnabledUI = enabled
+            self.remoteApprovalUntil = enabled ? until : nil
+        }
+    }
+
+    func disableRemoteApproval() {
+        setRemoteApprovalEnabled(false, until: nil)
+    }
+
+    var remoteApprovalSnapshot: (enabled: Bool, until: Date?) {
+        remoteLock.lock()
+        defer { remoteLock.unlock() }
+        return (_remoteEnabled, _remoteUntil)
+    }
+
     private var _planPolicyEngaged: Bool = false
     private let planPolicyLock = NSLock()
 

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -519,6 +519,28 @@ private struct SessionRow: View {
             }
             .frame(width: 76, alignment: .leading)
 
+            HStack(spacing: 4) {
+                Text("Phone")
+                    .font(.caption)
+                    .lineLimit(1)
+                Toggle("", isOn: Binding(
+                    get: { session.isRemoteApprovalEnabledUI },
+                    set: { newVal in
+                        let until = newVal ? Date().addingTimeInterval(Double(GavelConstants.remoteApprovalDefaultHours) * 3600) : nil
+                        session.setRemoteApprovalEnabled(newVal, until: until)
+                        viewModel.sessionManager.saveActiveSessions()
+                        viewModel.noteInteraction()
+                    }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .tint(.purple)
+                .controlSize(.small)
+            }
+            .frame(width: 86, alignment: .leading)
+            .disabled(viewModel.sessionManager.telegramChatId == nil)
+            .help("Send this session's approvals to Telegram; either device can answer. Configure Telegram first.")
+
             planControl
 
             Button("Prompt") {

--- a/Sources/Gavel/Observability/Handlers/SecretHandler.swift
+++ b/Sources/Gavel/Observability/Handlers/SecretHandler.swift
@@ -3,28 +3,6 @@ import Foundation
 final class SecretHandler: JsonlEventHandler {
     let name = "secret"
 
-    private struct SecretPattern {
-        let label: String
-        let regex: NSRegularExpression
-    }
-
-    private static let patterns: [SecretPattern] = {
-        let raw: [(String, String)] = [
-            ("AWS access key", #"AKIA[0-9A-Z]{16}"#),
-            ("GitHub PAT", #"ghp_[A-Za-z0-9]{36,}"#),
-            ("GitHub OAuth token", #"gho_[A-Za-z0-9]{36,}"#),
-            ("GitHub server token", #"ghs_[A-Za-z0-9]{36,}"#),
-            ("Anthropic API key", #"sk-ant-[A-Za-z0-9_\-]{40,}"#),
-            ("OpenAI API key", #"sk-[A-Za-z0-9]{40,}"#),
-            ("Slack token", #"xox[bpoa]-[A-Za-z0-9\-]{10,}"#),
-            ("Slack webhook URL", #"https://hooks\.slack\.com/services/[A-Z0-9/]{20,}"#)
-        ]
-        return raw.compactMap { (label, pattern) in
-            guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
-            return SecretPattern(label: label, regex: regex)
-        }
-    }()
-
     private static let cooldown: TimeInterval = 300
 
     private var lastFireByLabel: [String: Date] = [:]
@@ -32,7 +10,7 @@ final class SecretHandler: JsonlEventHandler {
     func handle(_ event: JsonlEvent, manager: SessionManager, session: Session) {
         let line = event.rawLine
         let range = NSRange(line.startIndex..., in: line)
-        for pattern in Self.patterns where pattern.regex.firstMatch(in: line, range: range) != nil {
+        for pattern in SecretRedactor.patterns where pattern.regex.firstMatch(in: line, range: range) != nil {
             if let last = lastFireByLabel[pattern.label],
                Date().timeIntervalSince(last) < Self.cooldown {
                 return

--- a/Sources/Gavel/Remote/RemoteApprovalBridge.swift
+++ b/Sources/Gavel/Remote/RemoteApprovalBridge.swift
@@ -1,0 +1,261 @@
+import Foundation
+import Security
+
+/// Bridges pending approvals to a Telegram bot and races inbound button taps
+/// against the on-Mac panel. Additive: the local panel stays authoritative.
+final class RemoteApprovalBridge {
+
+    static weak var shared: RemoteApprovalBridge?
+
+    private final class Correlation {
+        let resolvable: ResolvableApproval
+        let allowSession: (() -> Void)?
+        var messageId: Int?
+        init(resolvable: ResolvableApproval, allowSession: (() -> Void)?) {
+            self.resolvable = resolvable
+            self.allowSession = allowSession
+        }
+    }
+
+    private let transport: TelegramTransport
+    private let redact: (String) -> String
+    private let lock = NSLock()
+    private var byNonce: [String: Correlation] = [:]
+    private var offset = 0
+    private var running = false
+    private var backoff: TimeInterval = 1
+    private var chatId: Int64?
+
+    /// Fired when pairing captures a chat id, so the daemon can persist it.
+    var onPaired: ((Int64) -> Void)?
+    /// Emits a token-redacted status line for the feed/log.
+    var onStatus: ((String) -> Void)?
+
+    init(transport: TelegramTransport, chatId: Int64?, redact: @escaping (String) -> String = { $0 }) {
+        self.transport = transport
+        self.chatId = chatId
+        self.redact = redact
+    }
+
+    var isPaired: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return chatId != nil
+    }
+
+    func start() {
+        lock.lock()
+        if running { lock.unlock(); return }
+        running = true
+        lock.unlock()
+        RemoteApprovalBridge.shared = self
+        pollOnce()
+    }
+
+    func stop() {
+        lock.lock()
+        running = false
+        lock.unlock()
+    }
+
+    // MARK: - Outbound
+
+    /// Send a pending approval to the phone and register it for inbound resolution.
+    func notify(resolvable: ResolvableApproval, text: String, allowSession: (() -> Void)?) {
+        lock.lock(); let chat = chatId; lock.unlock()
+        guard let chat else { return }
+
+        let nonce = Self.makeNonce()
+        let corr = Correlation(resolvable: resolvable, allowSession: allowSession)
+        lock.lock(); byNonce[nonce] = corr; lock.unlock()
+
+        resolvable.addCleanup { [weak self] source, decision in
+            guard let self else { return }
+            self.lock.lock(); self.byNonce.removeValue(forKey: nonce); let mid = corr.messageId; self.lock.unlock()
+            guard source != .telegram else { return }
+            if let mid {
+                self.transport.editMessageText(chatId: chat, messageId: mid, text: Self.macResolvedText(source), completion: nil)
+            }
+        }
+
+        let keyboard: [[TelegramButton]] = [
+            [TelegramButton(text: "✅ Allow once", callbackData: "a:\(nonce)"),
+             TelegramButton(text: "🛑 Deny", callbackData: "d:\(nonce)")],
+            [TelegramButton(text: "✅ Allow for session", callbackData: "s:\(nonce)")]
+        ]
+        transport.sendMessage(chatId: chat, text: text, keyboard: keyboard) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let mid):
+                self.lock.lock(); corr.messageId = mid; self.lock.unlock()
+                if resolvable.isResolved {
+                    self.transport.editMessageText(chatId: chat, messageId: mid, text: Self.macResolvedText(.mac), completion: nil)
+                    self.lock.lock(); self.byNonce.removeValue(forKey: nonce); self.lock.unlock()
+                }
+            case .failure(let error):
+                self.onStatus?("Telegram send failed: \(self.redact("\(error)"))")
+            }
+        }
+    }
+
+    /// Send a contentless notice that an approval was withheld by the credential gate.
+    func notifyWithheld() {
+        lock.lock(); let chat = chatId; lock.unlock()
+        guard let chat else { return }
+        transport.sendMessage(
+            chatId: chat,
+            text: "🔒 Gavel: an approval was withheld from Telegram (sensitive content detected). Answer it on your Mac.",
+            keyboard: nil,
+            completion: { _ in }
+        )
+    }
+
+    // MARK: - Inbound poll loop
+
+    private func pollOnce() {
+        lock.lock(); let go = running; let off = offset; lock.unlock()
+        guard go else { return }
+        transport.getUpdates(offset: off, timeoutSeconds: GavelConstants.telegramPollTimeoutSeconds) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let updates):
+                self.resetBackoff()
+                for update in updates { self.handle(update) }
+                if let maxId = updates.map(\.updateId).max() {
+                    self.lock.lock(); self.offset = maxId + 1; self.lock.unlock()
+                }
+                self.rearm(after: 0)
+            case .failure(let error):
+                if case TelegramError.unauthorizedToken = error {
+                    self.onStatus?("Telegram disabled — token unauthorized")
+                    self.stop()
+                    return
+                }
+                let delay = self.bumpBackoff()
+                self.onStatus?("Telegram poll error (retry \(Int(delay))s): \(self.redact("\(error)"))")
+                self.rearm(after: delay)
+            }
+        }
+    }
+
+    private func rearm(after delay: TimeInterval) {
+        lock.lock(); let go = running; lock.unlock()
+        guard go else { return }
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.pollOnce()
+        }
+    }
+
+    func handle(_ update: TelegramUpdate) {
+        if let message = update.message { handleMessage(message); return }
+        if let callback = update.callback { handleCallback(callback) }
+    }
+
+    private func handleMessage(_ message: TelegramIncomingMessage) {
+        lock.lock(); let paired = chatId != nil; lock.unlock()
+        guard !paired, (message.text ?? "").hasPrefix("/start") else { return }
+        lock.lock(); chatId = message.chatId; lock.unlock()
+        onPaired?(message.chatId)
+        transport.sendMessage(
+            chatId: message.chatId,
+            text: "Gavel paired ✅ — this chat is now the only one that can answer approvals.",
+            keyboard: nil,
+            completion: { _ in }
+        )
+    }
+
+    private func handleCallback(_ callback: TelegramCallback) {
+        lock.lock(); let pinned = chatId; lock.unlock()
+        guard let pinned, callback.chatId == pinned, callback.fromId == pinned else {
+            transport.answerCallbackQuery(id: callback.id, text: "Not authorized", completion: nil)
+            return
+        }
+
+        let parts = callback.data.split(separator: ":", maxSplits: 1)
+        guard parts.count == 2 else {
+            transport.answerCallbackQuery(id: callback.id, text: nil, completion: nil)
+            return
+        }
+        let action = String(parts[0])
+        let nonce = String(parts[1])
+
+        lock.lock(); let corr = byNonce.removeValue(forKey: nonce); lock.unlock()
+        guard let corr else {
+            transport.answerCallbackQuery(id: callback.id, text: "Already resolved", completion: nil)
+            transport.editMessageText(chatId: pinned, messageId: callback.messageId, text: "↪️ Already resolved", completion: nil)
+            return
+        }
+
+        if action == "s" { corr.allowSession?() }
+        let won = corr.resolvable.resolve(Self.decision(for: action), from: .telegram)
+        if won {
+            transport.answerCallbackQuery(id: callback.id, text: action == "d" ? "Denied" : "Allowed", completion: nil)
+            transport.editMessageText(chatId: pinned, messageId: callback.messageId, text: Self.phoneResolvedText(action), completion: nil)
+        } else {
+            transport.answerCallbackQuery(id: callback.id, text: "Already resolved", completion: nil)
+            transport.editMessageText(chatId: pinned, messageId: callback.messageId, text: Self.macResolvedText(.mac), completion: nil)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func resetBackoff() { lock.lock(); backoff = 1; lock.unlock() }
+
+    private func bumpBackoff() -> TimeInterval {
+        lock.lock()
+        let current = backoff
+        backoff = min(backoff * 2, 60)
+        lock.unlock()
+        return current * Double.random(in: 0.8...1.2)
+    }
+
+    static func makeNonce() -> String {
+        var bytes = [UInt8](repeating: 0, count: 8)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func decision(for action: String) -> Decision {
+        switch action {
+        case "d": return Decision(verdict: .block, reason: "Denied from phone")
+        case "s": return Decision(verdict: .allow, reason: "Approved for session from phone")
+        default: return Decision(verdict: .allow, reason: "Approved from phone")
+        }
+    }
+
+    private static func phoneResolvedText(_ action: String) -> String {
+        action == "d" ? "🛑 Denied from phone" : "✅ Approved from phone"
+    }
+
+    private static func macResolvedText(_ source: ResolvableApproval.Source) -> String {
+        source == .timeout ? "⏱ Timed out — denied (Mac)" : "✅ Answered on Mac"
+    }
+
+    /// Build the redacted, truncated, control-stripped message body for an approval.
+    static func summaryBody(payload: PreToolUsePayload, session: Session, triggerReason: String?) -> String {
+        let label = session.label.isEmpty ? "PID \(session.pid)" : session.label
+        let raw = payload.command ?? payload.filePath ?? firstStringInput(payload) ?? ""
+        let summary = sanitizeForDisplay(SecretRedactor.redact(raw))
+        let capped = summary.count > GavelConstants.telegramSummaryMaxChars
+            ? String(summary.prefix(GavelConstants.telegramSummaryMaxChars)) + "…"
+            : summary
+        var lines = ["Gavel approval — \(sanitizeForDisplay(label))", "Tool: \(payload.toolName)"]
+        if !capped.isEmpty { lines.append(capped) }
+        if let reason = triggerReason, !reason.isEmpty { lines.append("(\(sanitizeForDisplay(reason)))") }
+        lines.append("(full detail on Mac)")
+        return lines.joined(separator: "\n")
+    }
+
+    private static func firstStringInput(_ payload: PreToolUsePayload) -> String? {
+        for (_, v) in payload.toolInput { if let s = v.stringValue { return s } }
+        return nil
+    }
+
+    private static func sanitizeForDisplay(_ text: String) -> String {
+        let bidi: Set<UInt32> = [0x200B, 0x200E, 0x200F, 0x202A, 0x202B, 0x202C, 0x202D, 0x202E, 0x2066, 0x2067, 0x2068, 0x2069, 0xFEFF]
+        return String(String.UnicodeScalarView(text.unicodeScalars.filter { scalar in
+            if scalar == "\n" { return true }
+            if scalar.value < 0x20 || scalar.value == 0x7F { return false }
+            return !bidi.contains(scalar.value)
+        }))
+    }
+}

--- a/Sources/Gavel/Remote/TelegramCredentials.swift
+++ b/Sources/Gavel/Remote/TelegramCredentials.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Security
+
+/// Keychain storage for the Telegram bot token. The token is a bearer credential
+/// (whoever holds it controls the bot) so it never touches disk in plaintext.
+enum TelegramCredentials {
+
+    private static let service = "com.gavel.telegram"
+    private static let account = "botToken"
+
+    static func storeToken(_ token: String) {
+        let data = Data(token.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+        var add = query
+        add[kSecValueData as String] = data
+        add[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        SecItemAdd(add as CFDictionary, nil)
+    }
+
+    static func loadToken() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data,
+              let token = String(data: data, encoding: .utf8) else { return nil }
+        return token
+    }
+
+    static func clearToken() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/Sources/Gavel/Remote/TelegramTransport.swift
+++ b/Sources/Gavel/Remote/TelegramTransport.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct TelegramButton {
+    let text: String
+    let callbackData: String
+}
+
+struct TelegramCallback {
+    let id: String
+    let fromId: Int64
+    let chatId: Int64
+    let messageId: Int
+    let data: String
+}
+
+struct TelegramIncomingMessage {
+    let fromId: Int64
+    let chatId: Int64
+    let text: String?
+}
+
+struct TelegramUpdate {
+    let updateId: Int
+    let callback: TelegramCallback?
+    let message: TelegramIncomingMessage?
+}
+
+enum TelegramError: Error {
+    case http(Int)
+    case api(String)
+    case malformedResponse
+    case unauthorizedToken
+}
+
+/// Abstracts the Telegram Bot API so the bridge can be unit-tested against a fake.
+protocol TelegramTransport: AnyObject {
+    func sendMessage(chatId: Int64, text: String, keyboard: [[TelegramButton]]?, completion: @escaping (Result<Int, Error>) -> Void)
+    func editMessageText(chatId: Int64, messageId: Int, text: String, completion: ((Result<Void, Error>) -> Void)?)
+    func answerCallbackQuery(id: String, text: String?, completion: ((Result<Void, Error>) -> Void)?)
+    func getUpdates(offset: Int, timeoutSeconds: Int, completion: @escaping (Result<[TelegramUpdate], Error>) -> Void)
+}

--- a/Sources/Gavel/Remote/URLSessionTelegramTransport.swift
+++ b/Sources/Gavel/Remote/URLSessionTelegramTransport.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Live Telegram Bot API transport over `URLSession` long-polling. Pure Foundation.
+/// The bot token is held privately and never logged.
+final class URLSessionTelegramTransport: TelegramTransport {
+
+    private let token: String
+    private let session: URLSession
+
+    init(token: String) {
+        self.token = token
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.timeoutIntervalForRequest = TimeInterval(GavelConstants.telegramPollTimeoutSeconds + 15)
+        cfg.timeoutIntervalForResource = TimeInterval(GavelConstants.telegramPollTimeoutSeconds + 20)
+        cfg.waitsForConnectivity = false
+        self.session = URLSession(configuration: cfg)
+    }
+
+    /// Replace the bot token with a placeholder so log lines never leak it.
+    func redactToken(_ text: String) -> String {
+        text.replacingOccurrences(of: token, with: "‹token›")
+    }
+
+    func sendMessage(chatId: Int64, text: String, keyboard: [[TelegramButton]]?, completion: @escaping (Result<Int, Error>) -> Void) {
+        var params: [String: Any] = [
+            "chat_id": chatId,
+            "text": text,
+            "disable_web_page_preview": true
+        ]
+        if let keyboard { params["reply_markup"] = ["inline_keyboard": encode(keyboard)] }
+        call("sendMessage", params: params) { result in
+            switch result {
+            case .success(let json):
+                if let r = json["result"] as? [String: Any], let mid = r["message_id"] as? Int {
+                    completion(.success(mid))
+                } else {
+                    completion(.failure(TelegramError.malformedResponse))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func editMessageText(chatId: Int64, messageId: Int, text: String, completion: ((Result<Void, Error>) -> Void)?) {
+        let params: [String: Any] = [
+            "chat_id": chatId,
+            "message_id": messageId,
+            "text": text,
+            "reply_markup": ["inline_keyboard": [[String: Any]]()]
+        ]
+        call("editMessageText", params: params) { result in
+            completion?(result.map { _ in () })
+        }
+    }
+
+    func answerCallbackQuery(id: String, text: String?, completion: ((Result<Void, Error>) -> Void)?) {
+        var params: [String: Any] = ["callback_query_id": id]
+        if let text { params["text"] = text }
+        call("answerCallbackQuery", params: params) { result in
+            completion?(result.map { _ in () })
+        }
+    }
+
+    func getUpdates(offset: Int, timeoutSeconds: Int, completion: @escaping (Result<[TelegramUpdate], Error>) -> Void) {
+        let params: [String: Any] = [
+            "offset": offset,
+            "timeout": timeoutSeconds,
+            "allowed_updates": ["callback_query", "message"]
+        ]
+        call("getUpdates", params: params) { result in
+            switch result {
+            case .success(let json):
+                guard let array = json["result"] as? [[String: Any]] else {
+                    completion(.failure(TelegramError.malformedResponse))
+                    return
+                }
+                completion(.success(array.compactMap { Self.parseUpdate($0) }))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private func encode(_ keyboard: [[TelegramButton]]) -> [[[String: String]]] {
+        keyboard.map { row in row.map { ["text": $0.text, "callback_data": $0.callbackData] } }
+    }
+
+    private func call(_ method: String, params: [String: Any], completion: @escaping (Result<[String: Any], Error>) -> Void) {
+        guard let url = URL(string: "https://api.telegram.org/bot\(token)/\(method)") else {
+            completion(.failure(TelegramError.malformedResponse))
+            return
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: params)
+
+        session.dataTask(with: request) { data, response, error in
+            if let error {
+                completion(.failure(error))
+                return
+            }
+            if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+                completion(.failure(TelegramError.unauthorizedToken))
+                return
+            }
+            guard let data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                completion(.failure(TelegramError.malformedResponse))
+                return
+            }
+            if (json["ok"] as? Bool) == true {
+                completion(.success(json))
+            } else {
+                completion(.failure(TelegramError.api(json["description"] as? String ?? "unknown")))
+            }
+        }.resume()
+    }
+
+    private static func parseUpdate(_ dict: [String: Any]) -> TelegramUpdate? {
+        guard let updateId = dict["update_id"] as? Int else { return nil }
+        return TelegramUpdate(
+            updateId: updateId,
+            callback: parseCallback(dict["callback_query"] as? [String: Any]),
+            message: parseMessage(dict["message"] as? [String: Any])
+        )
+    }
+
+    private static func parseCallback(_ dict: [String: Any]?) -> TelegramCallback? {
+        guard let dict,
+              let id = dict["id"] as? String,
+              let from = dict["from"] as? [String: Any],
+              let fromId = (from["id"] as? Int64) ?? (from["id"] as? Int).map(Int64.init),
+              let message = dict["message"] as? [String: Any],
+              let messageId = message["message_id"] as? Int,
+              let chat = message["chat"] as? [String: Any],
+              let chatId = (chat["id"] as? Int64) ?? (chat["id"] as? Int).map(Int64.init),
+              let data = dict["data"] as? String else { return nil }
+        return TelegramCallback(id: id, fromId: fromId, chatId: chatId, messageId: messageId, data: data)
+    }
+
+    private static func parseMessage(_ dict: [String: Any]?) -> TelegramIncomingMessage? {
+        guard let dict,
+              let from = dict["from"] as? [String: Any],
+              let fromId = (from["id"] as? Int64) ?? (from["id"] as? Int).map(Int64.init),
+              let chat = dict["chat"] as? [String: Any],
+              let chatId = (chat["id"] as? Int64) ?? (chat["id"] as? Int).map(Int64.init) else { return nil }
+        return TelegramIncomingMessage(fromId: fromId, chatId: chatId, text: dict["text"] as? String)
+    }
+}

--- a/Sources/Gavel/System/Constants.swift
+++ b/Sources/Gavel/System/Constants.swift
@@ -47,4 +47,19 @@ enum GavelConstants {
     /// Temp-like directory prefixes where content scanning applies.
     /// Files written outside these paths skip polyglot exfil detection.
     static let tempDirectoryPrefixes = ["/tmp/", "/var/tmp/", "/private/tmp/", "/var/folders/"]
+
+    /// Telegram long-poll hold time in seconds (server-side `getUpdates` timeout).
+    static let telegramPollTimeoutSeconds = 30
+
+    /// Max characters of redacted command/path summary sent to Telegram. Caps
+    /// exposure — full detail stays on the Mac.
+    static let telegramSummaryMaxChars = 200
+
+    /// Default lifetime of a per-session remote-approval grant, in hours.
+    /// Mirrors timed auto-approve: a walk-away with remote left on is the worst case.
+    static let remoteApprovalDefaultHours = 8
+
+    /// Minimum length of an alphanumeric run treated as credential-shaped by the
+    /// credential gate's entropy heuristic.
+    static let credentialEntropyRunLength = 20
 }

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -34,6 +34,7 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
     )
     var socketServer: SocketServer?
     var configWatcher: ConfigWatcher?
+    var remoteBridge: RemoteApprovalBridge?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Disable macOS smart dashes/quotes — gavel needs exact ASCII for patterns
@@ -45,6 +46,7 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         setupMenuBar()
         setupSocketServer()
         setupHookRouter()
+        startRemoteBridge()
         ConfigIntegrity.shared.protect()
         setupConfigWatcher()
         reportLoadIntegrity()
@@ -74,7 +76,64 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         configWatcher?.stop()
         ConfigIntegrity.shared.unprotect()
+        remoteBridge?.stop()
         socketServer?.stop()
+    }
+
+    private func startRemoteBridge() {
+        remoteBridge?.stop()
+        guard let token = TelegramCredentials.loadToken() else {
+            remoteBridge = nil
+            approvalCoordinator.remoteBridge = nil
+            return
+        }
+        let transport = URLSessionTelegramTransport(token: token)
+        let bridge = RemoteApprovalBridge(transport: transport, chatId: sessionManager.telegramChatId, redact: transport.redactToken)
+        bridge.onPaired = { [weak self] chatId in
+            DispatchQueue.main.async {
+                self?.sessionManager.telegramChatId = chatId
+                self?.sessionManager.saveDefaults()
+                self?.viewModel.appendFeedEntry(.system("Telegram paired (chat \(chatId))", pid: Int(getpid()), at: Date()))
+            }
+        }
+        bridge.onStatus = { [weak self] message in
+            gavelLog("[telegram] \(message)")
+            DispatchQueue.main.async {
+                self?.viewModel.appendFeedEntry(.system("Telegram: \(message)", pid: Int(getpid()), at: Date()))
+            }
+        }
+        approvalCoordinator.remoteBridge = bridge
+        remoteBridge = bridge
+        bridge.start()
+    }
+
+    @objc private func configureTelegram() {
+        let alert = NSAlert()
+        alert.messageText = "Configure Telegram Remote Approval"
+        alert.informativeText = "Paste your bot token from @BotFather. After saving, open your bot in Telegram and send /start to pair this chat. Remote approval must also be enabled per session in the Sessions tab. Command text is sent to Telegram's servers; payloads containing detected credentials are withheld automatically."
+        let field = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
+        field.placeholderString = "123456789:ABCdef..."
+        alert.accessoryView = field
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Cancel")
+        let hasToken = TelegramCredentials.loadToken() != nil
+        if hasToken { alert.addButton(withTitle: "Remove Token") }
+
+        let response = alert.runModal()
+        switch response {
+        case .alertFirstButtonReturn:
+            let token = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !token.isEmpty else { return }
+            TelegramCredentials.storeToken(token)
+            startRemoteBridge()
+        case .alertThirdButtonReturn where hasToken:
+            TelegramCredentials.clearToken()
+            sessionManager.telegramChatId = nil
+            sessionManager.saveDefaults()
+            startRemoteBridge()
+        default:
+            break
+        }
     }
 
     private func reportLoadIntegrity() {
@@ -150,6 +209,7 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         let editorItem = NSMenuItem(title: "Editor Preference", action: nil, keyEquivalent: "")
         editorItem.submenu = buildEditorSubmenu()
         menu.addItem(editorItem)
+        menu.addItem(NSMenuItem(title: "Configure Telegram…", action: #selector(configureTelegram), keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Pause All Sessions", action: #selector(togglePauseAll), keyEquivalent: ""))
         let promptAllItem = NSMenuItem(title: "Prompt All Sessions", action: #selector(promptAll), keyEquivalent: "P")
@@ -350,6 +410,7 @@ let terminationSignalSources: [DispatchSourceSignal] = [SIGTERM, SIGINT].map { s
     let source = DispatchSource.makeSignalSource(signal: sig, queue: signalQueue)
     source.setEventHandler {
         gavelLog("SIGNAL: \(sig) — unprotecting config before exit")
+        RemoteApprovalBridge.shared?.stop()
         ConfigIntegrity.shared.unprotect()
         exit(0)
     }

--- a/Tests/GavelTests/CredentialGateTests.swift
+++ b/Tests/GavelTests/CredentialGateTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import Gavel
+
+final class CredentialGateTests: XCTestCase {
+
+    private func payload(_ input: [String: Any]) -> PreToolUsePayload {
+        PreToolUsePayload(toolName: "Bash", toolInput: input.mapValues { AnyCodable($0) })
+    }
+
+    func testAwsKeyBlocks() {
+        XCTAssertTrue(CredentialGate.blocksRemote(payload(["command": "aws s3 ls AKIAIOSFODNN7EXAMPLE"])))
+    }
+
+    func testGitHubPatBlocks() {
+        XCTAssertTrue(CredentialGate.blocksRemote(payload(["command": "echo ghp_0123456789abcdefABCDEF0123456789abcdef"])))
+    }
+
+    func testGenericHighEntropyRunBlocks() {
+        XCTAssertTrue(CredentialGate.blocksRemote(payload(["command": "export TOKEN=Xa9Kd2Lp8Qw3Zr7Tv1Bn6Mc"])))
+    }
+
+    func testNestedInputFieldIsScanned() {
+        let nested: [String: Any] = ["env": ["SECRET": "AKIAIOSFODNN7EXAMPLE"]]
+        XCTAssertTrue(CredentialGate.blocksRemote(payload(nested)))
+    }
+
+    func testPlainCommandPasses() {
+        XCTAssertFalse(CredentialGate.blocksRemote(payload(["command": "swift build && swift test"])))
+    }
+
+    func testUuidIsNotCredentialShaped() {
+        XCTAssertFalse(CredentialGate.blocksRemote(payload(["command": "open 1d17c7c4-5cc5-4eda-a03f-a029b5254345"])))
+    }
+
+    func testIsoTimestampIsNotCredentialShaped() {
+        XCTAssertFalse(CredentialGate.blocksRemote(payload(["command": "log since 2026-06-16T11:09:00"])))
+    }
+
+    func testFilesystemPathIsNotCredentialShaped() {
+        XCTAssertFalse(CredentialGate.blocksRemote(payload(["file_path": "/Users/jay/code/Sources/Gavel/main.swift"])))
+    }
+}

--- a/Tests/GavelTests/FakeTelegramTransport.swift
+++ b/Tests/GavelTests/FakeTelegramTransport.swift
@@ -1,0 +1,38 @@
+import Foundation
+@testable import Gavel
+
+final class FakeTelegramTransport: TelegramTransport {
+    var sentMessages: [(chatId: Int64, text: String, keyboard: [[TelegramButton]]?)] = []
+    var edits: [(messageId: Int, text: String)] = []
+    var answers: [(id: String, text: String?)] = []
+    private var nextMessageId = 100
+
+    func sendMessage(chatId: Int64, text: String, keyboard: [[TelegramButton]]?, completion: @escaping (Result<Int, Error>) -> Void) {
+        sentMessages.append((chatId, text, keyboard))
+        let mid = nextMessageId
+        nextMessageId += 1
+        completion(.success(mid))
+    }
+
+    func editMessageText(chatId: Int64, messageId: Int, text: String, completion: ((Result<Void, Error>) -> Void)?) {
+        edits.append((messageId, text))
+        completion?(.success(()))
+    }
+
+    func answerCallbackQuery(id: String, text: String?, completion: ((Result<Void, Error>) -> Void)?) {
+        answers.append((id, text))
+        completion?(.success(()))
+    }
+
+    func getUpdates(offset: Int, timeoutSeconds: Int, completion: @escaping (Result<[TelegramUpdate], Error>) -> Void) {
+        parkedUpdatesCompletion = completion
+    }
+
+    var parkedUpdatesCompletion: ((Result<[TelegramUpdate], Error>) -> Void)?
+
+    var lastCallbackData: [String] {
+        (sentMessages.last?.keyboard ?? []).flatMap { $0 }.map { $0.callbackData }
+    }
+
+    var lastSentMessageId: Int { nextMessageId - 1 }
+}

--- a/Tests/GavelTests/RemoteApprovalBridgeTests.swift
+++ b/Tests/GavelTests/RemoteApprovalBridgeTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import Gavel
+
+final class RemoteApprovalBridgeTests: XCTestCase {
+
+    private let owner: Int64 = 42
+
+    private func nonce(from data: [String]) -> String {
+        let allow = data.first { $0.hasPrefix("a:") } ?? ""
+        return String(allow.dropFirst(2))
+    }
+
+    private func callbackUpdate(action: String, nonce: String, fromId: Int64, chatId: Int64, messageId: Int) -> TelegramUpdate {
+        TelegramUpdate(
+            updateId: 1,
+            callback: TelegramCallback(id: "cb1", fromId: fromId, chatId: chatId, messageId: messageId, data: "\(action):\(nonce)"),
+            message: nil
+        )
+    }
+
+    func testTelegramAllowResolvesAndEdits() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var resolved: Decision?
+        let approval = ResolvableApproval { resolved = $0 }
+
+        bridge.notify(resolvable: approval, text: "approve?", allowSession: nil)
+        XCTAssertEqual(fake.sentMessages.count, 1)
+
+        let n = nonce(from: fake.lastCallbackData)
+        bridge.handle(callbackUpdate(action: "a", nonce: n, fromId: owner, chatId: owner, messageId: fake.lastSentMessageId))
+
+        XCTAssertEqual(resolved?.verdict, .allow)
+        XCTAssertEqual(fake.answers.last?.text, "Allowed")
+        XCTAssertTrue(fake.edits.contains { $0.text.contains("from phone") })
+    }
+
+    func testUnauthorizedChatIgnored() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var resolved: Decision?
+        let approval = ResolvableApproval { resolved = $0 }
+
+        bridge.notify(resolvable: approval, text: "approve?", allowSession: nil)
+        let n = nonce(from: fake.lastCallbackData)
+        bridge.handle(callbackUpdate(action: "a", nonce: n, fromId: 999, chatId: 999, messageId: fake.lastSentMessageId))
+
+        XCTAssertNil(resolved)
+        XCTAssertEqual(fake.answers.last?.text, "Not authorized")
+    }
+
+    func testStaleNonceIsNoOp() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+
+        bridge.handle(callbackUpdate(action: "a", nonce: "deadbeef", fromId: owner, chatId: owner, messageId: 1))
+
+        XCTAssertEqual(fake.answers.last?.text, "Already resolved")
+    }
+
+    func testMacWinsThenLateTelegramTapIsNoOp() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var resolved: Decision?
+        let approval = ResolvableApproval { resolved = $0 }
+
+        bridge.notify(resolvable: approval, text: "approve?", allowSession: nil)
+        let n = nonce(from: fake.lastCallbackData)
+
+        approval.resolve(Decision(verdict: .block, reason: "denied on mac"), from: .mac)
+        XCTAssertTrue(fake.edits.contains { $0.text.contains("Answered on Mac") })
+
+        bridge.handle(callbackUpdate(action: "a", nonce: n, fromId: owner, chatId: owner, messageId: fake.lastSentMessageId))
+        XCTAssertEqual(resolved?.verdict, .block)
+        XCTAssertEqual(fake.answers.last?.text, "Already resolved")
+    }
+
+    func testPairingCapturesChatIdFromStart() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: nil)
+        var pairedWith: Int64?
+        bridge.onPaired = { pairedWith = $0 }
+
+        let start = TelegramUpdate(updateId: 1, callback: nil, message: TelegramIncomingMessage(fromId: owner, chatId: owner, text: "/start"))
+        bridge.handle(start)
+
+        XCTAssertEqual(pairedWith, owner)
+        XCTAssertTrue(bridge.isPaired)
+    }
+
+    func testAllowForSessionInvokesCallback() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        let approval = ResolvableApproval { _ in }
+        var sessionAllowed = false
+
+        bridge.notify(resolvable: approval, text: "approve?", allowSession: { sessionAllowed = true })
+        let n = nonce(from: fake.lastCallbackData)
+        bridge.handle(callbackUpdate(action: "s", nonce: n, fromId: owner, chatId: owner, messageId: fake.lastSentMessageId))
+
+        XCTAssertTrue(sessionAllowed)
+    }
+
+    func testSummaryBodyRedactsAndOmitsFileContent() {
+        let session = Session(pid: 123)
+        session.label = "demo"
+        let payload = PreToolUsePayload(
+            toolName: "Write",
+            toolInput: [
+                "file_path": AnyCodable("/tmp/out.txt"),
+                "content": AnyCodable("super secret body AKIAIOSFODNN7EXAMPLE that should never ship")
+            ]
+        )
+        let body = RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: nil)
+
+        XCTAssertTrue(body.contains("/tmp/out.txt"))
+        XCTAssertFalse(body.contains("super secret body"))
+        XCTAssertFalse(body.contains("AKIAIOSFODNN7EXAMPLE"))
+    }
+}

--- a/Tests/GavelTests/ResolvableApprovalTests.swift
+++ b/Tests/GavelTests/ResolvableApprovalTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import Gavel
+
+final class ResolvableApprovalTests: XCTestCase {
+
+    func testFirstResolveWinsSubsequentAreNoOps() {
+        var sunk: [Decision] = []
+        let approval = ResolvableApproval { sunk.append($0) }
+
+        let firstWon = approval.resolve(Decision(verdict: .allow, reason: "a"), from: .telegram)
+        let secondWon = approval.resolve(Decision(verdict: .block, reason: "b"), from: .mac)
+
+        XCTAssertTrue(firstWon)
+        XCTAssertFalse(secondWon)
+        XCTAssertEqual(sunk.count, 1)
+        XCTAssertEqual(sunk.first?.verdict, .allow)
+    }
+
+    func testCleanupHookFiresOnceWithWinningSource() {
+        let approval = ResolvableApproval { _ in }
+        var sources: [ResolvableApproval.Source] = []
+        approval.addCleanup { source, _ in sources.append(source) }
+
+        approval.resolve(Decision(verdict: .allow, reason: nil), from: .mac)
+        approval.resolve(Decision(verdict: .block, reason: nil), from: .telegram)
+
+        XCTAssertEqual(sources, [.mac])
+    }
+
+    func testIsResolvedReflectsState() {
+        let approval = ResolvableApproval { _ in }
+        XCTAssertFalse(approval.isResolved)
+        approval.resolve(Decision(verdict: .allow, reason: nil), from: .timeout)
+        XCTAssertTrue(approval.isResolved)
+    }
+
+    func testConcurrentResolveYieldsExactlyOneWinner() {
+        let approval = ResolvableApproval { _ in }
+        let winners = NSMutableArray()
+        let group = DispatchGroup()
+        for source in [ResolvableApproval.Source.mac, .telegram, .timeout] {
+            group.enter()
+            DispatchQueue.global().async {
+                if approval.resolve(Decision(verdict: .allow, reason: nil), from: source) {
+                    objc_sync_enter(winners); winners.add(1); objc_sync_exit(winners)
+                }
+                group.leave()
+            }
+        }
+        group.wait()
+        XCTAssertEqual(winners.count, 1)
+    }
+}


### PR DESCRIPTION
## What
Per-session, opt-in path to approve/deny pending tool calls from a phone via a Telegram bot, racing the on-Mac panel. Additive — the local panel stays authoritative and fail-closed.

## How
- Long-poll `getUpdates`; inline Allow / Deny / Allow-for-session buttons; first responder (Mac or phone) wins via an idempotent `ResolvableApproval` guard. The 24h fail-closed timeout is unchanged.
- Per-session **Phone** toggle (default off, 8h auto-expiry); the flag gates both send and accept. Cleared on Prompt-All / inactivity.
- **Credential gate (non-disableable):** payloads with known key patterns or a high-entropy run are withheld entirely (contentless notice only) — never redacted-and-sent.
- Bot token in Keychain; chat pinned via `/start`; single-use nonce in `callback_data`; plain text only; token never logged.

## Tests
533 green (19 new: race guard, credential gate, bridge correlation, fake transport). Dogfooded live: remote approve (`Approved from phone`) and credential-gate withhold (forced to Mac) both verified end to end.

## Known limitation
The high-entropy heuristic over-suppresses by design — long hyphenated identifiers (e.g. branch names ≥20 chars) trip it. Tuning is a follow-up.