### PR TITLE
fix(approval): strip string-literal content before taint extraction

### DIFF
--- a/Sources/Gavel/Approval/TaintTracker.swift
+++ b/Sources/Gavel/Approval/TaintTracker.swift
@@ -29,15 +29,16 @@ struct TaintTracker {
     /// Returns a block reason if detected, nil if safe.
     static func checkExfiltration(command: String, taintedPaths: Set<String>) -> String? {
         guard !taintedPaths.isEmpty else { return nil }
-        let range = NSRange(command.startIndex..., in: command)
+        let scanned = PatternMatcher.stripQuotedContent(command)
+        let range = NSRange(scanned.startIndex..., in: scanned)
 
         for taintedPath in taintedPaths {
-            guard command.contains(taintedPath) else { continue }
+            guard scanned.contains(taintedPath) else { continue }
 
-            if let reason = checkNetworkExfil(command: command, taintedPath: taintedPath, range: range) {
+            if let reason = checkNetworkExfil(command: scanned, taintedPath: taintedPath, range: range) {
                 return reason
             }
-            if let reason = checkDirectExecution(command: command, taintedPath: taintedPath, range: range) {
+            if let reason = checkDirectExecution(command: scanned, taintedPath: taintedPath, range: range) {
                 return reason
             }
         }
@@ -50,7 +51,8 @@ struct TaintTracker {
     /// buffer so the private extractors below keep their existing
     /// `inout Set<String>` signatures and we batch a single `formUnion` at
     /// the end (one lock acquisition instead of one per insert).
-    static func recordTaints(command: String, into store: TaintedPathStore) {
+    static func recordTaints(command rawCommand: String, into store: TaintedPathStore) {
+        let command = PatternMatcher.stripQuotedContent(rawCommand)
         guard referencesSensitiveSource(command) else { return }
         var buffer = Set<String>()
         extractRedirectTarget(from: command, into: &buffer)
@@ -63,7 +65,8 @@ struct TaintTracker {
 
     /// Set-style overload kept for unit tests that hand-craft a Set rather
     /// than going through the store.
-    static func recordTaints(command: String, into taintedPaths: inout Set<String>) {
+    static func recordTaints(command rawCommand: String, into taintedPaths: inout Set<String>) {
+        let command = PatternMatcher.stripQuotedContent(rawCommand)
         guard referencesSensitiveSource(command) else { return }
         extractRedirectTarget(from: command, into: &taintedPaths)
         extractCompileOutput(from: command, into: &taintedPaths)

--- a/Tests/GavelTests/TaintTrackerTests.swift
+++ b/Tests/GavelTests/TaintTrackerTests.swift
@@ -84,6 +84,27 @@ final class TaintTrackerTests: XCTestCase {
         XCTAssertEqual(taints, ["/tmp/exfil"])
     }
 
+    func testRedirectInsideCommitMessageDoesNotTaint() {
+        var taints = Set<String>()
+        TaintTracker.recordTaints(command: "git commit -m 'note: copy ~/.ssh/id_rsa >> /tmp/x someday'", into: &taints)
+        XCTAssertTrue(taints.isEmpty)
+    }
+
+    func testRedirectInsideHeredocBodyDoesNotTaint() {
+        let cmd = "git commit -F - <<'EOF'\nmentions ~/.aws/credentials >> /tmp/leak\nEOF"
+        var taints = Set<String>()
+        TaintTracker.recordTaints(command: cmd, into: &taints)
+        XCTAssertTrue(taints.isEmpty)
+    }
+
+    func testNetworkWordInCommitMessageIsNotExfil() {
+        let result = TaintTracker.checkExfiltration(
+            command: "git commit -m 'send /tmp/exfil with curl later'",
+            taintedPaths: ["/tmp/exfil"]
+        )
+        XCTAssertNil(result)
+    }
+
     func testCopyFromSensitiveSourceTaintsDestination() {
         var taints = Set<String>()
         TaintTracker.recordTaints(command: "cp ~/.aws/credentials /tmp/creds", into: &taints)


### PR DESCRIPTION
### The class of bug
The taint tracker analyzed the **raw** command string, so redirect operators and network/exec tokens that appeared *inside* a quoted commit message, an `echo` argument, or a heredoc body (e.g. a `gh pr create` body heredoc) were treated as real command structure. That created bogus tainted paths and false exfil matches — the root of the two self-blocks hit while dogfooding (a fd-dup-derived token, and a regex literal in a commit message).

### Fix
Route both `recordTaints` and `checkExfiltration` through the same string-literal stripping that `PatternMatcher` already applies (and `RuleStore` already reuses), so only real command structure is analyzed.

**No false-negative risk for the real cases:** a genuine `cat <key> > /tmp/x` redirect, or a pipe into a network tool, is unquoted and survives stripping — still tainted / still flagged (covered by the existing FN tests, which stay green).

### Scope note
Deliberately **not** command-position-anchoring the network patterns. That would miss env-var-prefixed invocations (`VAR=x <tool> @file`) — a real exfil shape and common in infra work — so anchoring would trade these FPs for a worse FN. Stripping fixes the cases that actually bit us without that tradeoff.

### Tests
New: operators/tokens inside messages and heredocs no longer taint or flag; real redirect + real network-tool exfil still caught. 565 pass.