### PR TITLE
feat(approval): inline deny-with-reason button via ForceReply

### DIFF
--- a/Sources/Gavel/Remote/RemoteApprovalBridge.swift
+++ b/Sources/Gavel/Remote/RemoteApprovalBridge.swift
@@ -27,6 +27,7 @@ final class RemoteApprovalBridge {
     private let redact: (String) -> String
     private let lock = NSLock()
     private var byNonce: [String: Correlation] = [:]
+    private var promptToNonce: [Int: String] = [:]
     private var pendingOrder: [String] = []
     private var offset = 0
     private var running = false
@@ -102,7 +103,8 @@ final class RemoteApprovalBridge {
         var keyboard: [[TelegramButton]] = [
             [TelegramButton(text: "✅ Allow once", callbackData: "a:\(nonce)"),
              TelegramButton(text: "🛑 Deny", callbackData: "d:\(nonce)")],
-            [TelegramButton(text: "✅ Allow for session", callbackData: "s:\(nonce)")]
+            [TelegramButton(text: "✅ Allow for session", callbackData: "s:\(nonce)")],
+            [TelegramButton(text: "🛑 Deny w/ reason", callbackData: "dr:\(nonce)")]
         ]
         if offerCommentClean {
             keyboard.append([TelegramButton(text: "🧹 Clean comments & re-propose", callbackData: "c:\(nonce)")])
@@ -224,6 +226,11 @@ final class RemoteApprovalBridge {
             transport.editMessageText(chatId: pinned, messageId: callback.messageId, text: "↪️ Already resolved", completion: nil)
             return
         }
+
+        if action == "dr" {
+            promptForDenyReason(corr: corr, callbackId: callback.id, chat: pinned)
+            return
+        }
         forget(nonce)
 
         if action == "s" { corr.allowSession?() }
@@ -236,6 +243,16 @@ final class RemoteApprovalBridge {
         } else {
             transport.answerCallbackQuery(id: callback.id, text: "Already resolved", completion: nil)
             transport.editMessageText(chatId: pinned, messageId: callback.messageId, text: Self.macResolvedText(.mac), completion: nil)
+        }
+    }
+
+    private func promptForDenyReason(corr: Correlation, callbackId: String, chat: Int64) {
+        transport.answerCallbackQuery(id: callbackId, text: "Reply with a reason", completion: nil)
+        let target = corr.toolName.isEmpty ? "this approval" : corr.toolName
+        transport.sendForceReply(chatId: chat, text: "Reply with a reason to deny \(target)…") { [weak self] result in
+            guard let self, case .success(let mid) = result else { return }
+            self.lock.lock(); self.promptToNonce[mid] = corr.nonce; self.lock.unlock()
+            self.remoteLog?("deny-reason prompt pid=\(corr.pid) nonce=\(corr.nonce) promptMid=\(mid)")
         }
     }
 
@@ -278,6 +295,7 @@ final class RemoteApprovalBridge {
         lock.lock()
         byNonce.removeValue(forKey: nonce)
         pendingOrder.removeAll { $0 == nonce }
+        promptToNonce = promptToNonce.filter { $0.value != nonce }
         lock.unlock()
     }
 
@@ -290,6 +308,7 @@ final class RemoteApprovalBridge {
     private func typedReplyTarget(replyTo: Int?) -> TypedReplyTarget {
         lock.lock(); defer { lock.unlock() }
         if let replyTo {
+            if let promptNonce = promptToNonce[replyTo], let corr = byNonce[promptNonce] { return .target(corr) }
             if let match = byNonce.values.first(where: { $0.messageId == replyTo }) { return .target(match) }
             return .none
         }

--- a/Sources/Gavel/Remote/TelegramTransport.swift
+++ b/Sources/Gavel/Remote/TelegramTransport.swift
@@ -37,6 +37,7 @@ enum TelegramError: Error {
 /// Abstracts the Telegram Bot API so the bridge can be unit-tested against a fake.
 protocol TelegramTransport: AnyObject {
     func sendMessage(chatId: Int64, text: String, keyboard: [[TelegramButton]]?, completion: @escaping (Result<Int, Error>) -> Void)
+    func sendForceReply(chatId: Int64, text: String, completion: @escaping (Result<Int, Error>) -> Void)
     func editMessageText(chatId: Int64, messageId: Int, text: String, completion: ((Result<Void, Error>) -> Void)?)
     func answerCallbackQuery(id: String, text: String?, completion: ((Result<Void, Error>) -> Void)?)
     func getUpdates(offset: Int, timeoutSeconds: Int, completion: @escaping (Result<[TelegramUpdate], Error>) -> Void)

--- a/Sources/Gavel/Remote/URLSessionTelegramTransport.swift
+++ b/Sources/Gavel/Remote/URLSessionTelegramTransport.swift
@@ -42,6 +42,27 @@ final class URLSessionTelegramTransport: TelegramTransport {
         }
     }
 
+    func sendForceReply(chatId: Int64, text: String, completion: @escaping (Result<Int, Error>) -> Void) {
+        let params: [String: Any] = [
+            "chat_id": chatId,
+            "text": text,
+            "disable_web_page_preview": true,
+            "reply_markup": ["force_reply": true, "selective": true]
+        ]
+        call("sendMessage", params: params) { result in
+            switch result {
+            case .success(let json):
+                if let r = json["result"] as? [String: Any], let mid = r["message_id"] as? Int {
+                    completion(.success(mid))
+                } else {
+                    completion(.failure(TelegramError.malformedResponse))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
     func editMessageText(chatId: Int64, messageId: Int, text: String, completion: ((Result<Void, Error>) -> Void)?) {
         let params: [String: Any] = [
             "chat_id": chatId,

--- a/Tests/GavelTests/FakeTelegramTransport.swift
+++ b/Tests/GavelTests/FakeTelegramTransport.swift
@@ -3,6 +3,7 @@ import Foundation
 
 final class FakeTelegramTransport: TelegramTransport {
     var sentMessages: [(chatId: Int64, text: String, keyboard: [[TelegramButton]]?)] = []
+    var forceReplies: [(chatId: Int64, text: String, messageId: Int)] = []
     var edits: [(messageId: Int, text: String)] = []
     var answers: [(id: String, text: String?)] = []
     private var nextMessageId = 100
@@ -11,6 +12,13 @@ final class FakeTelegramTransport: TelegramTransport {
         sentMessages.append((chatId, text, keyboard))
         let mid = nextMessageId
         nextMessageId += 1
+        completion(.success(mid))
+    }
+
+    func sendForceReply(chatId: Int64, text: String, completion: @escaping (Result<Int, Error>) -> Void) {
+        let mid = nextMessageId
+        nextMessageId += 1
+        forceReplies.append((chatId, text, mid))
         completion(.success(mid))
     }
 

--- a/Tests/GavelTests/RemoteApprovalBridgeTests.swift
+++ b/Tests/GavelTests/RemoteApprovalBridgeTests.swift
@@ -262,6 +262,66 @@ final class RemoteApprovalBridgeTests: XCTestCase {
         XCTAssertTrue(logs.contains { $0.hasPrefix("coalesced") })
     }
 
+    func testDenyWithReasonButtonOffered() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        bridge.notify(resolvable: ResolvableApproval { _ in }, text: "approve?", allowSession: nil)
+        XCTAssertTrue(fake.lastCallbackData.contains { $0.hasPrefix("dr:") })
+    }
+
+    func testDenyWithReasonButtonIssuesForceReplyWithoutResolving() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var resolved: Decision?
+        let approval = ResolvableApproval { resolved = $0 }
+
+        bridge.notify(resolvable: approval, text: "approve?", toolName: "Bash", allowSession: nil)
+        let n = nonce(from: fake.lastCallbackData)
+        bridge.handle(callbackUpdate(action: "dr", nonce: n, fromId: owner, chatId: owner, messageId: fake.lastSentMessageId))
+
+        XCTAssertNil(resolved)
+        XCTAssertEqual(fake.forceReplies.count, 1)
+        XCTAssertTrue(fake.forceReplies.last?.text.contains("Bash") == true)
+        XCTAssertEqual(fake.answers.last?.text, "Reply with a reason")
+    }
+
+    func testReplyToForceReplyPromptDeniesCorrectApproval() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var r1: Decision?
+        var r2: Decision?
+        bridge.notify(resolvable: ResolvableApproval { r1 = $0 }, text: "a1", allowSession: nil)
+        let firstNonce = nonce(from: fake.lastCallbackData)
+        bridge.notify(resolvable: ResolvableApproval { r2 = $0 }, text: "a2", allowSession: nil)
+
+        bridge.handle(callbackUpdate(action: "dr", nonce: firstNonce, fromId: owner, chatId: owner, messageId: 100))
+        let promptMid = fake.forceReplies.last!.messageId
+        bridge.handle(typedReply("looks unsafe", replyTo: promptMid))
+
+        XCTAssertEqual(r1?.verdict, .block)
+        XCTAssertEqual(r1?.reason, "Denied from phone — looks unsafe")
+        XCTAssertNil(r2)
+    }
+
+    func testReplyToForceReplyPromptAfterResolutionIsNoOp() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var resolveCount = 0
+        var resolved: Decision?
+        let approval = ResolvableApproval { resolved = $0; resolveCount += 1 }
+
+        bridge.notify(resolvable: approval, text: "approve?", allowSession: nil)
+        let n = nonce(from: fake.lastCallbackData)
+        bridge.handle(callbackUpdate(action: "dr", nonce: n, fromId: owner, chatId: owner, messageId: fake.lastSentMessageId))
+        let promptMid = fake.forceReplies.last!.messageId
+
+        approval.resolve(Decision(verdict: .block, reason: "denied on mac"), from: .mac)
+        bridge.handle(typedReply("too late", replyTo: promptMid))
+
+        XCTAssertEqual(resolveCount, 1)
+        XCTAssertEqual(resolved?.reason, "denied on mac")
+    }
+
     func testWithheldApprovalIsResolvableFromPhoneWithButtons() {
         let fake = FakeTelegramTransport()
         let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)


### PR DESCRIPTION
## What

Adds an inline **🛑 Deny w/ reason** button to the Telegram approval mirror. Tapping it sends a Telegram ForceReply prompt; the typed reply resolves *that specific* pending approval as a block with reason `Denied from phone — <text>`.

Closes the gap where deny-with-reason was only reachable via swipe-reply or a bare typed reply (the latter only when exactly one approval is pending).

## How (Pattern A — ForceReply + nonce)

- `notify()` adds a fourth button with `callback_data` `dr:<nonce>`.
- `handleCallback` special-cases `dr`: does **not** resolve or `forget` the nonce; sends a ForceReply prompt and records `promptMessageId → nonce`; answers the callback so the button stops spinning.
- `TelegramTransport` gains `sendForceReply(...)`; `URLSessionTelegramTransport` implements it with `reply_markup = {"force_reply": true, "selective": true}`.
- `handleMessage` resolves a reply whose `reply_to_message_id` is the prompt id via the existing `.target` path. The `promptToNonce` map is purged in `forget()`, so a reply after the approval was resolved elsewhere is a no-op.

Pattern B (`switch_inline_query_current_chat`) was rejected — `callback_data` can't pre-fill a draft; ForceReply is the mechanism.

## Tests

4 new tests mirroring the existing RemoteApprovalBridge suite (button offered; ForceReply issued without resolving; reply targets the correct nonce as block-with-reason; reply after resolution is a no-op). Full suite: **607 tests, 0 failures**.

## Verification

Dogfooded live through the dev daemon over real Telegram: deny-with-reason blocked tool calls with the typed reason end-to-end across multiple resolutions; the local panel stayed authoritative.
