### PR TITLE
Name spawned/remote sessions via GAVEL_SESSION_NAME

### DIFF
--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -56,6 +56,9 @@ final class HookRouter {
         case .sessionStart(let payload):
             if let sid = payload.sessionId { sessionManager.recordSessionId(sid, on: session) }
             if let cwd = payload.cwd { sessionManager.recordCwd(cwd, on: session) }
+            if let name = payload.sessionName {
+                sessionManager.updateLabel(name, on: session, sessionId: payload.sessionId)
+            }
             // Worker thread → main for the @Published write.
             let model = payload.model
             DispatchQueue.main.async { session.model = model }

--- a/Sources/Gavel/Models/HookEvent.swift
+++ b/Sources/Gavel/Models/HookEvent.swift
@@ -172,6 +172,7 @@ struct SessionStartPayload: Codable {
     let source: String?  // startup, resume, clear, compact
     let model: String?
     let requestRemoteApproval: Bool?
+    let sessionName: String?
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
@@ -179,6 +180,7 @@ struct SessionStartPayload: Codable {
         case source
         case model
         case requestRemoteApproval = "request_remote_approval"
+        case sessionName = "session_name"
     }
 }
 

--- a/Sources/GavelHook/main.swift
+++ b/Sources/GavelHook/main.swift
@@ -61,11 +61,17 @@ var envelope: [String: Any] = [
 let requestsRemoteApproval = ["1", "true", "yes"].contains(
     (ProcessInfo.processInfo.environment["GAVEL_REQUEST_PHONE"] ?? "").lowercased())
 
+let spawnedSessionName = (ProcessInfo.processInfo.environment["GAVEL_SESSION_NAME"] ?? "")
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+
 // Merge stdin JSON as payload (add "type" discriminator for daemon decoding)
 if var payload = stdinJson {
     payload["type"] = hookType
     if hookType == "SessionStart", requestsRemoteApproval {
         payload["request_remote_approval"] = true
+    }
+    if hookType == "SessionStart", !spawnedSessionName.isEmpty {
+        payload["session_name"] = spawnedSessionName
     }
     envelope["payload"] = payload
 }

--- a/Tests/GavelTests/RemoteSessionNameTests.swift
+++ b/Tests/GavelTests/RemoteSessionNameTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Gavel
+
+final class RemoteSessionNameTests: XCTestCase {
+
+    func testSessionStartPayloadDecodesSessionName() throws {
+        let json = #"{"type":"SessionStart","session_id":"abc","cwd":"/tmp/x","session_name":"openspec-play"}"#
+        let payload = try JSONDecoder().decode(SessionStartPayload.self, from: Data(json.utf8))
+        XCTAssertEqual(payload.sessionName, "openspec-play")
+        XCTAssertEqual(payload.sessionId, "abc")
+    }
+
+    func testSessionStartPayloadSessionNameNilWhenAbsent() throws {
+        let json = #"{"type":"SessionStart","session_id":"abc"}"#
+        let payload = try JSONDecoder().decode(SessionStartPayload.self, from: Data(json.utf8))
+        XCTAssertNil(payload.sessionName)
+    }
+
+    func testUpdateLabelAppliesExplicitNonDerivedName() {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gavel-remotename-\(UUID().uuidString)")
+        let manager = SessionManager(homeDir: tmp, autoStartTimers: false, autoDiscover: false)
+        let session = manager.session(for: 83001)
+        session.sessionId = "sid-1"
+        manager.updateLabel("openspec-play", on: session, sessionId: "sid-1")
+        let exp = expectation(description: "main queue drained")
+        DispatchQueue.main.async { exp.fulfill() }
+        wait(for: [exp], timeout: 1)
+        XCTAssertEqual(session.label, "openspec-play")
+        XCTAssertFalse(session.labelIsDerived)
+    }
+}

--- a/Tests/GavelTests/RenameHandlerTests.swift
+++ b/Tests/GavelTests/RenameHandlerTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Gavel
+
+final class RenameHandlerTests: XCTestCase {
+
+    private func isolatedManager() -> SessionManager {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gavel-rename-tests-\(UUID().uuidString)")
+        return SessionManager(homeDir: tmp, autoStartTimers: false, autoDiscover: false)
+    }
+
+    private func event(_ line: String) -> JsonlEvent {
+        JsonlEvent(rawLine: line, json: nil, sessionId: "s", cwd: "/tmp")
+    }
+
+    private func drainMain() {
+        let exp = expectation(description: "main queue drained")
+        DispatchQueue.main.async { exp.fulfill() }
+        wait(for: [exp], timeout: 1)
+    }
+
+    func testCustomTitleLineSetsExplicitLabel() {
+        let manager = isolatedManager()
+        let session = manager.session(for: 82001)
+        RenameHandler().handle(
+            event(#"{"type":"custom-title","customTitle":"personal-assistant-jun","sessionId":"s"}"#),
+            manager: manager, session: session)
+        drainMain()
+        XCTAssertEqual(session.label, "personal-assistant-jun")
+        XCTAssertFalse(session.labelIsDerived)
+    }
+
+    func testRenameCommandBlockSetsLabel() {
+        let manager = isolatedManager()
+        let session = manager.session(for: 82002)
+        RenameHandler().handle(
+            event("<command-message>rename</command-message> x <command-args>my-new-name</command-args>"),
+            manager: manager, session: session)
+        drainMain()
+        XCTAssertEqual(session.label, "my-new-name")
+        XCTAssertFalse(session.labelIsDerived)
+    }
+
+    func testNonMatchingLineLeavesLabelUnchanged() {
+        let manager = isolatedManager()
+        let session = manager.session(for: 82003)
+        session.label = "keep-me"
+        session.labelIsDerived = true
+        RenameHandler().handle(event(#"{"type":"user","message":"hello"}"#),
+                               manager: manager, session: session)
+        drainMain()
+        XCTAssertEqual(session.label, "keep-me")
+        XCTAssertTrue(session.labelIsDerived)
+    }
+}


### PR DESCRIPTION
## Problem

Spawned and remote-control sessions show blank (`Name…`) in the monitor, and a `/rename` on them never lands. Root cause is upstream: remote/headless sessions don't persist a local transcript (anthropics/claude-code#68488, #38313), and Gavel's naming is entirely transcript-based (seed via `JsonlRenameReader` + live via `JsonlWatcher`/`RenameHandler`). No local file → no name, ever.

## Change

Push the name through a side-channel that doesn't depend on the transcript, reusing the existing `GAVEL_REQUEST_PHONE` passthrough shape:

- `gavel-hook` reads `GAVEL_SESSION_NAME` and forwards it as `session_name` on SessionStart
- `SessionStartPayload` decodes it
- `HookRouter` applies it via `updateLabel` as an explicit (non-derived) label

## Testing

- Full suite 613/613 green, including 6 new tests: the previously-untested `RenameHandler` paths (custom-title + rename command-block) and the `session_name` decode/apply path.
- Verified live by swapping this build in: a spawn produced `label='gavel-name-proof-v2' der=false` within ~2s, where the old hook left it `None`.

## Depends on

The spawner has to set the env var: JaysonRawlins/claude-config `fix/spawn-session-naming` (spawn.sh `--name` + `GAVEL_SESSION_NAME`). The hook change here is inert without it, and only goes live once this ships as the installed `gavel-hook`.

## Known limitation

This names sessions at spawn time. An ad-hoc `/rename` typed into an already-running remote/mobile session still can't be reflected locally — that needs anthropics/claude-code#68488 / #38313 to be fixed upstream.