### PR TITLE
feat(approval): richer telegram approvals + token source + config self-protect

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -161,7 +161,8 @@ final class ApprovalCoordinator: ObservableObject {
             DispatchQueue.main.async { self?.dismissPending(id: pendingId, pid: session.pid) }
         }
         let text = RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: pending.triggerReason)
-        bridge.notify(resolvable: resolvable, text: text, allowSession: allowSession)
+        let isCommit = payload.toolName == "Bash" && (payload.command?.contains("commit") ?? false)
+        bridge.notify(resolvable: resolvable, text: text, allowSession: allowSession, offerCommentClean: isCommit)
     }
 
     /// Remove a pending approval resolved remotely from its session panel.

--- a/Sources/Gavel/Approval/PatternMatcher.swift
+++ b/Sources/Gavel/Approval/PatternMatcher.swift
@@ -203,7 +203,7 @@ struct PatternMatcher {
         // Ask user — config and tools that may legitimately need editing
         let rawAskUserPaths: [(pattern: String, reason: String)] = [
             // Gavel's own config
-            ("\\.claude/gavel/(rules\\.json|session-defaults\\.json|hooks/|bin/)", "Sensitive: Gavel config"),
+            ("\\.claude/gavel/", "Sensitive: Gavel config"),
             // Claude Code hooks and settings
             ("\\.claude/(settings\\.json|settings\\.local\\.json|hooks/)", "Sensitive: Claude Code settings/hooks"),
             // Project MCP server config (auto-enable / server-definition vector)

--- a/Sources/Gavel/Remote/RemoteApprovalBridge.swift
+++ b/Sources/Gavel/Remote/RemoteApprovalBridge.swift
@@ -8,10 +8,12 @@ final class RemoteApprovalBridge {
     static weak var shared: RemoteApprovalBridge?
 
     private final class Correlation {
+        let nonce: String
         let resolvable: ResolvableApproval
         let allowSession: (() -> Void)?
         var messageId: Int?
-        init(resolvable: ResolvableApproval, allowSession: (() -> Void)?) {
+        init(nonce: String, resolvable: ResolvableApproval, allowSession: (() -> Void)?) {
+            self.nonce = nonce
             self.resolvable = resolvable
             self.allowSession = allowSession
         }
@@ -21,10 +23,16 @@ final class RemoteApprovalBridge {
     private let redact: (String) -> String
     private let lock = NSLock()
     private var byNonce: [String: Correlation] = [:]
+    private var pendingOrder: [String] = []
     private var offset = 0
     private var running = false
     private var backoff: TimeInterval = 1
     private var chatId: Int64?
+
+    private var sendTokens = 5.0
+    private var lastRefill = Date()
+    private var coalescedCount = 0
+    private var lastCoalesceNotice: Date?
 
     /// Fired when pairing captures a chat id, so the daemon can persist it.
     var onPaired: ((Int64) -> Void)?
@@ -60,28 +68,37 @@ final class RemoteApprovalBridge {
     // MARK: - Outbound
 
     /// Send a pending approval to the phone and register it for inbound resolution.
-    func notify(resolvable: ResolvableApproval, text: String, allowSession: (() -> Void)?) {
+    func notify(resolvable: ResolvableApproval, text: String, allowSession: (() -> Void)?, offerCommentClean: Bool = false) {
         lock.lock(); let chat = chatId; lock.unlock()
         guard let chat else { return }
 
-        let nonce = Self.makeNonce()
-        let corr = Correlation(resolvable: resolvable, allowSession: allowSession)
-        lock.lock(); byNonce[nonce] = corr; lock.unlock()
+        guard consumeSendToken() else {
+            coalesce(chat: chat)
+            return
+        }
 
-        resolvable.addCleanup { [weak self] source, decision in
+        let nonce = Self.makeNonce()
+        let corr = Correlation(nonce: nonce, resolvable: resolvable, allowSession: allowSession)
+        lock.lock(); byNonce[nonce] = corr; pendingOrder.append(nonce); lock.unlock()
+
+        resolvable.addCleanup { [weak self] source, _ in
             guard let self else { return }
-            self.lock.lock(); self.byNonce.removeValue(forKey: nonce); let mid = corr.messageId; self.lock.unlock()
+            self.lock.lock(); let mid = corr.messageId; self.lock.unlock()
+            self.forget(nonce)
             guard source != .telegram else { return }
             if let mid {
                 self.transport.editMessageText(chatId: chat, messageId: mid, text: Self.macResolvedText(source), completion: nil)
             }
         }
 
-        let keyboard: [[TelegramButton]] = [
+        var keyboard: [[TelegramButton]] = [
             [TelegramButton(text: "✅ Allow once", callbackData: "a:\(nonce)"),
              TelegramButton(text: "🛑 Deny", callbackData: "d:\(nonce)")],
             [TelegramButton(text: "✅ Allow for session", callbackData: "s:\(nonce)")]
         ]
+        if offerCommentClean {
+            keyboard.append([TelegramButton(text: "🧹 Clean comments & re-propose", callbackData: "c:\(nonce)")])
+        }
         transport.sendMessage(chatId: chat, text: text, keyboard: keyboard) { [weak self] result in
             guard let self else { return }
             switch result {
@@ -89,7 +106,7 @@ final class RemoteApprovalBridge {
                 self.lock.lock(); corr.messageId = mid; self.lock.unlock()
                 if resolvable.isResolved {
                     self.transport.editMessageText(chatId: chat, messageId: mid, text: Self.macResolvedText(.mac), completion: nil)
-                    self.lock.lock(); self.byNonce.removeValue(forKey: nonce); self.lock.unlock()
+                    self.forget(nonce)
                 }
             case .failure(let error):
                 self.onStatus?("Telegram send failed: \(self.redact("\(error)"))")
@@ -130,6 +147,10 @@ final class RemoteApprovalBridge {
                     self.stop()
                     return
                 }
+                if case TelegramError.rateLimited(let retryAfter) = error {
+                    self.rearm(after: retryAfter)
+                    return
+                }
                 let delay = self.bumpBackoff()
                 self.onStatus?("Telegram poll error (retry \(Int(delay))s): \(self.redact("\(error)"))")
                 self.rearm(after: delay)
@@ -151,16 +172,35 @@ final class RemoteApprovalBridge {
     }
 
     private func handleMessage(_ message: TelegramIncomingMessage) {
-        lock.lock(); let paired = chatId != nil; lock.unlock()
-        guard !paired, (message.text ?? "").hasPrefix("/start") else { return }
-        lock.lock(); chatId = message.chatId; lock.unlock()
-        onPaired?(message.chatId)
-        transport.sendMessage(
-            chatId: message.chatId,
-            text: "Gavel paired ✅ — this chat is now the only one that can answer approvals.",
-            keyboard: nil,
-            completion: { _ in }
-        )
+        lock.lock(); let pinned = chatId; lock.unlock()
+
+        if pinned == nil {
+            guard (message.text ?? "").hasPrefix("/start") else { return }
+            lock.lock(); chatId = message.chatId; lock.unlock()
+            onPaired?(message.chatId)
+            transport.sendMessage(
+                chatId: message.chatId,
+                text: "Gavel paired ✅ — this chat is now the only one that can answer approvals.",
+                keyboard: nil,
+                completion: { _ in }
+            )
+            return
+        }
+
+        guard let pinned, message.chatId == pinned, message.fromId == pinned else { return }
+        guard let text = message.text, !text.isEmpty, !text.hasPrefix("/") else { return }
+        switch typedReplyTarget(replyTo: message.replyToMessageId) {
+        case .target(let corr):
+            forget(corr.nonce)
+            let decision = Decision(verdict: .block, reason: "Denied from phone — \(text)")
+            if corr.resolvable.resolve(decision, from: .telegram), let mid = corr.messageId {
+                transport.editMessageText(chatId: pinned, messageId: mid, text: "🛑 Denied from phone — \(text)", completion: nil)
+            }
+        case .ambiguous(let count):
+            transport.sendMessage(chatId: pinned, text: "\(count) approvals pending — swipe-reply the specific one you mean, or tap its buttons.", keyboard: nil, completion: { _ in })
+        case .none:
+            break
+        }
     }
 
     private func handleCallback(_ callback: TelegramCallback) {
@@ -178,17 +218,19 @@ final class RemoteApprovalBridge {
         let action = String(parts[0])
         let nonce = String(parts[1])
 
-        lock.lock(); let corr = byNonce.removeValue(forKey: nonce); lock.unlock()
+        lock.lock(); let corr = byNonce[nonce]; lock.unlock()
         guard let corr else {
             transport.answerCallbackQuery(id: callback.id, text: "Already resolved", completion: nil)
             transport.editMessageText(chatId: pinned, messageId: callback.messageId, text: "↪️ Already resolved", completion: nil)
             return
         }
+        forget(nonce)
 
         if action == "s" { corr.allowSession?() }
-        let won = corr.resolvable.resolve(Self.decision(for: action), from: .telegram)
+        let decision = Self.decision(for: action)
+        let won = corr.resolvable.resolve(decision, from: .telegram)
         if won {
-            transport.answerCallbackQuery(id: callback.id, text: action == "d" ? "Denied" : "Allowed", completion: nil)
+            transport.answerCallbackQuery(id: callback.id, text: decision.verdict == .block ? "Denied" : "Allowed", completion: nil)
             transport.editMessageText(chatId: pinned, messageId: callback.messageId, text: Self.phoneResolvedText(action), completion: nil)
         } else {
             transport.answerCallbackQuery(id: callback.id, text: "Already resolved", completion: nil)
@@ -217,31 +259,90 @@ final class RemoteApprovalBridge {
     static func decision(for action: String) -> Decision {
         switch action {
         case "d": return Decision(verdict: .block, reason: "Denied from phone")
+        case "c": return Decision(verdict: .block, reason: "Denied from phone — clean up the house-rule comment violations in this change, then re-propose the commit.")
         case "s": return Decision(verdict: .allow, reason: "Approved for session from phone")
         default: return Decision(verdict: .allow, reason: "Approved from phone")
         }
     }
 
     private static func phoneResolvedText(_ action: String) -> String {
-        action == "d" ? "🛑 Denied from phone" : "✅ Approved from phone"
+        switch action {
+        case "d": return "🛑 Denied from phone"
+        case "c": return "🧹 Denied — clean comments & re-propose"
+        default: return "✅ Approved from phone"
+        }
+    }
+
+    private func forget(_ nonce: String) {
+        lock.lock()
+        byNonce.removeValue(forKey: nonce)
+        pendingOrder.removeAll { $0 == nonce }
+        lock.unlock()
+    }
+
+    private enum TypedReplyTarget {
+        case target(Correlation)
+        case ambiguous(Int)
+        case none
+    }
+
+    private func typedReplyTarget(replyTo: Int?) -> TypedReplyTarget {
+        lock.lock(); defer { lock.unlock() }
+        if let replyTo {
+            if let match = byNonce.values.first(where: { $0.messageId == replyTo }) { return .target(match) }
+            return .none
+        }
+        switch pendingOrder.count {
+        case 0: return .none
+        case 1: return byNonce[pendingOrder[0]].map { .target($0) } ?? .none
+        default: return .ambiguous(pendingOrder.count)
+        }
+    }
+
+    private func consumeSendToken() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        let now = Date()
+        sendTokens = min(5.0, sendTokens + now.timeIntervalSince(lastRefill))
+        lastRefill = now
+        guard sendTokens >= 1 else { return false }
+        sendTokens -= 1
+        return true
+    }
+
+    private func coalesce(chat: Int64) {
+        lock.lock()
+        coalescedCount += 1
+        let count = coalescedCount
+        let now = Date()
+        let shouldNotice = lastCoalesceNotice.map { now.timeIntervalSince($0) > 5 } ?? true
+        if shouldNotice { lastCoalesceNotice = now }
+        lock.unlock()
+        guard shouldNotice else { return }
+        transport.sendMessage(chatId: chat, text: "⚠️ \(count) approvals queued too fast for Telegram — answer them on your Mac.", keyboard: nil, completion: { _ in })
     }
 
     private static func macResolvedText(_ source: ResolvableApproval.Source) -> String {
         source == .timeout ? "⏱ Timed out — denied (Mac)" : "✅ Answered on Mac"
     }
 
-    /// Build the redacted, truncated, control-stripped message body for an approval.
+    /// Build the redacted, control-stripped message body for an approval — full command, capped near Telegram's limit.
     static func summaryBody(payload: PreToolUsePayload, session: Session, triggerReason: String?) -> String {
         let label = session.label.isEmpty ? "PID \(session.pid)" : session.label
-        let raw = payload.command ?? payload.filePath ?? firstStringInput(payload) ?? ""
-        let summary = sanitizeForDisplay(SecretRedactor.redact(raw))
-        let capped = summary.count > GavelConstants.telegramSummaryMaxChars
-            ? String(summary.prefix(GavelConstants.telegramSummaryMaxChars)) + "…"
-            : summary
         var lines = ["Gavel approval — \(sanitizeForDisplay(label))", "Tool: \(payload.toolName)"]
-        if !capped.isEmpty { lines.append(capped) }
+        if let cwd = session.cwd {
+            let tail = cwd.split(separator: "/").suffix(2).joined(separator: "/")
+            if !tail.isEmpty { lines.append("cwd: …/\(tail)") }
+        }
+        let raw = payload.command ?? payload.filePath ?? firstStringInput(payload) ?? ""
+        if !raw.isEmpty {
+            let cleaned = sanitizeForDisplay(SecretRedactor.redact(raw))
+            if cleaned.count > GavelConstants.telegramBodyMaxChars {
+                lines.append(String(cleaned.prefix(GavelConstants.telegramBodyMaxChars)) + "… (truncated — full on Mac)")
+            } else {
+                lines.append(cleaned)
+            }
+        }
         if let reason = triggerReason, !reason.isEmpty { lines.append("(\(sanitizeForDisplay(reason)))") }
-        lines.append("(full detail on Mac)")
         return lines.joined(separator: "\n")
     }
 

--- a/Sources/Gavel/Remote/TelegramTokenSource.swift
+++ b/Sources/Gavel/Remote/TelegramTokenSource.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Where the Telegram bot token is read from (Doppler for dev builds, Keychain for release).
+protocol TelegramTokenSource {
+    func load() -> String?
+}
+
+struct KeychainTokenSource: TelegramTokenSource {
+    func load() -> String? { TelegramCredentials.loadToken() }
+}
+
+/// Reads the token via the `doppler` CLI using the user's login, so a fresh dev rebuild never prompts.
+struct DopplerTokenSource: TelegramTokenSource {
+    let project: String
+    let config: String
+    let secret: String
+
+    func load() -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["doppler", "secrets", "get", secret, "-p", project, "-c", config, "--plain"]
+        var env = ProcessInfo.processInfo.environment
+        let extra = "/opt/homebrew/bin:/usr/local/bin"
+        env["PATH"] = (env["PATH"].map { "\($0):\(extra)" }) ?? extra
+        task.environment = env
+        let out = Pipe()
+        task.standardOutput = out
+        task.standardError = Pipe()
+        do { try task.run() } catch { return nil }
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+        guard task.terminationStatus == 0 else { return nil }
+        let token = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (token?.isEmpty == false) ? token : nil
+    }
+}
+
+enum TelegramTokenResolver {
+    static func resolve(executablePath: String? = Bundle.main.executablePath) -> TelegramTokenSource {
+        if (executablePath ?? "").contains("/.build/") {
+            return DopplerTokenSource(project: "gavel", config: "dev", secret: "TELEGRAM_BOT_TOKEN")
+        }
+        return KeychainTokenSource()
+    }
+}

--- a/Sources/Gavel/Remote/TelegramTransport.swift
+++ b/Sources/Gavel/Remote/TelegramTransport.swift
@@ -17,6 +17,7 @@ struct TelegramIncomingMessage {
     let fromId: Int64
     let chatId: Int64
     let text: String?
+    let replyToMessageId: Int?
 }
 
 struct TelegramUpdate {
@@ -30,6 +31,7 @@ enum TelegramError: Error {
     case api(String)
     case malformedResponse
     case unauthorizedToken
+    case rateLimited(retryAfter: Double)
 }
 
 /// Abstracts the Telegram Bot API so the bridge can be unit-tested against a fake.

--- a/Sources/Gavel/Remote/URLSessionTelegramTransport.swift
+++ b/Sources/Gavel/Remote/URLSessionTelegramTransport.swift
@@ -112,6 +112,9 @@ final class URLSessionTelegramTransport: TelegramTransport {
             }
             if (json["ok"] as? Bool) == true {
                 completion(.success(json))
+            } else if (json["error_code"] as? Int) == 429 {
+                let retry = (json["parameters"] as? [String: Any])?["retry_after"] as? Double ?? 1
+                completion(.failure(TelegramError.rateLimited(retryAfter: retry)))
             } else {
                 completion(.failure(TelegramError.api(json["description"] as? String ?? "unknown")))
             }
@@ -146,6 +149,7 @@ final class URLSessionTelegramTransport: TelegramTransport {
               let fromId = (from["id"] as? Int64) ?? (from["id"] as? Int).map(Int64.init),
               let chat = dict["chat"] as? [String: Any],
               let chatId = (chat["id"] as? Int64) ?? (chat["id"] as? Int).map(Int64.init) else { return nil }
-        return TelegramIncomingMessage(fromId: fromId, chatId: chatId, text: dict["text"] as? String)
+        let replyTo = (dict["reply_to_message"] as? [String: Any])?["message_id"] as? Int
+        return TelegramIncomingMessage(fromId: fromId, chatId: chatId, text: dict["text"] as? String, replyToMessageId: replyTo)
     }
 }

--- a/Sources/Gavel/System/Constants.swift
+++ b/Sources/Gavel/System/Constants.swift
@@ -51,9 +51,8 @@ enum GavelConstants {
     /// Telegram long-poll hold time in seconds (server-side `getUpdates` timeout).
     static let telegramPollTimeoutSeconds = 30
 
-    /// Max characters of redacted command/path summary sent to Telegram. Caps
-    /// exposure — full detail stays on the Mac.
-    static let telegramSummaryMaxChars = 200
+    /// Max characters of the redacted command shown in a Telegram approval (under Telegram's 4096 limit).
+    static let telegramBodyMaxChars = 3500
 
     /// Default lifetime of a per-session remote-approval grant, in hours.
     /// Mirrors timed auto-approve: a walk-away with remote left on is the worst case.

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -82,7 +82,15 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
 
     private func startRemoteBridge() {
         remoteBridge?.stop()
-        guard let token = TelegramCredentials.loadToken() else {
+        let source = TelegramTokenResolver.resolve()
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let token = source.load()
+            DispatchQueue.main.async { self?.installBridge(token: token) }
+        }
+    }
+
+    private func installBridge(token: String?) {
+        guard let token else {
             remoteBridge = nil
             approvalCoordinator.remoteBridge = nil
             return

--- a/Tests/GavelTests/PatternMatcherTests.swift
+++ b/Tests/GavelTests/PatternMatcherTests.swift
@@ -16,6 +16,16 @@ final class PatternMatcherTests: XCTestCase {
         PreToolUsePayload(toolName: "Edit", toolInput: ["file_path": AnyCodable(filePath)])
     }
 
+    // MARK: - Gavel config self-protection
+
+    func testGavelDirWritesPromptIncludingSessionContext() {
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: writePayload(filePath: "/Users/x/.claude/gavel/session-context.md")))
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: editPayload(filePath: "/Users/x/.claude/gavel/session-context.md")))
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: writePayload(filePath: "/Users/x/.claude/gavel/active-sessions.json")))
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: writePayload(filePath: "/Users/x/.claude/gavel/rules.json")))
+        XCTAssertNil(matcher.matchSensitivePath(payload: writePayload(filePath: "/Users/x/code/project/README.md")))
+    }
+
     // MARK: - Safe commands pass
 
     func testSafeCommandsPass() {

--- a/Tests/GavelTests/RemoteApprovalBridgeTests.swift
+++ b/Tests/GavelTests/RemoteApprovalBridgeTests.swift
@@ -81,11 +81,112 @@ final class RemoteApprovalBridgeTests: XCTestCase {
         var pairedWith: Int64?
         bridge.onPaired = { pairedWith = $0 }
 
-        let start = TelegramUpdate(updateId: 1, callback: nil, message: TelegramIncomingMessage(fromId: owner, chatId: owner, text: "/start"))
+        let start = TelegramUpdate(updateId: 1, callback: nil, message: TelegramIncomingMessage(fromId: owner, chatId: owner, text: "/start", replyToMessageId: nil))
         bridge.handle(start)
 
         XCTAssertEqual(pairedWith, owner)
         XCTAssertTrue(bridge.isPaired)
+    }
+
+    func testTypedReplyDeniesWithInstruction() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var resolved: Decision?
+        let approval = ResolvableApproval { resolved = $0 }
+
+        bridge.notify(resolvable: approval, text: "approve?", allowSession: nil)
+        let reply = TelegramUpdate(updateId: 2, callback: nil, message: TelegramIncomingMessage(fromId: owner, chatId: owner, text: "clean it up first", replyToMessageId: nil))
+        bridge.handle(reply)
+
+        XCTAssertEqual(resolved?.verdict, .block)
+        XCTAssertEqual(resolved?.reason, "Denied from phone — clean it up first")
+    }
+
+    func testTypedReplyFromWrongChatIgnored() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var resolved: Decision?
+        let approval = ResolvableApproval { resolved = $0 }
+
+        bridge.notify(resolvable: approval, text: "approve?", allowSession: nil)
+        let reply = TelegramUpdate(updateId: 2, callback: nil, message: TelegramIncomingMessage(fromId: 999, chatId: 999, text: "do it", replyToMessageId: nil))
+        bridge.handle(reply)
+
+        XCTAssertNil(resolved)
+    }
+
+    func testCleanButtonDeniesWithCommentInstruction() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var resolved: Decision?
+        let approval = ResolvableApproval { resolved = $0 }
+
+        bridge.notify(resolvable: approval, text: "commit?", allowSession: nil, offerCommentClean: true)
+        XCTAssertTrue(fake.lastCallbackData.contains { $0.hasPrefix("c:") })
+        let n = nonce(from: fake.lastCallbackData)
+        bridge.handle(callbackUpdate(action: "c", nonce: n, fromId: owner, chatId: owner, messageId: fake.lastSentMessageId))
+
+        XCTAssertEqual(resolved?.verdict, .block)
+        XCTAssertEqual(resolved?.reason?.contains("comment"), true)
+    }
+
+    func testCleanButtonAbsentByDefault() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        bridge.notify(resolvable: ResolvableApproval { _ in }, text: "x", allowSession: nil)
+        XCTAssertFalse(fake.lastCallbackData.contains { $0.hasPrefix("c:") })
+    }
+
+    private func typedReply(_ text: String, replyTo: Int? = nil) -> TelegramUpdate {
+        TelegramUpdate(updateId: 9, callback: nil, message: TelegramIncomingMessage(fromId: owner, chatId: owner, text: text, replyToMessageId: replyTo))
+    }
+
+    func testBareTypedReplyResolvesWhenOnePending() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var resolved: Decision?
+        bridge.notify(resolvable: ResolvableApproval { resolved = $0 }, text: "a", allowSession: nil)
+        bridge.handle(typedReply("clean it"))
+        XCTAssertEqual(resolved?.verdict, .block)
+        XCTAssertEqual(resolved?.reason, "Denied from phone — clean it")
+    }
+
+    func testBareTypedReplyIsAmbiguousWithMultiplePending() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var r1: Decision?
+        var r2: Decision?
+        bridge.notify(resolvable: ResolvableApproval { r1 = $0 }, text: "a1", allowSession: nil)
+        bridge.notify(resolvable: ResolvableApproval { r2 = $0 }, text: "a2", allowSession: nil)
+        bridge.handle(typedReply("do it"))
+        XCTAssertNil(r1)
+        XCTAssertNil(r2)
+        XCTAssertEqual(fake.sentMessages.last?.text.contains("pending") == true, true)
+    }
+
+    func testReplyToTargetsSpecificApprovalWhenMultiplePending() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var r1: Decision?
+        var r2: Decision?
+        bridge.notify(resolvable: ResolvableApproval { r1 = $0 }, text: "a1", allowSession: nil)
+        let firstMessageId = fake.lastSentMessageId
+        bridge.notify(resolvable: ResolvableApproval { r2 = $0 }, text: "a2", allowSession: nil)
+        bridge.handle(typedReply("no", replyTo: firstMessageId))
+        XCTAssertEqual(r1?.verdict, .block)
+        XCTAssertNil(r2)
+    }
+
+    func testBurstCoalescesAfterTokenBucketDrains() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        for i in 0..<8 {
+            bridge.notify(resolvable: ResolvableApproval { _ in }, text: "a\(i)", allowSession: nil)
+        }
+        let buttonMessages = fake.sentMessages.filter { $0.keyboard != nil }.count
+        let coalesceNotices = fake.sentMessages.filter { $0.keyboard == nil && $0.text.contains("too fast") }.count
+        XCTAssertEqual(buttonMessages, 5)
+        XCTAssertGreaterThanOrEqual(coalesceNotices, 1)
     }
 
     func testAllowForSessionInvokesCallback() {

--- a/Tests/GavelTests/TelegramTokenSourceTests.swift
+++ b/Tests/GavelTests/TelegramTokenSourceTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import Gavel
+
+final class TelegramTokenSourceTests: XCTestCase {
+
+    func testDevBuildPathResolvesToDoppler() {
+        let source = TelegramTokenResolver.resolve(executablePath: "/Users/jay/code/claude-gavel/.build/release/gavel")
+        XCTAssertTrue(source is DopplerTokenSource)
+    }
+
+    func testBrewBuildPathResolvesToKeychain() {
+        let source = TelegramTokenResolver.resolve(executablePath: "/opt/homebrew/Cellar/gavel/1.24.0/bin/gavel")
+        XCTAssertTrue(source is KeychainTokenSource)
+    }
+
+    func testNilPathResolvesToKeychain() {
+        XCTAssertTrue(TelegramTokenResolver.resolve(executablePath: nil) is KeychainTokenSource)
+    }
+}


### PR DESCRIPTION
Builds on #134/#136 (telegram remote approval + credential gate). Six pieces:

1. **Full command in the approval message** — shows the whole command (capped near Telegram's 4096 limit) + cwd, instead of a 200-char stub. Credential gate still withholds secret-shaped payloads entirely.
2. **Typed-reply deny** — type a reply in Telegram and the text comes back as the deny instruction. Disambiguated when several are pending: a bare reply needs exactly one pending; a swipe-reply targets a specific approval by message id; otherwise you get "N pending — swipe-reply the one you mean."
3. **🧹 Clean-comments deny button** on commit approvals — denies with a canned "clean the house-rule comment violations and re-propose" instruction.
4. **Flood control** — token-bucket sends (burst 5, refill 1/s); a burst coalesces into one "N queued too fast — answer on Mac" notice; `429 retry_after` honored in the poll loop.
5. **Per-build token source** — Doppler for dev builds (no per-rebuild Keychain prompt), Keychain for release; loaded off the main thread so it can't wedge daemon startup.
6. **Config self-protection broadened** — any write under `~/.claude/gavel/` now forces an approval prompt (non-overridable), so `session-context.md` is editable-but-always-asks.

548 tests; dogfooded live (allow / deny / typed-reply all confirmed from phone).