### PR TITLE
feat(approval): resolvable withheld remote approvals + gate trigger logging

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -149,18 +149,17 @@ final class ApprovalCoordinator: ObservableObject {
         forceRemoteMirror || sessionActive
     }
 
-    /// Mirror a pending approval to Telegram when its session is remote-enabled.
-    /// The credential gate suppresses the message entirely for sensitive payloads.
+    /// Mirror a pending approval to Telegram; credential-gated payloads send metadata + buttons but withhold the command.
     private func maybeSendRemote(pending: PendingApproval, resolvable: ResolvableApproval) {
         guard Self.shouldMirrorRemote(forceRemoteMirror: pending.forceRemoteMirror, sessionActive: pending.session.isRemoteApprovalActive),
               let bridge = remoteBridge else { return }
-        if CredentialGate.blocksRemote(pending.payload) {
-            bridge.notifyWithheld()
-            return
-        }
         let session = pending.session
         let payload = pending.payload
         let pendingId = pending.id
+        let withheld = CredentialGate.inspect(payload)
+        if let withheld {
+            gavelLog("[remote-gate] withheld command — trigger=\(withheld.logDescription)")
+        }
         let allowSession: () -> Void = {
             let pattern = payload.command ?? payload.filePath ?? "*"
             let rule = SessionRule(toolName: payload.toolName, pattern: pattern)
@@ -170,8 +169,10 @@ final class ApprovalCoordinator: ObservableObject {
             guard source == .telegram else { return }
             DispatchQueue.main.async { self?.dismissPending(id: pendingId, pid: session.pid) }
         }
-        let text = RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: pending.triggerReason)
-        let isCommit = payload.toolName == "Bash" && (payload.command?.contains("commit") ?? false)
+        let text = withheld != nil
+            ? RemoteApprovalBridge.withheldBody(payload: payload, session: session)
+            : RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: pending.triggerReason)
+        let isCommit = withheld == nil && payload.toolName == "Bash" && (payload.command?.contains("commit") ?? false)
         bridge.notify(resolvable: resolvable, text: text, allowSession: allowSession, offerCommentClean: isCommit)
     }
 

--- a/Sources/Gavel/Approval/CredentialGate.swift
+++ b/Sources/Gavel/Approval/CredentialGate.swift
@@ -1,17 +1,37 @@
 import Foundation
 
-/// Non-disableable safety gate for outbound remote-approval messages.
-/// When any payload field is credential-shaped, the message is suppressed entirely.
+/// Non-disableable safety gate that withholds credential-shaped commands from the remote channel.
 enum CredentialGate {
 
-    /// True when the payload must NOT be sent to a remote channel (Telegram).
-    /// Scans every tool-input value, the command, and file path — biased to over-suppress.
-    static func blocksRemote(_ payload: PreToolUsePayload) -> Bool {
-        for text in scannableStrings(payload) {
-            if SecretRedactor.containsKnownSecret(text) { return true }
-            if containsHighEntropyRun(text) { return true }
+    /// What tripped the gate — carries only log-safe fragments, never the full token.
+    enum Trigger: Equatable {
+        case knownPattern(label: String)
+        case entropyRun(prefix: String, length: Int)
+
+        var logDescription: String {
+            switch self {
+            case .knownPattern(let label): return "known-pattern \"\(label)\""
+            case .entropyRun(let prefix, let length): return "entropy-run prefix=\"\(prefix)…\" len=\(length)"
+            }
         }
-        return false
+    }
+
+    /// The first credential-shaped trigger in the payload, or nil when clean.
+    static func inspect(_ payload: PreToolUsePayload) -> Trigger? {
+        for text in scannableStrings(payload) {
+            if let label = SecretRedactor.firstMatchLabel(in: text) {
+                return .knownPattern(label: label)
+            }
+            if let run = firstHighEntropyRun(in: text) {
+                return .entropyRun(prefix: String(run.prefix(4)), length: run.count)
+            }
+        }
+        return nil
+    }
+
+    /// True when the payload's command must be withheld from the remote channel.
+    static func blocksRemote(_ payload: PreToolUsePayload) -> Bool {
+        inspect(payload) != nil
     }
 
     private static func scannableStrings(_ payload: PreToolUsePayload) -> [String] {
@@ -41,18 +61,21 @@ enum CredentialGate {
         }
     }
 
-    /// A 20+ char key-like run that is not a UUID or ISO-8601 timestamp is
-    /// credential-shaped. `/` is excluded so paths split into short segments.
+    /// True when the text contains a non-whitelisted 20+ char key-like run.
     static func containsHighEntropyRun(_ text: String) -> Bool {
+        firstHighEntropyRun(in: text) != nil
+    }
+
+    /// The first non-whitelisted 20+ char key-like run, or nil — `/` is excluded so paths split into short segments.
+    static func firstHighEntropyRun(in text: String) -> String? {
         let range = NSRange(text.startIndex..., in: text)
-        let matches = entropyRegex.matches(in: text, range: range)
-        for match in matches {
+        for match in entropyRegex.matches(in: text, range: range) {
             guard let r = Range(match.range, in: text) else { continue }
             let token = String(text[r])
             if isWhitelisted(token) { continue }
-            return true
+            return token
         }
-        return false
+        return nil
     }
 
     private static func isWhitelisted(_ token: String) -> Bool {

--- a/Sources/Gavel/Remote/RemoteApprovalBridge.swift
+++ b/Sources/Gavel/Remote/RemoteApprovalBridge.swift
@@ -114,18 +114,6 @@ final class RemoteApprovalBridge {
         }
     }
 
-    /// Send a contentless notice that an approval was withheld by the credential gate.
-    func notifyWithheld() {
-        lock.lock(); let chat = chatId; lock.unlock()
-        guard let chat else { return }
-        transport.sendMessage(
-            chatId: chat,
-            text: "🔒 Gavel: an approval was withheld from Telegram (sensitive content detected). Answer it on your Mac.",
-            keyboard: nil,
-            completion: { _ in }
-        )
-    }
-
     // MARK: - Inbound poll loop
 
     private func pollOnce() {
@@ -343,6 +331,18 @@ final class RemoteApprovalBridge {
             }
         }
         if let reason = triggerReason, !reason.isEmpty { lines.append("(\(sanitizeForDisplay(reason)))") }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Metadata-only body for a credential-gated approval — names the session so it can be verified in Claude, never the command.
+    static func withheldBody(payload: PreToolUsePayload, session: Session) -> String {
+        let label = session.label.isEmpty ? "PID \(session.pid)" : session.label
+        var lines = ["🔒 Gavel — command withheld", "Session: \(sanitizeForDisplay(label))", "Tool: \(payload.toolName)"]
+        if let cwd = session.cwd {
+            let tail = cwd.split(separator: "/").suffix(2).joined(separator: "/")
+            if !tail.isEmpty { lines.append("cwd: …/\(tail)") }
+        }
+        lines.append("Sensitive content detected — command not shown. Verify it in the Claude session, then Allow or Deny below.")
         return lines.joined(separator: "\n")
     }
 

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -118,7 +118,7 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
     @objc private func configureTelegram() {
         let alert = NSAlert()
         alert.messageText = "Configure Telegram Remote Approval"
-        alert.informativeText = "Paste your bot token from @BotFather. After saving, open your bot in Telegram and send /start to pair this chat. Remote approval must also be enabled per session in the Sessions tab. Command text is sent to Telegram's servers; payloads containing detected credentials are withheld automatically."
+        alert.informativeText = "Paste your bot token from @BotFather. After saving, open your bot in Telegram and send /start to pair this chat. Remote approval must also be enabled per session in the Sessions tab. Command text is sent to Telegram's servers; for payloads with detected credentials the command is withheld and only metadata plus the approval buttons are sent."
         let field = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
         field.placeholderString = "123456789:ABCdef..."
         alert.accessoryView = field

--- a/Tests/GavelTests/CredentialGateTests.swift
+++ b/Tests/GavelTests/CredentialGateTests.swift
@@ -56,4 +56,39 @@ final class CredentialGateTests: XCTestCase {
         let cmd = "AWS_PROFILE=AcmeCorp-Root-123456789012-AWSAdministratorAccess aws sts get-caller-identity"
         XCTAssertFalse(CredentialGate.blocksRemote(payload(["command": cmd])))
     }
+
+    func testInspectReportsKnownPatternByLabel() {
+        let trigger = CredentialGate.inspect(payload(["command": "aws s3 ls AKIAIOSFODNN7EXAMPLE"]))
+        XCTAssertEqual(trigger, .knownPattern(label: "AWS access key"))
+    }
+
+    func testInspectKnownPatternWinsOverEntropy() {
+        let trigger = CredentialGate.inspect(payload(["command": "echo ghp_0123456789abcdefABCDEF0123456789abcdef"]))
+        XCTAssertEqual(trigger, .knownPattern(label: "GitHub PAT"))
+    }
+
+    func testInspectReportsEntropyRunPrefixAndLength() {
+        let trigger = CredentialGate.inspect(payload(["command": "export TOKEN=Xa9Kd2Lp8Qw3Zr7Tv1Bn6Mc"]))
+        XCTAssertEqual(trigger, .entropyRun(prefix: "Xa9K", length: 23))
+    }
+
+    func testInspectReturnsNilForCleanCommand() {
+        XCTAssertNil(CredentialGate.inspect(payload(["command": "swift build && swift test"])))
+    }
+
+    func testLogDescriptionNeverLeaksFullToken() {
+        let token = "Xa9Kd2Lp8Qw3Zr7Tv1Bn6Mc"
+        guard case let .entropyRun(prefix, length)? = CredentialGate.inspect(payload(["command": "echo \(token)"])) else {
+            return XCTFail("expected entropy-run trigger")
+        }
+        let description = CredentialGate.Trigger.entropyRun(prefix: prefix, length: length).logDescription
+        XCTAssertFalse(description.contains(token))
+        XCTAssertEqual(description, "entropy-run prefix=\"Xa9K…\" len=23")
+    }
+
+    func testKnownPatternLogDescriptionHasNoToken() {
+        let description = CredentialGate.Trigger.knownPattern(label: "AWS access key").logDescription
+        XCTAssertEqual(description, "known-pattern \"AWS access key\"")
+        XCTAssertFalse(description.contains("AKIA"))
+    }
 }

--- a/Tests/GavelTests/RemoteApprovalBridgeTests.swift
+++ b/Tests/GavelTests/RemoteApprovalBridgeTests.swift
@@ -218,4 +218,35 @@ final class RemoteApprovalBridgeTests: XCTestCase {
         XCTAssertFalse(body.contains("super secret body"))
         XCTAssertFalse(body.contains("AKIAIOSFODNN7EXAMPLE"))
     }
+
+    func testWithheldBodyCarriesMetadataButNoCommand() {
+        let session = Session(pid: 123, cwd: "/Users/jay/code/claude-gavel")
+        session.label = "demo"
+        let payload = PreToolUsePayload(
+            toolName: "Bash",
+            toolInput: ["command": AnyCodable("aws configure set aws_secret_access_key AKIAIOSFODNN7EXAMPLE")]
+        )
+        let body = RemoteApprovalBridge.withheldBody(payload: payload, session: session)
+
+        XCTAssertTrue(body.contains("demo"))
+        XCTAssertTrue(body.contains("Bash"))
+        XCTAssertTrue(body.contains("claude-gavel"))
+        XCTAssertFalse(body.contains("AKIAIOSFODNN7EXAMPLE"))
+        XCTAssertFalse(body.contains("aws configure"))
+    }
+
+    func testWithheldApprovalIsResolvableFromPhoneWithButtons() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var resolved: Decision?
+        let approval = ResolvableApproval { resolved = $0 }
+
+        bridge.notify(resolvable: approval, text: "🔒 Gavel — command withheld", allowSession: nil)
+        XCTAssertFalse(fake.lastCallbackData.isEmpty)
+
+        let n = nonce(from: fake.lastCallbackData)
+        bridge.handle(callbackUpdate(action: "d", nonce: n, fromId: owner, chatId: owner, messageId: fake.lastSentMessageId))
+
+        XCTAssertEqual(resolved?.verdict, .block)
+    }
 }


### PR DESCRIPTION
## Problem

Credential-gated remote approvals were a dead end. When the gate detected credential-shaped content in a payload, the Telegram message was contentless and carried **no buttons** — the only way to resolve it was to walk to the Mac. Away from the desk (e.g. incident response) a genuinely-needed command could not be resolved at all.

## Change

The gate now withholds only the **command**, not the whole interaction:

- The Telegram message still carries session / tool / cwd metadata and the **Allow / Deny / Allow-for-session** buttons, so it resolves from the phone after the command is verified in the Claude session.
- **No command bytes** (redacted or otherwise) leave the Mac for a gated payload — the original "suppress over redact" guarantee is fully preserved. The only relaxed property is "sensitive payloads can't be resolved off-device" → now they can, but blind, relying on in-session verification.

## Diagnostics

`CredentialGate.inspect` returns a **log-safe** `Trigger`:

- `known-pattern "<label>"` — the label only, never the secret.
- `entropy-run prefix="abcd…" len=N` — a 4-char prefix + length, never the full token.

`maybeSendRemote` writes it to `gavel.log` (`[remote-gate] withheld command — trigger=…`), so the entropy heuristic's over-firing can be diagnosed against the command that's already visible in the Claude session. Known patterns are matched before entropy so a recognized secret never reaches the prefix-logging branch.

## Testing

- **Unit (585 green):** `inspect` trigger classification, log-safe formatting (no full token), `withheldBody` carries metadata but no command, gated approval resolvable via buttons.
- **Live E2E** (dev daemon, real Telegram): known-pattern → `known-pattern "AWS access key"` logged (no key); entropy → `entropy-run prefix="Xa9K…" len=23` logged (no token); full chat scan shows zero command/secret bytes in any message; all three gated approvals **resolved from the phone**, vs. the old build's `Answer it on your Mac` dead-ends visible in the same chat history.