### PR TITLE
feat(approval): launchctl/LaunchAgent fail-closed prompt + opt-in remote-approval enable

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -39,6 +39,8 @@ final class ApprovalCoordinator: ObservableObject {
         let session: Session
         let timestamp: Date
         let forceDialog: Bool
+        /// Mirror to Telegram even when the session itself isn't phone-enabled — used by the remote-approval enable request so the bootstrap prompt can reach the phone.
+        let forceRemoteMirror: Bool
         /// Reason from the engine when dialog was forced. Nil for default-tier prompts.
         let triggerReason: String?
         /// Why an engaged plan's overlay did not authorize this command. Nil when no plan is engaged.
@@ -85,6 +87,7 @@ final class ApprovalCoordinator: ObservableObject {
         session: Session,
         timestamp: Date,
         forceDialog: Bool = false,
+        forceRemoteMirror: Bool = false,
         triggerReason: String? = nil,
         overlayContext: String? = nil,
         triggeringRuleId: UUID? = nil
@@ -107,6 +110,7 @@ final class ApprovalCoordinator: ObservableObject {
             session: session,
             timestamp: timestamp,
             forceDialog: forceDialog,
+            forceRemoteMirror: forceRemoteMirror,
             triggerReason: triggerReason,
             overlayContext: overlayContext,
             triggeringRuleId: triggeringRuleId,
@@ -140,10 +144,16 @@ final class ApprovalCoordinator: ObservableObject {
         return result
     }
 
+    /// Whether a pending approval should be mirrored to Telegram: either the session is phone-enabled, or this is a bootstrap request that forces the mirror.
+    static func shouldMirrorRemote(forceRemoteMirror: Bool, sessionActive: Bool) -> Bool {
+        forceRemoteMirror || sessionActive
+    }
+
     /// Mirror a pending approval to Telegram when its session is remote-enabled.
     /// The credential gate suppresses the message entirely for sensitive payloads.
     private func maybeSendRemote(pending: PendingApproval, resolvable: ResolvableApproval) {
-        guard pending.session.isRemoteApprovalActive, let bridge = remoteBridge else { return }
+        guard Self.shouldMirrorRemote(forceRemoteMirror: pending.forceRemoteMirror, sessionActive: pending.session.isRemoteApprovalActive),
+              let bridge = remoteBridge else { return }
         if CredentialGate.blocksRemote(pending.payload) {
             bridge.notifyWithheld()
             return

--- a/Sources/Gavel/Approval/PatternMatcher.swift
+++ b/Sources/Gavel/Approval/PatternMatcher.swift
@@ -104,7 +104,6 @@ struct PatternMatcher {
             // name so a `CRONTAB=/etc/crontab` env-var assignment (which has `=`
             // after the name, a `\b` boundary but not `\s`) doesn't false-match.
             ("(^|[|&;(])\\s*crontab(?!\\s+(-u\\s+\\S+\\s+)?-l\\b)(\\s+|$)", "Crontab modification"),
-            ("\\blaunchctl\\b\\s+(load|unload|submit|bootstrap|bootout|enable|disable|kickstart)", "LaunchAgent/Daemon modification"),
             // `at` command: require a segment boundary AND a recognizable timespec.
             // The previous `\bat\b\s+` matched any prose "at " — e.g. heredoc bodies
             // inside `gh pr create`, or commit messages like "fix bug at line 42".
@@ -176,6 +175,7 @@ struct PatternMatcher {
             ("\\bcurl\\b.*\\$\\(", "curl with command substitution (broad — review)"),
             ("\\bcurl\\b.*(?-i:-d|--data|--data-raw|--data-binary|--data-urlencode|-F|--form|--upload-file|-T)\\b", "curl sending data — review for exfiltration"),
             ("\\bcrontab\\b", "crontab reference (broad — review)"),
+            ("\\blaunchctl\\b\\s+(load|unload|submit|bootstrap|bootout|enable|disable|kickstart)", "LaunchAgent/Daemon modification"),
         ]
 
         // Hard block — credentials and persistence vectors that should never be written
@@ -184,9 +184,6 @@ struct PatternMatcher {
             ("\\.ssh/(id_|authorized_keys|config)", "Protected: SSH keys/config"),
             // GPG keys
             ("\\.gnupg/", "Protected: GPG keys"),
-            // LaunchAgents (persistence vector)
-            ("LaunchAgents/", "Protected: LaunchAgent (persistence risk)"),
-            ("LaunchDaemons/", "Protected: LaunchDaemon (persistence risk)"),
             // AWS/cloud credentials
             ("\\.aws/(credentials|config)", "Protected: AWS credentials"),
             ("\\.kube/config", "Protected: Kubernetes config"),
@@ -204,6 +201,8 @@ struct PatternMatcher {
             ("\\.mcp\\.json$", "Sensitive: MCP server config"),
             // Shell config
             ("\\.(bash_profile|bashrc|zshrc|zprofile|profile|zshenv)$", "Sensitive: Shell config"),
+            ("LaunchAgents/", "Sensitive: LaunchAgent (persistence vector)"),
+            ("LaunchDaemons/", "Sensitive: LaunchDaemon (persistence vector)"),
         ]
 
         bashPatterns = rawBash.compactMap { entry in

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -61,6 +61,9 @@ final class HookRouter {
             DispatchQueue.main.async { session.model = model }
             let source = payload.source ?? "startup"
             emitFeed(.system("Session \(source)", pid: session.pid, at: ts))
+            if payload.requestRemoteApproval == true {
+                requestRemoteApprovalToggle(session: session, timestamp: ts)
+            }
 
         case .stop:
             emitFeed(.stop(pid: session.pid, at: ts))
@@ -369,6 +372,33 @@ final class HookRouter {
         if let respond = respond,
            let responseData = #"{"verdict":"allow"}"#.data(using: .utf8) {
             respond(responseData)
+        }
+    }
+
+    /// Raise a non-overridable, fail-closed, phone-mirrored approval that enables per-session remote approval only if allowed.
+    private func requestRemoteApprovalToggle(session: Session, timestamp: Date) {
+        let hours = GavelConstants.remoteApprovalDefaultHours
+        let location = session.cwd.map { " — \($0)" } ?? ""
+        let reason = "Session pid \(session.pid)\(location) requests PHONE (remote) approval. Allow enables it for \(hours)h; deny or ignore leaves it OFF."
+        let payload = PreToolUsePayload(toolName: "__EnableRemoteApproval", toolInput: [:])
+        DispatchQueue.global().async { [weak self] in
+            guard let self else { return }
+            let decision = self.approvalCoordinator.requestApproval(
+                payload: payload,
+                session: session,
+                timestamp: timestamp,
+                forceDialog: true,
+                forceRemoteMirror: true,
+                triggerReason: reason
+            )
+            if decision.verdict == .allow {
+                let until = Date().addingTimeInterval(Double(hours) * 3600)
+                session.setRemoteApprovalEnabled(true, until: until)
+                self.sessionManager.saveActiveSessions()
+                self.emitFeed(.system("Remote (phone) approval ENABLED for \(hours)h", pid: session.pid, at: timestamp))
+            } else {
+                self.emitFeed(.system("Remote (phone) approval request denied", pid: session.pid, at: timestamp))
+            }
         }
     }
 

--- a/Sources/Gavel/Models/HookEvent.swift
+++ b/Sources/Gavel/Models/HookEvent.swift
@@ -171,12 +171,14 @@ struct SessionStartPayload: Codable {
     let cwd: String?
     let source: String?  // startup, resume, clear, compact
     let model: String?
+    let requestRemoteApproval: Bool?
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
         case cwd
         case source
         case model
+        case requestRemoteApproval = "request_remote_approval"
     }
 }
 

--- a/Sources/GavelHook/main.swift
+++ b/Sources/GavelHook/main.swift
@@ -56,9 +56,17 @@ var envelope: [String: Any] = [
     "timestamp": timestamp,
 ]
 
+// Opt-in remote-approval request: the spawner sets GAVEL_REQUEST_PHONE on the
+// launched session; the daemon only honors it on SessionStart.
+let requestsRemoteApproval = ["1", "true", "yes"].contains(
+    (ProcessInfo.processInfo.environment["GAVEL_REQUEST_PHONE"] ?? "").lowercased())
+
 // Merge stdin JSON as payload (add "type" discriminator for daemon decoding)
 if var payload = stdinJson {
     payload["type"] = hookType
+    if hookType == "SessionStart", requestsRemoteApproval {
+        payload["request_remote_approval"] = true
+    }
     envelope["payload"] = payload
 }
 

--- a/Tests/GavelTests/PatternMatcherTests.swift
+++ b/Tests/GavelTests/PatternMatcherTests.swift
@@ -314,16 +314,28 @@ final class PatternMatcherTests: XCTestCase {
         XCTAssertNotNil(matcher.matchSensitivePath(payload: bashPayload(command: "bash -c \"crontab -e\"")))
     }
 
-    func testLaunchctlBootstrapBlocked() {
-        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "launchctl bootstrap gui/501 ~/Library/LaunchAgents/evil.plist")))
+    func testLaunchctlBootstrapNotHardBlocked() {
+        XCTAssertNil(matcher.matchDangerous(payload: bashPayload(command: "launchctl bootstrap gui/501 ~/Library/LaunchAgents/evil.plist")))
     }
 
-    func testLaunchctlLoadBlocked() {
-        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "launchctl load ~/Library/LaunchAgents/evil.plist")))
+    func testLaunchctlBootstrapAsksUser() {
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: bashPayload(command: "launchctl bootstrap gui/501 ~/Library/LaunchAgents/evil.plist")))
     }
 
-    func testLaunchctlEnableBlocked() {
-        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "launchctl enable gui/501/com.evil")))
+    func testLaunchctlLoadNotHardBlocked() {
+        XCTAssertNil(matcher.matchDangerous(payload: bashPayload(command: "launchctl load ~/Library/LaunchAgents/evil.plist")))
+    }
+
+    func testLaunchctlLoadAsksUser() {
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: bashPayload(command: "launchctl load ~/Library/LaunchAgents/evil.plist")))
+    }
+
+    func testLaunchctlEnableNotHardBlocked() {
+        XCTAssertNil(matcher.matchDangerous(payload: bashPayload(command: "launchctl enable gui/501/com.evil")))
+    }
+
+    func testLaunchctlEnableAsksUser() {
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: bashPayload(command: "launchctl enable gui/501/com.evil")))
     }
 
     // MARK: - `at` job scheduling (issue #18 — tightened regex)
@@ -477,8 +489,12 @@ final class PatternMatcherTests: XCTestCase {
         XCTAssertNotNil(matcher.matchSensitivePath(payload: writePayload(filePath: "/Users/x/.zshrc")))
     }
 
-    func testWriteLaunchAgentBlocked() {
-        XCTAssertNotNil(matcher.matchDangerous(payload: writePayload(filePath: "/Users/x/Library/LaunchAgents/com.evil.plist")))
+    func testWriteLaunchAgentNotHardBlocked() {
+        XCTAssertNil(matcher.matchDangerous(payload: writePayload(filePath: "/Users/x/Library/LaunchAgents/com.evil.plist")))
+    }
+
+    func testWriteLaunchAgentAsksUser() {
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: writePayload(filePath: "/Users/x/Library/LaunchAgents/com.evil.plist")))
     }
 
     func testWriteAwsCredentialsBlocked() {
@@ -519,6 +535,7 @@ final class PatternMatcherTests: XCTestCase {
 
     func testCommitWithLaunchctlMentionAllowed() {
         XCTAssertNil(matcher.matchDangerous(payload: bashPayload(command: "git commit -m 'added launchctl bootstrap detection'")))
+        XCTAssertNil(matcher.matchSensitivePath(payload: bashPayload(command: "git commit -m 'added launchctl bootstrap detection'")))
     }
 
     func testHeredocWithDangerousContentAllowed() {

--- a/Tests/GavelTests/RemoteApprovalToggleTests.swift
+++ b/Tests/GavelTests/RemoteApprovalToggleTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import Gavel
+
+final class RemoteApprovalToggleTests: XCTestCase {
+
+    func testForceRemoteMirrorSendsEvenWhenSessionPhoneOff() {
+        XCTAssertTrue(ApprovalCoordinator.shouldMirrorRemote(forceRemoteMirror: true, sessionActive: false))
+    }
+
+    func testNoMirrorWhenNeitherForcedNorActive() {
+        XCTAssertFalse(ApprovalCoordinator.shouldMirrorRemote(forceRemoteMirror: false, sessionActive: false))
+    }
+
+    func testMirrorWhenSessionActive() {
+        XCTAssertTrue(ApprovalCoordinator.shouldMirrorRemote(forceRemoteMirror: false, sessionActive: true))
+    }
+
+    func testSessionStartDecodesRemoteApprovalRequest() throws {
+        let json = """
+        {
+            "hookType": "SessionStart",
+            "sessionPid": 4242,
+            "timestamp": 1712600000.0,
+            "payload": {
+                "type": "SessionStart",
+                "session_id": "sess-1",
+                "source": "startup",
+                "request_remote_approval": true
+            }
+        }
+        """
+        let event = try JSONDecoder().decode(HookEvent.self, from: json.data(using: .utf8)!)
+        guard case .sessionStart(let payload) = event.payload else {
+            XCTFail("Expected sessionStart payload")
+            return
+        }
+        XCTAssertEqual(payload.requestRemoteApproval, true)
+    }
+
+    func testSessionStartAbsentFlagDecodesNil() throws {
+        let json = """
+        {
+            "hookType": "SessionStart",
+            "sessionPid": 4242,
+            "timestamp": 1712600000.0,
+            "payload": { "type": "SessionStart", "source": "startup" }
+        }
+        """
+        let event = try JSONDecoder().decode(HookEvent.self, from: json.data(using: .utf8)!)
+        guard case .sessionStart(let payload) = event.payload else {
+            XCTFail("Expected sessionStart payload")
+            return
+        }
+        XCTAssertNil(payload.requestRemoteApproval)
+    }
+
+    func testEnableGrantActiveWithFutureExpiry() {
+        let session = Session(pid: 4242)
+        session.setRemoteApprovalEnabled(true, until: Date().addingTimeInterval(3600))
+        XCTAssertTrue(session.isRemoteApprovalActive)
+    }
+
+    func testExpiredGrantIsInactiveFailClosed() {
+        let session = Session(pid: 4242)
+        session.setRemoteApprovalEnabled(true, until: Date().addingTimeInterval(-1))
+        XCTAssertFalse(session.isRemoteApprovalActive)
+    }
+
+    func testDisableDeactivates() {
+        let session = Session(pid: 4242)
+        session.setRemoteApprovalEnabled(true, until: Date().addingTimeInterval(3600))
+        session.disableRemoteApproval()
+        XCTAssertFalse(session.isRemoteApprovalActive)
+    }
+}


### PR DESCRIPTION
Two related changes, both moving security-sensitive actions onto the same posture: **a fail-closed prompt — never a silent allow, never an un-actionable hard deny.**

## 1. launchctl / LaunchAgent modification → fail-closed prompt
`launchctl (load|unload|submit|bootstrap|bootout|enable|disable|kickstart)` and writes to `LaunchAgents/` / `LaunchDaemons/` moved from the hard-block tier (`matchDangerous`, stage 1) to the ask-user tier (`matchSensitivePath`, stage 5).

They now force a non-overridable dialog instead of an unconditional deny: a broad allow rule can't silence them, and an unanswered prompt times out to blocked. Same posture as the git-commit checkpoint. Commit-message mentions of `launchctl` stay allowed (quoted content is stripped before matching).

## 2. Opt-in, fail-closed per-session remote-approval enable
A session launched with `GAVEL_REQUEST_PHONE` set raises a non-overridable, fail-closed approval at SessionStart to enable its own remote (phone) approval. Opt-in by design — ordinary sessions are unaffected, so no approval fatigue.

Key property: the prompt is mirrored to Telegram **even though the session isn't phone-enabled yet** (`forceRemoteMirror`), so the bootstrap can reach the phone. On Allow it enables remote approval for the default window; on deny or timeout it stays off. Telegram only *answers* the prompt — it never initiates one. A burst of these (sprawl) floods the existing approval queue, which is the intended alarm.

- `GavelHook`: stamp `request_remote_approval` on SessionStart from the env flag
- `HookEvent`: `SessionStartPayload.requestRemoteApproval`
- `ApprovalCoordinator`: `forceRemoteMirror` + `shouldMirrorRemote` predicate
- `HookRouter`: `requestRemoteApprovalToggle` — async (doesn't block SessionStart), enables on allow, stays off on deny/timeout

## Tests / verification
- 574 tests pass (+8 new: mirror predicate, payload decode, enable/expiry/disable fail-closed).
- Verified live against a bounced dev daemon, end to end: env flag → shim → daemon → Telegram → Allow → enabled + persisted.

## Deploy note
The `GavelHook` change is in the shim binary — it only takes effect once released and `brew upgrade`d. Until then the env flag is honored only when `GAVEL_HOOK` points at a build carrying this change.
