### PR TITLE
feat(approval): instrument the remote-approval path in gavel.log

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -158,7 +158,7 @@ final class ApprovalCoordinator: ObservableObject {
         let pendingId = pending.id
         let withheld = CredentialGate.inspect(payload)
         if let withheld {
-            gavelLog("[remote-gate] withheld command — trigger=\(withheld.logDescription)")
+            gavelLog("[remote-gate] withheld command — pid=\(session.pid) trigger=\(withheld.logDescription)")
         }
         let allowSession: () -> Void = {
             let pattern = payload.command ?? payload.filePath ?? "*"
@@ -173,7 +173,7 @@ final class ApprovalCoordinator: ObservableObject {
             ? RemoteApprovalBridge.withheldBody(payload: payload, session: session)
             : RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: pending.triggerReason)
         let isCommit = withheld == nil && payload.toolName == "Bash" && (payload.command?.contains("commit") ?? false)
-        bridge.notify(resolvable: resolvable, text: text, allowSession: allowSession, offerCommentClean: isCommit)
+        bridge.notify(resolvable: resolvable, text: text, pid: session.pid, toolName: payload.toolName, withheld: withheld != nil, allowSession: allowSession, offerCommentClean: isCommit)
     }
 
     /// Remove a pending approval resolved remotely from its session panel.

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -346,7 +346,7 @@ final class HookRouter {
         // ever lacks a matching `[hook] respond` and `[socket] exit wrote=N`
         // (with N > 0), the worker died/wedged after read but before write.
         let reasonTag = decision.reason ?? "-"
-        gavelLog("[hook] respond verdict=\(decision.verdict.rawValue) reason=\(reasonTag.prefix(80))")
+        gavelLog("[hook] respond pid=\(session?.pid ?? -1) verdict=\(decision.verdict.rawValue) reason=\(reasonTag.prefix(80))")
         if let respond = respond,
            let data = decision.hookResponse.data(using: .utf8) {
             respond(data)

--- a/Sources/Gavel/Remote/RemoteApprovalBridge.swift
+++ b/Sources/Gavel/Remote/RemoteApprovalBridge.swift
@@ -9,11 +9,15 @@ final class RemoteApprovalBridge {
 
     private final class Correlation {
         let nonce: String
+        let pid: Int
+        let toolName: String
         let resolvable: ResolvableApproval
         let allowSession: (() -> Void)?
         var messageId: Int?
-        init(nonce: String, resolvable: ResolvableApproval, allowSession: (() -> Void)?) {
+        init(nonce: String, pid: Int, toolName: String, resolvable: ResolvableApproval, allowSession: (() -> Void)?) {
             self.nonce = nonce
+            self.pid = pid
+            self.toolName = toolName
             self.resolvable = resolvable
             self.allowSession = allowSession
         }
@@ -38,6 +42,8 @@ final class RemoteApprovalBridge {
     var onPaired: ((Int64) -> Void)?
     /// Emits a token-redacted status line for the feed/log.
     var onStatus: ((String) -> Void)?
+    /// Emits a gavel.log-only trail of remote sends/resolutions (no UI feed, no secrets).
+    var remoteLog: ((String) -> Void)?
 
     init(transport: TelegramTransport, chatId: Int64?, redact: @escaping (String) -> String = { $0 }) {
         self.transport = transport
@@ -68,17 +74,18 @@ final class RemoteApprovalBridge {
     // MARK: - Outbound
 
     /// Send a pending approval to the phone and register it for inbound resolution.
-    func notify(resolvable: ResolvableApproval, text: String, allowSession: (() -> Void)?, offerCommentClean: Bool = false) {
+    func notify(resolvable: ResolvableApproval, text: String, pid: Int = 0, toolName: String = "", withheld: Bool = false, allowSession: (() -> Void)?, offerCommentClean: Bool = false) {
         lock.lock(); let chat = chatId; lock.unlock()
         guard let chat else { return }
 
         guard consumeSendToken() else {
+            remoteLog?("coalesced pid=\(pid) tool=\(toolName) — flood control, Mac-fallback")
             coalesce(chat: chat)
             return
         }
 
         let nonce = Self.makeNonce()
-        let corr = Correlation(nonce: nonce, resolvable: resolvable, allowSession: allowSession)
+        let corr = Correlation(nonce: nonce, pid: pid, toolName: toolName, resolvable: resolvable, allowSession: allowSession)
         lock.lock(); byNonce[nonce] = corr; pendingOrder.append(nonce); lock.unlock()
 
         resolvable.addCleanup { [weak self] source, _ in
@@ -86,6 +93,7 @@ final class RemoteApprovalBridge {
             self.lock.lock(); let mid = corr.messageId; self.lock.unlock()
             self.forget(nonce)
             guard source != .telegram else { return }
+            self.remoteLog?("dropped pid=\(pid) nonce=\(nonce) source=\(source)")
             if let mid {
                 self.transport.editMessageText(chatId: chat, messageId: mid, text: Self.macResolvedText(source), completion: nil)
             }
@@ -104,11 +112,13 @@ final class RemoteApprovalBridge {
             switch result {
             case .success(let mid):
                 self.lock.lock(); corr.messageId = mid; self.lock.unlock()
+                self.remoteLog?("sent pid=\(pid) nonce=\(nonce) tool=\(toolName) withheld=\(withheld) mid=\(mid)")
                 if resolvable.isResolved {
                     self.transport.editMessageText(chatId: chat, messageId: mid, text: Self.macResolvedText(.mac), completion: nil)
                     self.forget(nonce)
                 }
             case .failure(let error):
+                self.remoteLog?("send-failed pid=\(pid) nonce=\(nonce) tool=\(toolName)")
                 self.onStatus?("Telegram send failed: \(self.redact("\(error)"))")
             }
         }
@@ -181,7 +191,9 @@ final class RemoteApprovalBridge {
         case .target(let corr):
             forget(corr.nonce)
             let decision = Decision(verdict: .block, reason: "Denied from phone — \(text)")
-            if corr.resolvable.resolve(decision, from: .telegram), let mid = corr.messageId {
+            let won = corr.resolvable.resolve(decision, from: .telegram)
+            remoteLog?("resolved pid=\(corr.pid) nonce=\(corr.nonce) action=deny-reason won=\(won)")
+            if won, let mid = corr.messageId {
                 transport.editMessageText(chatId: pinned, messageId: mid, text: "🛑 Denied from phone — \(text)", completion: nil)
             }
         case .ambiguous(let count):
@@ -217,6 +229,7 @@ final class RemoteApprovalBridge {
         if action == "s" { corr.allowSession?() }
         let decision = Self.decision(for: action)
         let won = corr.resolvable.resolve(decision, from: .telegram)
+        remoteLog?("resolved pid=\(corr.pid) nonce=\(nonce) action=\(action) won=\(won)")
         if won {
             transport.answerCallbackQuery(id: callback.id, text: decision.verdict == .block ? "Denied" : "Allowed", completion: nil)
             transport.editMessageText(chatId: pinned, messageId: callback.messageId, text: Self.phoneResolvedText(action), completion: nil)

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -110,6 +110,7 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
                 self?.viewModel.appendFeedEntry(.system("Telegram: \(message)", pid: Int(getpid()), at: Date()))
             }
         }
+        bridge.remoteLog = { gavelLog("[remote] \($0)") }
         approvalCoordinator.remoteBridge = bridge
         remoteBridge = bridge
         bridge.start()

--- a/Tests/GavelTests/RemoteApprovalBridgeTests.swift
+++ b/Tests/GavelTests/RemoteApprovalBridgeTests.swift
@@ -235,6 +235,33 @@ final class RemoteApprovalBridgeTests: XCTestCase {
         XCTAssertFalse(body.contains("aws configure"))
     }
 
+    func testRemoteLogTrailCapturesSendAndResolve() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var logs: [String] = []
+        bridge.remoteLog = { logs.append($0) }
+        let approval = ResolvableApproval { _ in }
+
+        bridge.notify(resolvable: approval, text: "approve?", pid: 4242, toolName: "Bash", withheld: true, allowSession: nil)
+        XCTAssertTrue(logs.contains { $0.hasPrefix("sent pid=4242") && $0.contains("tool=Bash") && $0.contains("withheld=true") })
+
+        let n = nonce(from: fake.lastCallbackData)
+        bridge.handle(callbackUpdate(action: "d", nonce: n, fromId: owner, chatId: owner, messageId: fake.lastSentMessageId))
+        XCTAssertTrue(logs.contains { $0.hasPrefix("resolved pid=4242") && $0.contains("action=d") && $0.contains("won=true") })
+    }
+
+    func testRemoteLogRecordsFloodCoalesce() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var logs: [String] = []
+        bridge.remoteLog = { logs.append($0) }
+
+        for i in 0..<7 {
+            bridge.notify(resolvable: ResolvableApproval { _ in }, text: "x", pid: i, toolName: "Bash", allowSession: nil)
+        }
+        XCTAssertTrue(logs.contains { $0.hasPrefix("coalesced") })
+    }
+
     func testWithheldApprovalIsResolvableFromPhoneWithButtons() {
         let fake = FakeTelegramTransport()
         let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)


### PR DESCRIPTION
## Problem

The remote/Telegram approval path was a logging blind spot, and it repeatedly sent debugging down the wrong path:

- `maybeSendRemote` pushed prompts to the phone but wrote **nothing** to `gavel.log`.
- `[approval] show` only fires when an approval becomes the **current Mac panel** item, so any approval resolved from the phone *while still queued* left no `show` and no `advance` line — invisible.
- `[hook] respond` lines carried **no pid**, so decisions couldn't be attributed to a session (counts were polluted by other sessions + the agent's own diagnostic Bash).

Net: you could not reconstruct what was pushed to the phone or how it resolved. Live debugging concluded "logs say 3, I saw 6–7" with no way to close the gap.

## Change

A `gavel.log`-only `[remote]` trail, keyed by **pid + nonce**, with no command text or secrets:

- `sent pid=… nonce=… tool=… withheld=… mid=…` — one per phone prompt actually delivered.
- `resolved pid=… nonce=… action=… won=…` — button taps and typed-reply denies, correlated to the send by nonce.
- `coalesced pid=… tool=… — flood control` — burst >5 collapsed to the Mac-fallback notice (previously wrote nothing anywhere but the phone).
- `dropped pid=… nonce=… source=…` — a phone prompt superseded by a Mac/timeout resolution.
- `send-failed pid=… nonce=… tool=…`.

Plus `pid=` on `[hook] respond` and `[remote-gate]` so every decision is attributable to a session.

## Testing

- **Unit (587, +2):** the `[remote]` trail records send + resolve with pid/nonce/action; flood-control coalesce is logged.
- **Live (dev daemon):** fired 3 concurrent sub-agents → exactly 2 `[remote] sent` lines (pid+nonce+tool), 2 `[remote] resolved` (action=a, won=true) correlated by nonce, `[hook] respond` carrying pid. The trail immediately explained the 3-vs-2 gap: one sub-agent reported `tool_uses: 0` and never ran its command — previously an unexplainable mystery, now plainly "only 2 were ever sent."