### PR TITLE
fix(approval): exclude 2>&1 fd-dup from taint redirect-target capture

### DIFF
--- a/Sources/Gavel/Approval/TaintTracker.swift
+++ b/Sources/Gavel/Approval/TaintTracker.swift
@@ -111,7 +111,7 @@ struct TaintTracker {
     }
 
     private static func extractRedirectTarget(from command: String, into paths: inout Set<String>) {
-        guard let regex = try? NSRegularExpression(pattern: #">>?\s*(\S+)"#),
+        guard let regex = try? NSRegularExpression(pattern: #">>?\s*(?!&)(\S+)"#),
               let match = regex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)),
               let pathRange = Range(match.range(at: 1), in: command) else { return }
         paths.insert(String(command[pathRange]))

--- a/Tests/GavelTests/TaintTrackerTests.swift
+++ b/Tests/GavelTests/TaintTrackerTests.swift
@@ -71,6 +71,19 @@ final class TaintTrackerTests: XCTestCase {
         XCTAssertTrue(taints.isEmpty)
     }
 
+    func testFdDuplicationIsNotTaintedAsRedirectTarget() {
+        var taints = Set<String>()
+        TaintTracker.recordTaints(command: "gh pr create --body 'see .ssh/ and .aws/ creds' 2>&1 | tail", into: &taints)
+        XCTAssertFalse(taints.contains("&1"))
+        XCTAssertTrue(taints.isEmpty)
+    }
+
+    func testRealRedirectStillTaintedAlongsideFdDuplication() {
+        var taints = Set<String>()
+        TaintTracker.recordTaints(command: "cat ~/.ssh/id_rsa > /tmp/exfil 2>&1", into: &taints)
+        XCTAssertEqual(taints, ["/tmp/exfil"])
+    }
+
     func testCopyFromSensitiveSourceTaintsDestination() {
         var taints = Set<String>()
         TaintTracker.recordTaints(command: "cp ~/.aws/credentials /tmp/creds", into: &taints)


### PR DESCRIPTION
### The bug
The taint tracker's redirect-target extractor treated a file-descriptor duplication (the `2 > & 1` idiom, written without spaces) as if it were a redirect to a file literally named "and-one". When the same command also referenced a sensitive source (e.g. a `gh pr create --body` whose text mentions credential paths), that bogus token was inserted into the session's tainted-path set — poisoning the session.

From then on, every later command using that fd-dup idiom carried the bogus tainted token, and any network-ish word anywhere in the string (including a network-tool name appearing inside a git branch name) tripped the network-exfil check and hard-blocked a benign `git branch`.

### The fix
A negative lookahead so fd-duplication targets are never captured as files. A real redirect to a file alongside a dup still taints the real file.

### Tests
- fd-dup with a sensitive source present taints nothing
- real-redirect + dup still taints the file

561 pass. Found while dogfooding the session-tags build.

### Known follow-up (separate, bigger)
The extractor and the network-pattern matcher both scan the raw command string, so redirect operators or tool names that appear inside quoted strings / commit messages / branch names are still misread. The robust fix is to anchor to command position and skip string-literal content, mirroring the treatment the PatternMatcher rules already got. Tracking separately.