### PR TITLE
fix(approval): exclude kebab/snake identifiers from credential gate heuristic

### DIFF
--- a/Sources/Gavel/Approval/CredentialGate.swift
+++ b/Sources/Gavel/Approval/CredentialGate.swift
@@ -59,6 +59,7 @@ enum CredentialGate {
         let range = NSRange(token.startIndex..., in: token)
         if uuidRegex.firstMatch(in: token, range: range) != nil { return true }
         if iso8601Regex.firstMatch(in: token, range: range) != nil { return true }
+        if identifierRegex.firstMatch(in: token, range: range) != nil { return true }
         return false
     }
 
@@ -72,5 +73,9 @@ enum CredentialGate {
 
     private static let iso8601Regex = try! NSRegularExpression(
         pattern: "^\\d{4}-\\d{2}-\\d{2}([T ]\\d{2}:\\d{2}(:\\d{2})?)?"
+    )
+
+    private static let identifierRegex = try! NSRegularExpression(
+        pattern: "^[a-z0-9]+([_-][a-z0-9]+)+$"
     )
 }

--- a/Tests/GavelTests/CredentialGateTests.swift
+++ b/Tests/GavelTests/CredentialGateTests.swift
@@ -39,4 +39,16 @@ final class CredentialGateTests: XCTestCase {
     func testFilesystemPathIsNotCredentialShaped() {
         XCTAssertFalse(CredentialGate.blocksRemote(payload(["file_path": "/Users/jay/code/Sources/Gavel/main.swift"])))
     }
+
+    func testKebabBranchNameIsNotCredentialShaped() {
+        XCTAssertFalse(CredentialGate.blocksRemote(payload(["command": "git push origin feat/telegram-remote-approval"])))
+    }
+
+    func testSnakeIdentifierIsNotCredentialShaped() {
+        XCTAssertFalse(CredentialGate.blocksRemote(payload(["command": "call some_very_long_function_name_here"])))
+    }
+
+    func testMixedCaseHighEntropyStillBlocksAfterIdentifierWhitelist() {
+        XCTAssertTrue(CredentialGate.blocksRemote(payload(["command": "echo Xa9Kd2Lp8Qw3Zr7Tv1Bn6Mc"])))
+    }
 }


### PR DESCRIPTION
## Problem
The credential gate's high-entropy heuristic flagged **any** 20+ char run, so lowercase kebab/snake identifiers -- notably git branch names like `feat/telegram-remote-approval` -- were withheld from Telegram as if credential-shaped. Surfaced while dogfooding #134.

## Fix
Whitelist lowercase identifiers separated by `-` or `_` (`^[a-z0-9]+([_-][a-z0-9]+)+$`). Mixed-case and separator-free high-entropy strings still block, and known key patterns (`SecretRedactor`) are matched **before** the heuristic, so real secrets -- including `sk-ant-…` -- are unaffected.

## Tests
536 green; 3 new gate cases (kebab branch name, snake identifier, mixed-case still blocks).

## Note
The `git stash push` false positive from the same session is **not** here -- that's a user rule in `rules.json` (`\bgit\b.*\bpush\b`), not code; fix it in the Rules tab.