### PR TITLE
feat(session): default phone toggle + [[/stop-phone]] emergency hatch

### DIFF
--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -380,9 +380,8 @@ final class HookRouter {
 
     /// Raise a non-overridable, fail-closed, phone-mirrored approval that enables per-session remote approval only if allowed.
     private func requestRemoteApprovalToggle(session: Session, timestamp: Date) {
-        let hours = GavelConstants.remoteApprovalDefaultHours
         let location = session.cwd.map { " — \($0)" } ?? ""
-        let reason = "Session pid \(session.pid)\(location) requests PHONE (remote) approval. Allow enables it for \(hours)h; deny or ignore leaves it OFF."
+        let reason = "Session pid \(session.pid)\(location) requests PHONE (remote) approval. Allow enables it until you go idle or send [[/stop-phone]]; deny or ignore leaves it OFF."
         let payload = PreToolUsePayload(toolName: "__EnableRemoteApproval", toolInput: [:])
         DispatchQueue.global().async { [weak self] in
             guard let self else { return }
@@ -395,10 +394,9 @@ final class HookRouter {
                 triggerReason: reason
             )
             if decision.verdict == .allow {
-                let until = Date().addingTimeInterval(Double(hours) * 3600)
-                session.setRemoteApprovalEnabled(true, until: until)
+                session.setRemoteApprovalEnabled(true, until: nil)
                 self.sessionManager.saveActiveSessions()
-                self.emitFeed(.system("Remote (phone) approval ENABLED for \(hours)h", pid: session.pid, at: timestamp))
+                self.emitFeed(.system("Remote (phone) approval ENABLED", pid: session.pid, at: timestamp))
             } else {
                 self.emitFeed(.system("Remote (phone) approval request denied", pid: session.pid, at: timestamp))
             }

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -14,6 +14,11 @@ final class SessionManager: ObservableObject {
     @Published var defaultSubAgentInherit: Bool = false
     @Published var defaultPaused: Bool = false
 
+    @Published var defaultRemoteApprove: Bool = false
+
+    /// Fired after an emergency phone-stop with the count of sessions that had phone on.
+    var onPhoneStopped: ((_ affected: Int) -> Void)?
+
     /// Inactivity threshold in minutes. 0 disables the timer.
     /// When the user hasn't interacted with gavel for this long, auto-approval
     /// is revoked across all sessions (walk-away defense).
@@ -75,6 +80,9 @@ final class SessionManager: ObservableObject {
         session.isAutoApproveEnabled = defaultAutoApprove
         session.isSubAgentInheritEnabled = defaultSubAgentInherit
         session.isPaused = defaultPaused
+        if defaultRemoteApprove && telegramChatId != nil {
+            session.setRemoteApprovalEnabled(true, until: nil)
+        }
         sessions[pid] = session
         saveActiveSessionsLocked()
         lock.unlock()
@@ -94,6 +102,7 @@ final class SessionManager: ObservableObject {
             "autoApprove": defaultAutoApprove,
             "subAgentInherit": defaultSubAgentInherit,
             "paused": defaultPaused,
+            "remoteApprove": defaultRemoteApprove,
             "inactivityTimeoutMinutes": inactivityTimeoutMinutes,
             "sessionLabels": sessionLabels
         ]
@@ -109,6 +118,7 @@ final class SessionManager: ObservableObject {
         defaultAutoApprove = (json["autoApprove"] as? Bool) ?? false
         defaultSubAgentInherit = (json["subAgentInherit"] as? Bool) ?? false
         defaultPaused = (json["paused"] as? Bool) ?? false
+        defaultRemoteApprove = (json["remoteApprove"] as? Bool) ?? false
         inactivityTimeoutMinutes = (json["inactivityTimeoutMinutes"] as? Int) ?? 15
         sessionLabels = (json["sessionLabels"] as? [String: String]) ?? [:]
         telegramChatId = (json["telegramChatId"] as? Int64) ?? (json["telegramChatId"] as? Int).map(Int64.init)
@@ -197,7 +207,7 @@ final class SessionManager: ObservableObject {
         let path = (NSHomeDirectory() as NSString)
             .appendingPathComponent(".claude/projects")
             .appending("/\(encoded)/\(sid).jsonl")
-        let handlers: [JsonlEventHandler] = [RenameHandler(), SecretHandler(), SkillTagHandler()]
+        let handlers: [JsonlEventHandler] = [RenameHandler(), SecretHandler(), SkillTagHandler(), StopPhoneHandler()]
         let dispatcher = JsonlEventDispatcher(handlers: handlers, manager: self, session: session)
         let watcher = JsonlWatcher(path: path, dispatcher: dispatcher)
         watchers[session.pid] = watcher
@@ -445,6 +455,9 @@ final class SessionManager: ObservableObject {
             session.isAutoApproveEnabled = defaultAutoApprove
             session.isSubAgentInheritEnabled = defaultSubAgentInherit
             session.isPaused = defaultPaused
+            if defaultRemoteApprove && telegramChatId != nil {
+                session.setRemoteApprovalEnabled(true, until: nil)
+            }
             sessions[pidInt] = session
             addedPids.append(pidInt)
         }
@@ -537,6 +550,22 @@ final class SessionManager: ObservableObject {
             self.saveActiveSessions()
             GavelNotifications.notify(title: "Gavel — Prompt Mode", body: reason)
             self.noteInteraction()
+        }
+    }
+
+    /// Emergency hatch: disables phone approval on every live session and clears Default Phone.
+    func stopAllPhone(reason: String = "stop-phone") {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            let affected = self.sessions.values.filter { $0.remoteApprovalSnapshot.enabled }.count
+            for session in self.sessions.values { session.disableRemoteApproval() }
+            self.defaultRemoteApprove = false
+            self.saveDefaults()
+            self.saveActiveSessions()
+            gavelLog("[stop-phone] \(reason) — disabled phone on \(affected) session(s), default off")
+            GavelNotifications.notify(title: "Gavel — Phone OFF", body: reason)
+            self.noteInteraction()
+            self.onPhoneStopped?(affected)
         }
     }
 

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -306,6 +306,23 @@ struct MonitorWindow: View {
                 .tint(.green)
                 .controlSize(.small)
                 .help("New sessions start with auto-approve enabled. Deny rules, prompt rules, and sensitive paths still force dialogs.")
+
+                Toggle(isOn: Binding(
+                    get: { viewModel.sessionManager.defaultRemoteApprove },
+                    set: { newVal in
+                        viewModel.sessionManager.defaultRemoteApprove = newVal
+                        viewModel.sessionManager.saveDefaults()
+                        viewModel.noteInteraction()
+                    }
+                )) {
+                    Text("Default Phone")
+                        .font(.caption)
+                }
+                .toggleStyle(.switch)
+                .tint(.purple)
+                .controlSize(.small)
+                .disabled(viewModel.sessionManager.telegramChatId == nil)
+                .help("New sessions start with phone (Telegram) approval enabled, no expiry — until you go idle (inactivity timeout) or send [[/stop-phone]]. Configure Telegram first.")
             }
         }
     }
@@ -546,8 +563,7 @@ private struct SessionRow: View {
                 Toggle("", isOn: Binding(
                     get: { session.isRemoteApprovalEnabledUI },
                     set: { newVal in
-                        let until = newVal ? Date().addingTimeInterval(Double(GavelConstants.remoteApprovalDefaultHours) * 3600) : nil
-                        session.setRemoteApprovalEnabled(newVal, until: until)
+                        session.setRemoteApprovalEnabled(newVal, until: nil)
                         viewModel.sessionManager.saveActiveSessions()
                         viewModel.noteInteraction()
                     }

--- a/Sources/Gavel/Observability/Handlers/StopPhoneHandler.swift
+++ b/Sources/Gavel/Observability/Handlers/StopPhoneHandler.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+final class StopPhoneHandler: JsonlEventHandler {
+    let name = "stop-phone"
+
+    private static let pattern = try! NSRegularExpression(
+        pattern: #"\[\[/stop-phone\]\]"#, options: [.caseInsensitive]
+    )
+
+    static func matches(_ text: String) -> Bool {
+        let range = NSRange(text.startIndex..., in: text)
+        return pattern.firstMatch(in: text, range: range) != nil
+    }
+
+    func handle(_ event: JsonlEvent, manager: SessionManager, session: Session) {
+        guard (event.json?["type"] as? String) == "user" else { return }
+        guard Self.matches(event.rawLine) else { return }
+        manager.stopAllPhone(reason: "[[/stop-phone]] in transcript (pid \(session.pid))")
+    }
+}

--- a/Sources/Gavel/Remote/RemoteApprovalBridge.swift
+++ b/Sources/Gavel/Remote/RemoteApprovalBridge.swift
@@ -41,6 +41,8 @@ final class RemoteApprovalBridge {
 
     /// Fired when pairing captures a chat id, so the daemon can persist it.
     var onPaired: ((Int64) -> Void)?
+    /// Fired when the pinned chat sends `[[/stop-phone]]`, so the daemon can kill phone approval.
+    var onStopPhone: (() -> Void)?
     /// Emits a token-redacted status line for the feed/log.
     var onStatus: ((String) -> Void)?
     /// Emits a gavel.log-only trail of remote sends/resolutions (no UI feed, no secrets).
@@ -126,6 +128,13 @@ final class RemoteApprovalBridge {
         }
     }
 
+    /// Send an unsolicited, keyboard-less notice to the pinned chat (e.g. a stop-phone confirmation).
+    func sendNotice(_ text: String) {
+        lock.lock(); let chat = chatId; lock.unlock()
+        guard let chat else { return }
+        transport.sendMessage(chatId: chat, text: text, keyboard: nil, completion: { _ in })
+    }
+
     // MARK: - Inbound poll loop
 
     private func pollOnce() {
@@ -189,6 +198,11 @@ final class RemoteApprovalBridge {
 
         guard let pinned, message.chatId == pinned, message.fromId == pinned else { return }
         guard let text = message.text, !text.isEmpty, !text.hasPrefix("/") else { return }
+        if StopPhoneHandler.matches(text) {
+            remoteLog?("stop-phone command received")
+            onStopPhone?()
+            return
+        }
         switch typedReplyTarget(replyTo: message.replyToMessageId) {
         case .target(let corr):
             forget(corr.nonce)

--- a/Sources/Gavel/System/Constants.swift
+++ b/Sources/Gavel/System/Constants.swift
@@ -54,10 +54,6 @@ enum GavelConstants {
     /// Max characters of the redacted command shown in a Telegram approval (under Telegram's 4096 limit).
     static let telegramBodyMaxChars = 3500
 
-    /// Default lifetime of a per-session remote-approval grant, in hours.
-    /// Mirrors timed auto-approve: a walk-away with remote left on is the worst case.
-    static let remoteApprovalDefaultHours = 8
-
     /// Minimum length of an alphanumeric run treated as credential-shaped by the
     /// credential gate's entropy heuristic.
     static let credentialEntropyRunLength = 20

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -111,6 +111,12 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
             }
         }
         bridge.remoteLog = { gavelLog("[remote] \($0)") }
+        bridge.onStopPhone = { [weak self] in
+            self?.sessionManager.stopAllPhone(reason: "[[/stop-phone]] from Telegram")
+        }
+        sessionManager.onPhoneStopped = { [weak bridge] affected in
+            bridge?.sendNotice("🛑 Phone approval OFF — \(affected) session(s) disabled, Default Phone off.")
+        }
         approvalCoordinator.remoteBridge = bridge
         remoteBridge = bridge
         bridge.start()

--- a/Tests/GavelTests/DefaultPhoneTests.swift
+++ b/Tests/GavelTests/DefaultPhoneTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import Gavel
+
+final class DefaultPhoneTests: XCTestCase {
+
+    private func homeDir() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gavel-defaultphone-tests-\(UUID().uuidString)")
+    }
+
+    private func manager(_ home: URL) -> SessionManager {
+        SessionManager(homeDir: home, autoStartTimers: false, autoDiscover: false)
+    }
+
+    func testNewSessionInheritsPhoneWhenPaired() {
+        let m = manager(homeDir())
+        m.telegramChatId = 7
+        m.defaultRemoteApprove = true
+        let session = m.session(for: 92001)
+        XCTAssertTrue(session.isRemoteApprovalActive)
+        XCTAssertNil(session.remoteApprovalSnapshot.until)
+    }
+
+    func testNewSessionDoesNotInheritPhoneWhenUnpaired() {
+        let m = manager(homeDir())
+        m.telegramChatId = nil
+        m.defaultRemoteApprove = true
+        let session = m.session(for: 92002)
+        XCTAssertFalse(session.isRemoteApprovalActive)
+    }
+
+    func testNewSessionNoPhoneWhenDefaultOff() {
+        let m = manager(homeDir())
+        m.telegramChatId = 7
+        m.defaultRemoteApprove = false
+        let session = m.session(for: 92003)
+        XCTAssertFalse(session.isRemoteApprovalActive)
+    }
+
+    func testDefaultRemoteApproveRoundTrips() {
+        let home = homeDir()
+        let first = manager(home)
+        first.defaultRemoteApprove = true
+        first.saveDefaults()
+
+        let second = manager(home)
+        XCTAssertTrue(second.defaultRemoteApprove)
+    }
+
+    func testStopAllPhoneClearsSessionsAndDefault() {
+        let m = manager(homeDir())
+        m.telegramChatId = 7
+        m.defaultRemoteApprove = true
+        let a = m.session(for: 92010)
+        let b = m.session(for: 92011)
+
+        let stopped = expectation(description: "stopped")
+        m.onPhoneStopped = { affected in
+            XCTAssertEqual(affected, 2)
+            stopped.fulfill()
+        }
+        m.stopAllPhone()
+        wait(for: [stopped], timeout: 2)
+
+        XCTAssertFalse(a.remoteApprovalSnapshot.enabled)
+        XCTAssertFalse(b.remoteApprovalSnapshot.enabled)
+        XCTAssertFalse(m.defaultRemoteApprove)
+    }
+}

--- a/Tests/GavelTests/RemoteApprovalBridgeTests.swift
+++ b/Tests/GavelTests/RemoteApprovalBridgeTests.swift
@@ -336,4 +336,35 @@ final class RemoteApprovalBridgeTests: XCTestCase {
 
         XCTAssertEqual(resolved?.verdict, .block)
     }
+
+    func testStopPhoneMessageFiresCallback() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var stopped = false
+        bridge.onStopPhone = { stopped = true }
+
+        bridge.handle(typedReply("[[/stop-phone]]"))
+
+        XCTAssertTrue(stopped)
+    }
+
+    func testStopPhoneFromWrongChatIgnored() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var stopped = false
+        bridge.onStopPhone = { stopped = true }
+
+        let foreign = TelegramUpdate(updateId: 9, callback: nil, message: TelegramIncomingMessage(fromId: 999, chatId: 999, text: "[[/stop-phone]]", replyToMessageId: nil))
+        bridge.handle(foreign)
+
+        XCTAssertFalse(stopped)
+    }
+
+    func testSendNoticePostsToPinnedChat() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        bridge.sendNotice("Phone off")
+        XCTAssertEqual(fake.sentMessages.last?.chatId, owner)
+        XCTAssertEqual(fake.sentMessages.last?.text, "Phone off")
+    }
 }

--- a/Tests/GavelTests/StopPhoneHandlerTests.swift
+++ b/Tests/GavelTests/StopPhoneHandlerTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Gavel
+
+final class StopPhoneHandlerTests: XCTestCase {
+
+    private func isolatedManager() -> SessionManager {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gavel-stopphone-tests-\(UUID().uuidString)")
+        return SessionManager(homeDir: tmp, autoStartTimers: false, autoDiscover: false)
+    }
+
+    private func event(_ line: String, type: String = "user") -> JsonlEvent {
+        JsonlEvent(rawLine: line, json: ["type": type], sessionId: "s", cwd: "/tmp")
+    }
+
+    func testMatchesMarker() {
+        XCTAssertTrue(StopPhoneHandler.matches("please [[/stop-phone]] now"))
+    }
+
+    func testMatchesCaseInsensitive() {
+        XCTAssertTrue(StopPhoneHandler.matches("[[/STOP-PHONE]]"))
+    }
+
+    func testIgnoresPlainText() {
+        XCTAssertFalse(StopPhoneHandler.matches("stop the phone please"))
+        XCTAssertFalse(StopPhoneHandler.matches("[[/stop]]"))
+    }
+
+    func testUserEntryDisablesPhoneEverywhere() {
+        let handler = StopPhoneHandler()
+        let manager = isolatedManager()
+        manager.telegramChatId = 7
+        manager.defaultRemoteApprove = true
+        let session = manager.session(for: 91001)
+        session.setRemoteApprovalEnabled(true, until: nil)
+
+        let stopped = expectation(description: "phone stopped")
+        manager.onPhoneStopped = { affected in
+            XCTAssertEqual(affected, 1)
+            stopped.fulfill()
+        }
+        handler.handle(event("[[/stop-phone]]"), manager: manager, session: session)
+        wait(for: [stopped], timeout: 2)
+
+        XCTAssertFalse(session.remoteApprovalSnapshot.enabled)
+        XCTAssertFalse(manager.defaultRemoteApprove)
+    }
+
+    func testNonUserEntryIgnored() {
+        let handler = StopPhoneHandler()
+        let manager = isolatedManager()
+        manager.defaultRemoteApprove = true
+
+        let notStopped = expectation(description: "callback not fired")
+        notStopped.isInverted = true
+        manager.onPhoneStopped = { _ in notStopped.fulfill() }
+        handler.handle(event("[[/stop-phone]]", type: "assistant"), manager: manager, session: manager.session(for: 91002))
+        wait(for: [notStopped], timeout: 0.5)
+
+        XCTAssertTrue(manager.defaultRemoteApprove)
+    }
+}


### PR DESCRIPTION
## What

Two phone-approval features plus a consistency fix.

**Default Phone** — a persistent toggle (next to `Default Auto`) so new sessions inherit Telegram approval automatically. Gated to when a chat is paired; persisted in `session-defaults.json`. No per-session expiry.

**`[[/stop-phone]]` emergency hatch** — disables phone approval on every live session and clears the `Default Phone` setting. Reachable two ways:
- **Telegram:** a message to the pinned chat (identity-gated — only your chat can trigger it)
- **Transcript:** a `[[/stop-phone]]` marker in a user entry (own handler, gated to user entries so assistant/tool echoes can't trip it)

Both confirm back to the phone.

**Asymmetry fix** — all three phone-enable paths (manual toggle, default inheritance, spawn-remote bootstrap) now mint no expiry. Auto-off is uniform: 15-min inactivity timeout, manual off, or `[[/stop-phone]]`. Removes the dead `remoteApprovalDefaultHours` constant and stale "8h" user-facing copy.

## Safety notes

- `[[/stop-phone]]` fails **safe**: turning phone off only removes a remote-approval path; the Mac panel stays authoritative. A stray marker in tool-result text disables phone you wanted on — never the reverse. Same fail-direction as the existing skill-tag scan.
- The credential gate is untouched and still non-disableable.

## Tests

627 pass. New: `StopPhoneHandlerTests` (5), `DefaultPhoneTests` (5 — inheritance, pairing gate, persistence round-trip, stop-all), bridge stop-phone (3).