### PR TITLE
feat(session): tag sessions from user-typed skill slash commands

### DIFF
--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -197,7 +197,7 @@ final class SessionManager: ObservableObject {
         let path = (NSHomeDirectory() as NSString)
             .appendingPathComponent(".claude/projects")
             .appending("/\(encoded)/\(sid).jsonl")
-        let handlers: [JsonlEventHandler] = [RenameHandler(), SecretHandler()]
+        let handlers: [JsonlEventHandler] = [RenameHandler(), SecretHandler(), SkillTagHandler()]
         let dispatcher = JsonlEventDispatcher(handlers: handlers, manager: self, session: session)
         let watcher = JsonlWatcher(path: path, dispatcher: dispatcher)
         watchers[session.pid] = watcher

--- a/Sources/Gavel/Observability/Handlers/SkillTagHandler.swift
+++ b/Sources/Gavel/Observability/Handlers/SkillTagHandler.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+final class SkillTagHandler: JsonlEventHandler {
+    let name = "skill-tag"
+
+    private let knownSkills: Set<String>
+
+    private static let pattern = try! NSRegularExpression(
+        pattern: #"<command-name>\s*/?([A-Za-z0-9][\w-]*)\s*</command-name>"#
+    )
+
+    init(knownSkills: Set<String> = SkillTagHandler.liveSkills) {
+        self.knownSkills = knownSkills
+    }
+
+    func handle(_ event: JsonlEvent, manager: SessionManager, session: Session) {
+        guard !knownSkills.isEmpty else { return }
+        let line = event.rawLine
+        let range = NSRange(line.startIndex..., in: line)
+        let at = Self.timestamp(from: event.json) ?? Date()
+        var added = false
+        for match in Self.pattern.matches(in: line, range: range) {
+            guard match.numberOfRanges >= 2, let r = Range(match.range(at: 1), in: line) else { continue }
+            let skill = String(line[r])
+            guard knownSkills.contains(skill) else { continue }
+            if session.tags.addObserved("skill:\(skill)", at: at) { added = true }
+        }
+        if added { manager.saveActiveSessions() }
+    }
+
+    private static func timestamp(from json: [String: Any]?) -> Date? {
+        guard let value = json?["timestamp"] as? String else { return nil }
+        return isoFormatter.date(from: value)
+    }
+
+    private static let isoFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    static let liveSkills: Set<String> = discoverSkills()
+
+    static func discoverSkills(
+        in directory: String = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/skills")
+    ) -> Set<String> {
+        let fileManager = FileManager.default
+        guard let names = try? fileManager.contentsOfDirectory(atPath: directory) else { return [] }
+        var skills = Set<String>()
+        for name in names {
+            var isDir: ObjCBool = false
+            let full = (directory as NSString).appendingPathComponent(name)
+            if fileManager.fileExists(atPath: full, isDirectory: &isDir), isDir.boolValue {
+                skills.insert(name)
+            }
+        }
+        return skills
+    }
+}

--- a/Sources/Gavel/Observability/JsonlWatcher.swift
+++ b/Sources/Gavel/Observability/JsonlWatcher.swift
@@ -7,6 +7,7 @@ final class JsonlWatcher {
 
     private var fileHandle: FileHandle?
     private var source: DispatchSourceFileSystemObject?
+    private var pollTimer: DispatchSourceTimer?
     private var lastOffset: UInt64 = 0
     private var lineBuffer = Data()
 
@@ -20,11 +21,39 @@ final class JsonlWatcher {
     }
 
     func start() {
-        queue.async { [weak self] in self?.openAndSubscribe() }
+        queue.async { [weak self] in
+            self?.openAndSubscribe()
+            self?.startPoll()
+        }
     }
 
     func stop() {
-        queue.async { [weak self] in self?.tearDown() }
+        queue.async { [weak self] in
+            self?.pollTimer?.cancel()
+            self?.pollTimer = nil
+            self?.tearDown()
+        }
+    }
+
+    private func startPoll() {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + 2, repeating: 2)
+        timer.setEventHandler { [weak self] in self?.pollOnce() }
+        timer.resume()
+        pollTimer = timer
+    }
+
+    private func pollOnce() {
+        guard fileHandle != nil else {
+            openAndSubscribe()
+            return
+        }
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+           let size = (attrs[.size] as? NSNumber)?.uint64Value, size < lastOffset {
+            reopenAfterRotation()
+            return
+        }
+        readNewBytes()
     }
 
     private func openAndSubscribe() {

--- a/Tests/GavelTests/SkillTagHandlerTests.swift
+++ b/Tests/GavelTests/SkillTagHandlerTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import Gavel
+
+final class SkillTagHandlerTests: XCTestCase {
+
+    private func isolatedManager() -> SessionManager {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gavel-skilltag-tests-\(UUID().uuidString)")
+        return SessionManager(homeDir: tmp, autoStartTimers: false, autoDiscover: false)
+    }
+
+    private func event(_ line: String, ts: String? = nil) -> JsonlEvent {
+        var json: [String: Any]? = nil
+        if let ts = ts { json = ["timestamp": ts] }
+        return JsonlEvent(rawLine: line, json: json, sessionId: "s", cwd: "/tmp")
+    }
+
+    private func date(_ iso: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: iso)!
+    }
+
+    func testTagsKnownSkillFromCommandName() {
+        let handler = SkillTagHandler(knownSkills: ["daybook"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81001)
+        handler.handle(event(#"{"x":"<command-name>/daybook</command-name>"}"#), manager: manager, session: session)
+        XCTAssertTrue(session.tags.matches(token: "skill:daybook"))
+        XCTAssertEqual(session.tags.count, 1)
+    }
+
+    func testNoLeadingSlashAlsoTags() {
+        let handler = SkillTagHandler(knownSkills: ["lookup"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81002)
+        handler.handle(event("<command-name>lookup</command-name>"), manager: manager, session: session)
+        XCTAssertTrue(session.tags.matches(token: "skill:lookup"))
+    }
+
+    func testIgnoresCommandThatIsNotAKnownSkill() {
+        let handler = SkillTagHandler(knownSkills: ["daybook"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81003)
+        handler.handle(event("<command-name>/rename</command-name>"), manager: manager, session: session)
+        XCTAssertTrue(session.tags.isEmpty)
+    }
+
+    func testNoCommandNameRecordsNothing() {
+        let handler = SkillTagHandler(knownSkills: ["daybook"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81004)
+        handler.handle(event(#"{"type":"user","message":"just some text"}"#), manager: manager, session: session)
+        XCTAssertTrue(session.tags.isEmpty)
+    }
+
+    func testDedupesRepeatedInvocation() {
+        let handler = SkillTagHandler(knownSkills: ["daybook"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81005)
+        let line = "<command-name>/daybook</command-name>"
+        handler.handle(event(line, ts: "2026-06-18T18:00:00.000Z"), manager: manager, session: session)
+        handler.handle(event(line, ts: "2026-06-18T19:00:00.000Z"), manager: manager, session: session)
+        XCTAssertEqual(session.tags.count, 1)
+        XCTAssertEqual(session.tags.snapshot.first?.appliedAt, date("2026-06-18T18:00:00.000Z"))
+    }
+
+    func testEmptyKnownSkillsIsNoOp() {
+        let handler = SkillTagHandler(knownSkills: [])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81006)
+        handler.handle(event("<command-name>/daybook</command-name>"), manager: manager, session: session)
+        XCTAssertTrue(session.tags.isEmpty)
+    }
+
+    func testTimestampParsedFromEventJson() {
+        let handler = SkillTagHandler(knownSkills: ["daybook"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81007)
+        handler.handle(event("<command-name>/daybook</command-name>", ts: "2026-06-18T18:00:00.000Z"),
+                       manager: manager, session: session)
+        XCTAssertEqual(session.tags.snapshot.first?.appliedAt, date("2026-06-18T18:00:00.000Z"))
+    }
+
+    func testDiscoverSkillsReadsSubdirectories() {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gavel-skills-\(UUID().uuidString)")
+        let fm = FileManager.default
+        try? fm.createDirectory(at: dir.appendingPathComponent("daybook"), withIntermediateDirectories: true)
+        try? fm.createDirectory(at: dir.appendingPathComponent("lookup"), withIntermediateDirectories: true)
+        fm.createFile(atPath: dir.appendingPathComponent("loose-file.md").path, contents: Data())
+
+        let discovered = SkillTagHandler.discoverSkills(in: dir.path)
+        XCTAssertEqual(discovered, ["daybook", "lookup"])
+    }
+}


### PR DESCRIPTION
### The gap
Session-tags (#140) only observed **agent-invoked** Skill tool calls via the PreToolUse hook. A **user-typed** slash command (e.g. `/daybook`) is pre-loaded by the harness and never generates a `Skill` tool-use, so it reached nothing and never tagged — the cause of "I ran daybook and it didn't add the tag."

### The fix
`SkillTagHandler` — a JSONL event handler (sibling to `RenameHandler`) that parses `<command-name>/X</command-name>` from the transcript and records `skill:X` if `X` is a known skill (discovered from `~/.claude/skills/`). Dedup by name means agent- and user-invoked invocations collapse to one tag.

### Two delivery bugs found by live dogfooding (gavel-dev-daemon swap)
Both would have made this silently fail in production:

1. **`JsonlWatcher` dropped writes.** It relied solely on `DispatchSource` fs-events, which deliver intermittently — the transcript line was present but never handed to the handler. Added a **2s poll safety-net** that re-reads new bytes and detects truncation/rotation, so a missed event is caught within seconds. This also makes `SecretHandler` more reliable.
2. **`discoverSkills` read the wrong home.** It used `FileManager.homeDirectoryForCurrentUser`, which resolves to a different path in the daemon process, leaving the known-skills set **empty** so the handler no-op'd. Switched to `NSHomeDirectory()` (what the rest of the daemon uses).

### Testing
- Unit: command-name extraction (leading-slash and bare), known-skill filtering, dedup/keep-first, timestamp parsing, skills discovery.
- **Live end-to-end** via dev-daemon swap: a user-typed `/note` produced `skill:note` on the session, persisted. 595 pass.

Note: tags only fire for skills present in `~/.claude/skills/` (the discovery source); MCP/plugin-only skills aren't covered. Built-in commands like `/rename` are correctly ignored.