### PR TITLE
fix(approval): whitelist mixed-case kebab/snake identifiers in credential gate

### DIFF
--- a/Sources/Gavel/Approval/CredentialGate.swift
+++ b/Sources/Gavel/Approval/CredentialGate.swift
@@ -76,6 +76,6 @@ enum CredentialGate {
     )
 
     private static let identifierRegex = try! NSRegularExpression(
-        pattern: "^[a-z0-9]+([_-][a-z0-9]+)+$"
+        pattern: "^[A-Za-z0-9]+([_-][A-Za-z0-9]+)+$"
     )
 }

--- a/Tests/GavelTests/CredentialGateTests.swift
+++ b/Tests/GavelTests/CredentialGateTests.swift
@@ -51,4 +51,9 @@ final class CredentialGateTests: XCTestCase {
     func testMixedCaseHighEntropyStillBlocksAfterIdentifierWhitelist() {
         XCTAssertTrue(CredentialGate.blocksRemote(payload(["command": "echo Xa9Kd2Lp8Qw3Zr7Tv1Bn6Mc"])))
     }
+
+    func testMixedCaseKebabProfileNameIsNotCredentialShaped() {
+        let cmd = "AWS_PROFILE=AcmeCorp-Root-123456789012-AWSAdministratorAccess aws sts get-caller-identity"
+        XCTAssertFalse(CredentialGate.blocksRemote(payload(["command": cmd])))
+    }
 }


### PR DESCRIPTION
### The false positive
The remote-approval credential gate suppressed an ordinary infra command -- `AWS_PROFILE=<account>-<role> aws sts get-caller-identity … cdk deploy …` -- even though it contained no secret. Root cause: #136 whitelisted kebab/snake identifiers but anchored the pattern to **lowercase only** (`^[a-z0-9]+([_-][a-z0-9]+)+$`). Real AWS identifiers (SSO profile names, IAM role names, CDK stack names) are mixed-case, so they fell through, tripped the 20-char entropy run, and the whole Telegram message was withheld.

For an infra-heavy workflow that token shape is in nearly every command, which made remote approval close to useless.

### The fix
Widen the identifier whitelist to mixed-case (`^[A-Za-z0-9]+([_-][A-Za-z0-9]+)+$`).

**Safety preserved** -- the whitelist still requires kebab/snake *structure* (alternating alphanumerics and `-`/`_`). A separator-free high-entropy run -- the shape of real secrets (`AKIA…`, base64, hex) -- is still suppressed (guarded by the existing `testMixedCaseHighEntropyStillBlocks…` test). Known-secret pattern matching (AKIA / sk-ant- / ghp_ / PEM) is unchanged and runs first.

### Tests
New: mixed-case kebab profile name (anonymized `AcmeCorp-Root-123456789012-AWSAdministratorAccess`) no longer suppresses. 562 pass.

Found dogfooding. This is the targeted fix; if the gate is still too noisy in practice, the next lever is dropping the generic entropy backstop and keeping known-patterns-only -- deliberately not doing that here.