### PR TITLE
feat(monitor): show full session tags in Sessions tab + overflow tooltip

### DIFF
--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -806,6 +806,7 @@ private struct SessionTagBadges: View {
                     Text(verbatim: "+\(tags.count - 3)")
                         .font(.system(size: 9))
                         .foregroundColor(.secondary)
+                        .help(tags.dropFirst(3).map(\.name).joined(separator: ", "))
                 }
             }
             .help(tags.map(\.name).joined(separator: ", "))
@@ -1463,6 +1464,16 @@ struct SessionRulesView: View {
                     .foregroundColor(.orange)
             }
             .font(.caption2)
+
+            if !session.tags.isEmpty {
+                HStack(alignment: .top, spacing: 4) {
+                    Text("Tags:").foregroundColor(.secondary)
+                    Text(session.tags.snapshot.map(\.name).joined(separator: "   "))
+                        .foregroundColor(.teal)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .font(.caption2)
+            }
 
             // Session rules
             if session.sessionRules.isEmpty {


### PR DESCRIPTION
Follow-up to session-tags (#140). The compact session row truncates tags to three with a `+N` badge and there was no way to see the hidden ones, and the Sessions tab — which has plenty of room — showed no tags at all.

- **Sessions tab** (`SessionRulesView` per-session detail) now lists every tag for a session on a wrapping line. Full visibility, no truncation.
- **Compact `+N` badge** gets its own tooltip listing the hidden tag names, so hovering it reveals the overflow.

Cosmetic; build-verified. (Live render not verified headless — the running daemon is currently another session's build.)