### PR TITLE
fix(monitor): serialize gavelLog writes to stop concurrent-write log drops

### DIFF
--- a/Sources/Gavel/System/LogWriter.swift
+++ b/Sources/Gavel/System/LogWriter.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Serializes log-line appends to one file so concurrent writers can't drop or tear lines.
+final class LogWriter {
+    private let path: String
+    private let lock = NSLock()
+
+    init(path: String) {
+        self.path = path
+    }
+
+    func append(_ line: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let fh = FileHandle(forWritingAtPath: path) {
+            fh.seekToEndOfFile()
+            fh.write(Data(line.utf8))
+            fh.closeFile()
+        } else {
+            FileManager.default.createFile(atPath: path, contents: Data(line.utf8))
+        }
+    }
+}
+
+let gavelLogWriter = LogWriter(
+    path: FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".claude/gavel/gavel.log").path
+)

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -370,20 +370,9 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
 
 // MARK: - Launch
 
-// Crash logging — write last words before dying
-let logPath = FileManager.default.homeDirectoryForCurrentUser
-    .appendingPathComponent(".claude/gavel/gavel.log").path
-
 func gavelLog(_ msg: String) {
     let ts = ISO8601DateFormatter().string(from: Date())
-    let line = "[\(ts)] \(msg)\n"
-    if let fh = FileHandle(forWritingAtPath: logPath) {
-        fh.seekToEndOfFile()
-        fh.write(Data(line.utf8))
-        fh.closeFile()
-    } else {
-        FileManager.default.createFile(atPath: logPath, contents: Data(line.utf8))
-    }
+    gavelLogWriter.append("[\(ts)] \(msg)\n")
 }
 
 // Catch uncaught exceptions

--- a/Tests/GavelTests/LogWriterTests.swift
+++ b/Tests/GavelTests/LogWriterTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Gavel
+
+/// Hammers LogWriter from many threads to prove serialized appends drop or tear no lines.
+final class LogWriterTests: XCTestCase {
+
+    private var path = ""
+
+    override func setUp() {
+        super.setUp()
+        path = NSTemporaryDirectory() + "logwriter-\(UUID().uuidString).log"
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: path)
+        super.tearDown()
+    }
+
+    func testConcurrentAppendsDropNoLines() {
+        let writer = LogWriter(path: path)
+        let threads = 16
+        let perThread = 500
+        let total = threads * perThread
+
+        DispatchQueue.concurrentPerform(iterations: threads) { t in
+            for i in 0..<perThread {
+                writer.append("thread=\(t) seq=\(i)\n")
+            }
+        }
+
+        let contents = try! String(contentsOfFile: path, encoding: .utf8)
+        let lines = contents.split(separator: "\n", omittingEmptySubsequences: true)
+        XCTAssertEqual(lines.count, total, "expected every appended line to survive")
+
+        var seen = Set<String>()
+        for line in lines {
+            XCTAssertTrue(
+                line.range(of: #"^thread=\d+ seq=\d+$"#, options: .regularExpression) != nil,
+                "torn or interleaved line: \(line)"
+            )
+            seen.insert(String(line))
+        }
+        XCTAssertEqual(seen.count, total, "expected every line to be unique and present")
+    }
+}


### PR DESCRIPTION
## Root cause (confirmed, two-witness + symbolicated)

`gavelLog` opened a fresh `FileHandle` per call → `seekToEndOfFile()` → `write()` → `closeFile()` with **no serialization** (`Sources/Gavel/main.swift:377`). Multiple threads call it concurrently:

- `com.gavel.socket` is a **`.concurrent`** queue (`SocketServer.swift:11`)
- the Telegram resolve path (`RemoteApprovalBridge.handleMessage` → `remoteLog`) runs on URLSession completion + `DispatchQueue.global(.utility)` rearm threads
- plus `HookRouter`, `SessionManager`, `main`

Two callers can each `seekToEndOfFile` to the same offset N and both `write` at N — the second write **overwrites** the first, dropping a whole line (not merely interleaving). That is exactly the dropped `[remote] resolved … action=deny-reason won=true` audit line seen while dogfooding PR #156.

## Fix

Route all appends through a single `LogWriter` guarded by an `NSLock` (the repo's house lock idiom). Kept **synchronous** so crash/signal handlers still flush their last words before `exit()`.

The shared `LogWriter` instance is a **lazy global in `LogWriter.swift`**, not a top-level statement in `main.swift`. This matters: `main.swift` top-level `let`s are the executable's sequential main-entry and never run under the xctest harness — declaring the writer there left it uninitialized in tests and crashed with a bad-pointer dereference (`0x20`) the moment a test drove a real path into `gavelLog`. Lazy globals in a regular file are `swift_once`-guarded and safe in every target.

## Tests

- New `Tests/GavelTests/LogWriterTests.swift` hammers `LogWriter` from 16 threads × 500 appends (8000 lines) and asserts every line survives, is unique, and is well-formed (no torn/interleaved lines).
- `swift build` green; `swift test` **608 tests, 0 failures**, confirmed stable across 5 consecutive runs (the uninitialized-global crash is gone).

Scope `monitor` per the gavel logging primitive; release-please parses the PR title.