### PR TITLE
feat(session): observed skill tags with tag filter and row badges

### DIFF
--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -121,6 +121,12 @@ final class HookRouter {
             at: timestamp
         ))
 
+        if payload.toolName == "Skill", let skill = payload.skill, !skill.isEmpty {
+            if session.tags.addObserved("skill:\(skill)", at: timestamp) {
+                sessionManager.saveActiveSessions()
+            }
+        }
+
         // Stage 0: Taint tracking — detect multi-step exfiltration
         if ["Write", "Edit", "MultiEdit"].contains(payload.toolName), let path = payload.filePath {
             session.taintedPaths.insert(path)

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -278,6 +278,7 @@ final class SessionManager: ObservableObject {
         let planPolicyDroppedReason: String?
         let isRemoteApprovalEnabled: Bool?
         let remoteApprovalUntil: Date?
+        let tags: [SessionTag]?
     }
 
     private struct PersistedState: Codable {
@@ -324,7 +325,8 @@ final class SessionManager: ObservableObject {
             engagedPlanHash: session.engagedPlanHash,
             planPolicyDroppedReason: session.planPolicyDroppedReason,
             isRemoteApprovalEnabled: session.remoteApprovalSnapshot.enabled ? true : nil,
-            remoteApprovalUntil: session.remoteApprovalSnapshot.until
+            remoteApprovalUntil: session.remoteApprovalSnapshot.until,
+            tags: session.tags.isEmpty ? nil : session.tags.snapshot
         )
     }
 
@@ -373,6 +375,7 @@ final class SessionManager: ObservableObject {
             session.setRemoteApprovalEnabled(true, until: snap.remoteApprovalUntil)
         }
         rehydratePlanPolicy(snap, into: session)
+        session.tags.load(snap.tags ?? [])
         sessions[snap.pid] = session
         tryJsonlSeed(session: session)
     }
@@ -421,6 +424,7 @@ final class SessionManager: ObservableObject {
             session.label = derived
             session.labelIsDerived = true
         }
+        session.tags.load(snap.tags ?? [])
         deadSessions[sessionId] = session
     }
 

--- a/Sources/Gavel/Models/HookEvent.swift
+++ b/Sources/Gavel/Models/HookEvent.swift
@@ -146,6 +146,10 @@ struct PreToolUsePayload: Codable {
     var filePath: String? {
         toolInput["file_path"]?.stringValue ?? toolInput["path"]?.stringValue
     }
+
+    var skill: String? {
+        toolInput["skill"]?.stringValue
+    }
 }
 
 struct PostToolUsePayload: Codable {

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -135,6 +135,8 @@ final class Session: ObservableObject, Identifiable {
     /// `.isEmpty` on it directly via the conveniences on the store type.
     let taintedPaths = TaintedPathStore()
 
+    let tags = SessionTagStore()
+
     // Computed proxies so `session.toolCallCount` style call-sites in views
     // and the stats aggregator still read naturally.
     var toolCallCount: Int { stats.toolCallCount }

--- a/Sources/Gavel/Models/SessionTag.swift
+++ b/Sources/Gavel/Models/SessionTag.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+enum TagSource: String, Codable {
+    case observed
+    case manual
+}
+
+struct SessionTag: Codable, Hashable {
+    let name: String
+    let appliedAt: Date
+    let source: TagSource
+}
+
+final class SessionTagStore {
+    private let lock = NSLock()
+    private var _tags: [String: SessionTag] = [:]
+
+    var snapshot: [SessionTag] {
+        lock.lock(); defer { lock.unlock() }
+        return _tags.values.sorted {
+            $0.appliedAt == $1.appliedAt ? $0.name < $1.name : $0.appliedAt < $1.appliedAt
+        }
+    }
+
+    @discardableResult
+    func addObserved(_ name: String, at time: Date) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard _tags[name] == nil else { return false }
+        _tags[name] = SessionTag(name: name, appliedAt: time, source: .observed)
+        return true
+    }
+
+    func load(_ tags: [SessionTag]) {
+        lock.lock(); defer { lock.unlock() }
+        for tag in tags where _tags[tag.name] == nil {
+            _tags[tag.name] = tag
+        }
+    }
+
+    func matches(token: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        let needle = token.lowercased()
+        return _tags.keys.contains { $0.lowercased().contains(needle) }
+    }
+
+    var count: Int { lock.lock(); defer { lock.unlock() }; return _tags.count }
+    var isEmpty: Bool { lock.lock(); defer { lock.unlock() }; return _tags.isEmpty }
+}

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -347,6 +347,14 @@ struct MonitorWindow: View {
     private func filterSessions(_ sessions: [Session], query: String) -> [Session] {
         let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !q.isEmpty else { return sessions }
+        if q.hasPrefix("-tag:") {
+            let token = String(q.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+            return token.isEmpty ? sessions : sessions.filter { !$0.tags.matches(token: token) }
+        }
+        if q.hasPrefix("tag:") {
+            let token = String(q.dropFirst(4)).trimmingCharacters(in: .whitespaces)
+            return token.isEmpty ? sessions : sessions.filter { $0.tags.matches(token: token) }
+        }
         return sessions.filter { session in
             if String(session.pid).contains(q) { return true }
             if let sid = session.sessionId, sid.lowercased().contains(q) { return true }
@@ -452,6 +460,8 @@ private struct SessionRow: View {
                 }
                 viewModel.noteInteraction()
             }
+
+            SessionTagBadges(tags: session.tags.snapshot)
 
             Spacer()
 
@@ -765,6 +775,35 @@ private struct SessionRow: View {
 
     private var rowBackground: Color {
         alternate ? Color.secondary.opacity(0.06) : Color.clear
+    }
+}
+
+private struct SessionTagBadges: View {
+    let tags: [SessionTag]
+
+    var body: some View {
+        if !tags.isEmpty {
+            HStack(spacing: 3) {
+                ForEach(tags.prefix(3), id: \.name) { tag in
+                    Text(displayName(tag.name))
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(Color.secondary.opacity(0.12), in: RoundedRectangle(cornerRadius: 3))
+                }
+                if tags.count > 3 {
+                    Text(verbatim: "+\(tags.count - 3)")
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+                }
+            }
+            .help(tags.map(\.name).joined(separator: ", "))
+        }
+    }
+
+    private func displayName(_ name: String) -> String {
+        name.hasPrefix("skill:") ? String(name.dropFirst(6)) : name
     }
 }
 

--- a/Tests/GavelTests/SessionTagTests.swift
+++ b/Tests/GavelTests/SessionTagTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import Gavel
+
+final class SessionTagTests: XCTestCase {
+
+    // MARK: - Store: dedup + keep-first
+
+    func testAddObservedDedupesByNameKeepingFirstTimestamp() {
+        let store = SessionTagStore()
+        let t1 = Date(timeIntervalSince1970: 1000)
+        let t2 = Date(timeIntervalSince1970: 2000)
+
+        XCTAssertTrue(store.addObserved("skill:daybook", at: t1))
+        XCTAssertFalse(store.addObserved("skill:daybook", at: t2))
+
+        XCTAssertEqual(store.count, 1)
+        XCTAssertEqual(store.snapshot.first?.appliedAt, t1)
+        XCTAssertEqual(store.snapshot.first?.source, .observed)
+    }
+
+    func testSnapshotOrdersByAppliedAtThenName() {
+        let store = SessionTagStore()
+        store.addObserved("skill:b", at: Date(timeIntervalSince1970: 2000))
+        store.addObserved("skill:a", at: Date(timeIntervalSince1970: 1000))
+
+        XCTAssertEqual(store.snapshot.map(\.name), ["skill:a", "skill:b"])
+    }
+
+    // MARK: - Store: filter predicate
+
+    func testMatchesTokenIsCaseInsensitiveSubstring() {
+        let store = SessionTagStore()
+        store.addObserved("skill:daybook", at: Date())
+
+        XCTAssertTrue(store.matches(token: "daybook"))
+        XCTAssertTrue(store.matches(token: "skill:daybook"))
+        XCTAssertTrue(store.matches(token: "SKILL:DAYBOOK"))
+        XCTAssertFalse(store.matches(token: "jira"))
+    }
+
+    // MARK: - Store: load (persistence restore)
+
+    func testLoadRestoresTagsAndStaysIdempotent() {
+        let store = SessionTagStore()
+        let original = SessionTag(name: "skill:jira", appliedAt: Date(timeIntervalSince1970: 500), source: .observed)
+        store.load([original])
+        store.load([SessionTag(name: "skill:jira", appliedAt: Date(timeIntervalSince1970: 999), source: .observed)])
+
+        XCTAssertEqual(store.count, 1)
+        XCTAssertEqual(store.snapshot.first?.appliedAt, original.appliedAt)
+    }
+
+    // MARK: - Codable round-trip
+
+    func testSessionTagCodableRoundTrip() throws {
+        let tags = [
+            SessionTag(name: "skill:daybook", appliedAt: Date(timeIntervalSince1970: 1000), source: .observed),
+            SessionTag(name: "manual:hot", appliedAt: Date(timeIntervalSince1970: 2000), source: .manual)
+        ]
+        let data = try JSONEncoder().encode(tags)
+        let decoded = try JSONDecoder().decode([SessionTag].self, from: data)
+        XCTAssertEqual(decoded, tags)
+    }
+
+    // MARK: - Payload accessor
+
+    func testPayloadExtractsSkillName() {
+        let payload = PreToolUsePayload(toolName: "Skill", toolInput: ["skill": AnyCodable("daybook")])
+        XCTAssertEqual(payload.skill, "daybook")
+    }
+
+    func testPayloadSkillNilWhenAbsent() {
+        let payload = PreToolUsePayload(toolName: "Bash", toolInput: ["command": AnyCodable("ls")])
+        XCTAssertNil(payload.skill)
+    }
+
+    // MARK: - HookRouter observation integration
+
+    private func makeIsolatedManager() -> SessionManager {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gavel-tag-tests-\(UUID().uuidString)")
+        return SessionManager(homeDir: tmp, autoStartTimers: false, autoDiscover: false)
+    }
+
+    private func makeRouter(_ manager: SessionManager) -> HookRouter {
+        let engine = ApprovalEngine(ruleStore: RuleStore(configPath: "/dev/null"))
+        return HookRouter(sessionManager: manager, approvalEngine: engine, approvalCoordinator: ApprovalCoordinator())
+    }
+
+    private func skillEvent(pid: Int, skill: String, ts: Double) -> Data {
+        """
+        {
+            "hookType": "PreToolUse",
+            "sessionPid": \(pid),
+            "timestamp": \(ts),
+            "payload": {
+                "type": "PreToolUse",
+                "tool_name": "Skill",
+                "tool_input": {"skill": "\(skill)"},
+                "session_id": "tag-test"
+            }
+        }
+        """.data(using: .utf8)!
+    }
+
+    func testRouterTagsSessionOnSkillCall() {
+        let manager = makeIsolatedManager()
+        let session = manager.session(for: 71001)
+        session.isAutoApproveEnabled = true
+        let router = makeRouter(manager)
+
+        router.handle(data: skillEvent(pid: 71001, skill: "daybook", ts: 1712600000.0), respond: { _ in })
+
+        XCTAssertTrue(session.tags.matches(token: "skill:daybook"))
+        XCTAssertEqual(session.tags.count, 1)
+    }
+
+    func testRouterDoesNotDoubleTagRepeatedSkill() {
+        let manager = makeIsolatedManager()
+        let session = manager.session(for: 71002)
+        session.isAutoApproveEnabled = true
+        let router = makeRouter(manager)
+
+        router.handle(data: skillEvent(pid: 71002, skill: "daybook", ts: 1712600000.0), respond: { _ in })
+        router.handle(data: skillEvent(pid: 71002, skill: "daybook", ts: 1712600099.0), respond: { _ in })
+
+        XCTAssertEqual(session.tags.count, 1)
+        XCTAssertEqual(session.tags.snapshot.first?.appliedAt, Date(timeIntervalSince1970: 1712600000.0))
+    }
+
+    func testRouterDoesNotTagOnNonSkillCall() {
+        let manager = makeIsolatedManager()
+        let session = manager.session(for: 71003)
+        session.isAutoApproveEnabled = true
+        let router = makeRouter(manager)
+
+        let bash = """
+        {
+            "hookType": "PreToolUse",
+            "sessionPid": 71003,
+            "timestamp": 1712600000.0,
+            "payload": {
+                "type": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls"},
+                "session_id": "tag-test"
+            }
+        }
+        """.data(using: .utf8)!
+        router.handle(data: bash, respond: { _ in })
+
+        XCTAssertTrue(session.tags.isEmpty)
+    }
+}


### PR DESCRIPTION
Auto-derive structured tags from observed Skill tool calls.

**Verified premise first** (two witnesses): a `Skill` invocation reaches Gavel's PreToolUse hook with `tool_name="Skill"` and the skill name in `tool_input.skill` — historical `tool=Skill` approval panels in `gavel.log`, plus a live `keybindings-help` call resolving through the hook. So tagging is passive observation; no IPC from skills.

### What's in it
- `SessionTag {name, appliedAt, source}` + thread-safe `SessionTagStore` (same worker-thread model as `SessionStats`; UI reads via the 2s timer).
- `HookRouter.handlePreToolUse` observes Skill calls → `skill:<name>` tag, dedup by name keeping first `appliedAt`; persists on each new tag.
- `PreToolUsePayload.skill` accessor (mirrors `command`/`filePath`).
- Persisted in the `{live,dead}` envelope, nil-tolerant for legacy files; backfilled on rehydrate (live + tombstone).
- Monitor filter gains `tag:<x>` / `-tag:<x>`; rows show compact dimmed badges.

### Scope
MVP: observed tags only. Manual-tag add/remove UI deferred — the model already carries `source: .manual`.

### Testing
558 tests (+10: store dedup/order/match, payload accessor, Codable round-trip, router observation integration). **Live-dogfooded**: real Skill calls tagged the session, persisted, and **survived a daemon restart** (rehydrated into memory, re-saved with the tag intact). Legacy decode verified live against a mixed `active-sessions.json`. Not verified headless: the SwiftUI badge rendering + filter box (GUI-only).