### PR TITLE
feat(session): [[/skill]] manual tag marker, gated to user transcript entries

### DIFF
--- a/Sources/Gavel/Models/SessionTag.swift
+++ b/Sources/Gavel/Models/SessionTag.swift
@@ -23,11 +23,16 @@ final class SessionTagStore {
     }
 
     @discardableResult
-    func addObserved(_ name: String, at time: Date) -> Bool {
+    func add(_ name: String, at time: Date, source: TagSource) -> Bool {
         lock.lock(); defer { lock.unlock() }
         guard _tags[name] == nil else { return false }
-        _tags[name] = SessionTag(name: name, appliedAt: time, source: .observed)
+        _tags[name] = SessionTag(name: name, appliedAt: time, source: source)
         return true
+    }
+
+    @discardableResult
+    func addObserved(_ name: String, at time: Date) -> Bool {
+        add(name, at: time, source: .observed)
     }
 
     func load(_ tags: [SessionTag]) {

--- a/Sources/Gavel/Observability/Handlers/SkillTagHandler.swift
+++ b/Sources/Gavel/Observability/Handlers/SkillTagHandler.swift
@@ -5,8 +5,12 @@ final class SkillTagHandler: JsonlEventHandler {
 
     private let knownSkills: Set<String>
 
-    private static let pattern = try! NSRegularExpression(
+    private static let commandNamePattern = try! NSRegularExpression(
         pattern: #"<command-name>\s*/?([A-Za-z0-9][\w-]*)\s*</command-name>"#
+    )
+
+    private static let markerPattern = try! NSRegularExpression(
+        pattern: #"\[\[/([A-Za-z0-9][\w-]*)\]\]"#
     )
 
     init(knownSkills: Set<String> = SkillTagHandler.liveSkills) {
@@ -15,17 +19,24 @@ final class SkillTagHandler: JsonlEventHandler {
 
     func handle(_ event: JsonlEvent, manager: SessionManager, session: Session) {
         guard !knownSkills.isEmpty else { return }
+        guard (event.json?["type"] as? String) == "user" else { return }
         let line = event.rawLine
-        let range = NSRange(line.startIndex..., in: line)
         let at = Self.timestamp(from: event.json) ?? Date()
+        let observed = tag(line: line, pattern: Self.commandNamePattern, source: .observed, at: at, session: session)
+        let manual = tag(line: line, pattern: Self.markerPattern, source: .manual, at: at, session: session)
+        if observed || manual { manager.saveActiveSessions() }
+    }
+
+    private func tag(line: String, pattern: NSRegularExpression, source: TagSource, at: Date, session: Session) -> Bool {
+        let range = NSRange(line.startIndex..., in: line)
         var added = false
-        for match in Self.pattern.matches(in: line, range: range) {
+        for match in pattern.matches(in: line, range: range) {
             guard match.numberOfRanges >= 2, let r = Range(match.range(at: 1), in: line) else { continue }
             let skill = String(line[r])
             guard knownSkills.contains(skill) else { continue }
-            if session.tags.addObserved("skill:\(skill)", at: at) { added = true }
+            if session.tags.add("skill:\(skill)", at: at, source: source) { added = true }
         }
-        if added { manager.saveActiveSessions() }
+        return added
     }
 
     private static func timestamp(from json: [String: Any]?) -> Date? {

--- a/Tests/GavelTests/SkillTagHandlerTests.swift
+++ b/Tests/GavelTests/SkillTagHandlerTests.swift
@@ -9,9 +9,9 @@ final class SkillTagHandlerTests: XCTestCase {
         return SessionManager(homeDir: tmp, autoStartTimers: false, autoDiscover: false)
     }
 
-    private func event(_ line: String, ts: String? = nil) -> JsonlEvent {
-        var json: [String: Any]? = nil
-        if let ts = ts { json = ["timestamp": ts] }
+    private func event(_ line: String, ts: String? = nil, type: String = "user") -> JsonlEvent {
+        var json: [String: Any] = ["type": type]
+        if let ts = ts { json["timestamp"] = ts }
         return JsonlEvent(rawLine: line, json: json, sessionId: "s", cwd: "/tmp")
     }
 
@@ -63,6 +63,42 @@ final class SkillTagHandlerTests: XCTestCase {
         handler.handle(event(line, ts: "2026-06-18T19:00:00.000Z"), manager: manager, session: session)
         XCTAssertEqual(session.tags.count, 1)
         XCTAssertEqual(session.tags.snapshot.first?.appliedAt, date("2026-06-18T18:00:00.000Z"))
+    }
+
+    func testManualMarkerTagsKnownSkill() {
+        let handler = SkillTagHandler(knownSkills: ["jira"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81010)
+        handler.handle(event("please add the tag [[/jira]] retroactively"), manager: manager, session: session)
+        XCTAssertTrue(session.tags.matches(token: "skill:jira"))
+        XCTAssertEqual(session.tags.snapshot.first?.source, .manual)
+    }
+
+    func testManualMarkerIgnoresUnknownSkill() {
+        let handler = SkillTagHandler(knownSkills: ["jira"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81011)
+        handler.handle(event("[[/not-a-skill]]"), manager: manager, session: session)
+        XCTAssertTrue(session.tags.isEmpty)
+    }
+
+    func testManualMarkerDoesNotOverrideObservedSource() {
+        let handler = SkillTagHandler(knownSkills: ["jira"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81012)
+        handler.handle(event("<command-name>/jira</command-name>"), manager: manager, session: session)
+        handler.handle(event("[[/jira]]"), manager: manager, session: session)
+        XCTAssertEqual(session.tags.count, 1)
+        XCTAssertEqual(session.tags.snapshot.first?.source, .observed)
+    }
+
+    func testIgnoresNonUserEntry() {
+        let handler = SkillTagHandler(knownSkills: ["daybook"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81013)
+        handler.handle(event("<command-name>/daybook</command-name> and [[/daybook]]", type: "assistant"),
+                       manager: manager, session: session)
+        XCTAssertTrue(session.tags.isEmpty)
     }
 
     func testEmptyKnownSkillsIsNoOp() {


### PR DESCRIPTION
Follow-up to #152. Two things:

### 1. Manual `[[/skill]]` marker
A way to tag a session for a skill the auto-detection missed (it ran before the daemon had this feature, or a delivery gap) **without re-running the skill** and its side effects. Type a text marker — `[[/jira]]` — and the session gains `skill:jira` (`source: manual`). Only known skills are tagged, so typos are ignored. Beats re-invoking, which does real work.

### 2. Gate tagging to `user` transcript entries
While testing the marker, the long-standing meta-conversation false-positive became obvious: both the command-name and marker patterns matched **any** transcript line, so agent prose quoting a slash command — or just explaining the `[[/jira]]` syntax — tagged the session. Now `SkillTagHandler` only acts on `type == "user"` entries. Real slash commands and user-typed markers are `user`; agent/system entries are ignored. Agent-**invoked** skills are unaffected — they tag via the PreToolUse HookRouter path, not this one.

### Testing
- Unit: marker tags known skill as `manual`, ignores unknown skill, doesn't override an `observed` source on dedup, and a non-user entry tags nothing.
- **Live**: a user-typed `[[/research]]` tagged `skill:research` (manual), while the identical marker in *my* agent prose did not. 599 pass.