### PR TITLE
feat(session): [[-/skill]] marker to remove a session tag

### DIFF
--- a/Sources/Gavel/Models/SessionTag.swift
+++ b/Sources/Gavel/Models/SessionTag.swift
@@ -35,6 +35,12 @@ final class SessionTagStore {
         add(name, at: time, source: .observed)
     }
 
+    @discardableResult
+    func remove(_ name: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _tags.removeValue(forKey: name) != nil
+    }
+
     func load(_ tags: [SessionTag]) {
         lock.lock(); defer { lock.unlock() }
         for tag in tags where _tags[tag.name] == nil {

--- a/Sources/Gavel/Observability/Handlers/SkillTagHandler.swift
+++ b/Sources/Gavel/Observability/Handlers/SkillTagHandler.swift
@@ -13,6 +13,10 @@ final class SkillTagHandler: JsonlEventHandler {
         pattern: #"\[\[/([A-Za-z0-9][\w-]*)\]\]"#
     )
 
+    private static let removeMarkerPattern = try! NSRegularExpression(
+        pattern: #"\[\[-/([A-Za-z0-9][\w-]*)\]\]"#
+    )
+
     init(knownSkills: Set<String> = SkillTagHandler.liveSkills) {
         self.knownSkills = knownSkills
     }
@@ -24,7 +28,18 @@ final class SkillTagHandler: JsonlEventHandler {
         let at = Self.timestamp(from: event.json) ?? Date()
         let observed = tag(line: line, pattern: Self.commandNamePattern, source: .observed, at: at, session: session)
         let manual = tag(line: line, pattern: Self.markerPattern, source: .manual, at: at, session: session)
-        if observed || manual { manager.saveActiveSessions() }
+        let removed = untag(line: line, pattern: Self.removeMarkerPattern, session: session)
+        if observed || manual || removed { manager.saveActiveSessions() }
+    }
+
+    private func untag(line: String, pattern: NSRegularExpression, session: Session) -> Bool {
+        let range = NSRange(line.startIndex..., in: line)
+        var removed = false
+        for match in pattern.matches(in: line, range: range) {
+            guard match.numberOfRanges >= 2, let r = Range(match.range(at: 1), in: line) else { continue }
+            if session.tags.remove("skill:\(String(line[r]))") { removed = true }
+        }
+        return removed
     }
 
     private func tag(line: String, pattern: NSRegularExpression, source: TagSource, at: Date, session: Session) -> Bool {

--- a/Tests/GavelTests/SkillTagHandlerTests.swift
+++ b/Tests/GavelTests/SkillTagHandlerTests.swift
@@ -92,6 +92,42 @@ final class SkillTagHandlerTests: XCTestCase {
         XCTAssertEqual(session.tags.snapshot.first?.source, .observed)
     }
 
+    func testRemoveMarkerRemovesTag() {
+        let handler = SkillTagHandler(knownSkills: ["jira"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81020)
+        handler.handle(event("[[/jira]]"), manager: manager, session: session)
+        XCTAssertTrue(session.tags.matches(token: "skill:jira"))
+        handler.handle(event("oops remove it [[-/jira]]"), manager: manager, session: session)
+        XCTAssertTrue(session.tags.isEmpty)
+    }
+
+    func testRemoveMarkerForAbsentTagIsNoOp() {
+        let handler = SkillTagHandler(knownSkills: ["jira"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81021)
+        handler.handle(event("[[-/jira]]"), manager: manager, session: session)
+        XCTAssertTrue(session.tags.isEmpty)
+    }
+
+    func testRemoveMarkerDoesNotRequireKnownSkill() {
+        let handler = SkillTagHandler(knownSkills: ["jira"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81022)
+        session.tags.add("skill:retired", at: Date(timeIntervalSince1970: 1), source: .observed)
+        handler.handle(event("[[-/retired]]"), manager: manager, session: session)
+        XCTAssertFalse(session.tags.matches(token: "skill:retired"))
+    }
+
+    func testRemoveMarkerIgnoredInNonUserEntry() {
+        let handler = SkillTagHandler(knownSkills: ["jira"])
+        let manager = isolatedManager()
+        let session = manager.session(for: 81023)
+        handler.handle(event("[[/jira]]"), manager: manager, session: session)
+        handler.handle(event("[[-/jira]]", type: "assistant"), manager: manager, session: session)
+        XCTAssertTrue(session.tags.matches(token: "skill:jira"))
+    }
+
     func testIgnoresNonUserEntry() {
         let handler = SkillTagHandler(knownSkills: ["daybook"])
         let manager = isolatedManager()


### PR DESCRIPTION
Companion to the `[[/skill]]` add marker (#154). Typing `[[-/skill]]` in a user message removes `skill:<skill>` from the session — for clearing a tag added by mistake or an auto-detection false positive.

- Unlike the add marker, removal does **not** require the skill to still be known, so a tag for a since-deleted skill can still be cleared.
- Same `user`-entry gating: agent prose is ignored. The add (`[[/x]]`) and remove (`[[-/x]]`) patterns don't overlap.
- Multiple markers in one message all apply.

### Testing
- Unit: removes an existing tag, no-ops for an absent tag, works for a skill not in the known set, non-user entry removes nothing.
- **Live**: a user `[[-/jira]] [[-/research]]` cleared both test tags in one message while the legit tags remained. 603 pass.