### PR TITLE
feat(matcher): gate mutating kubectl verbs, hard-prompt prod context

### DIFF
--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -24,7 +24,7 @@ final class RuleStore: ObservableObject {
     )
 
     /// Current seed version — bump when adding new default rules.
-    private static let seedVersion = 11
+    private static let seedVersion = 12
 
     /// Built-in patterns replaced by a corrected/broadened seeded rule. On re-seed
     /// these are dropped from existing rules.json so a pattern fix swaps cleanly
@@ -333,6 +333,25 @@ final class RuleStore: ObservableObject {
             verdict: .prompt,
             explanation: "Infrastructure apply/destroy — review the changeset/plan before mutating real resources",
             builtIn: true
+        ),
+
+        PersistentRule(
+            toolName: "Bash",
+            pattern: "\\b(kubectl|kubectl\\.\\S+|k)\\b(\\s+-{1,2}\\S+(\\s+\\S+)?)*\\s+(rollout|delete|apply|scale|patch|drain|cordon|uncordon|edit|replace|annotate|label|set|create|taint|rollback)\\b",
+            isRegex: true,
+            verdict: .prompt,
+            explanation: "Mutating kubectl verb against a live cluster — review the target before changing cluster state",
+            builtIn: true
+        ),
+
+        PersistentRule(
+            toolName: "Bash",
+            pattern: "\\b(kubectl|kubectl\\.\\S+|k)\\b(?=[^&|;]*\\b(rollout|delete|apply|scale|patch|drain|cordon|uncordon|edit|replace|annotate|label|set|create|taint|rollback)\\b)(?=[^&|;]*(--(context|cluster)(=|\\s+)\\S*prod|\\b[a-z0-9]+-prod\\b|\\bprod-[a-z0-9-]+\\b))",
+            isRegex: true,
+            verdict: .prompt,
+            explanation: "Mutating kubectl against a PROD context — prod cluster mutations must never auto-pass",
+            builtIn: true,
+            overridable: false
         ),
 
         // ── Persistence-creating scheduler tools ──

--- a/Tests/GavelTests/PersistentRuleTests.swift
+++ b/Tests/GavelTests/PersistentRuleTests.swift
@@ -185,11 +185,7 @@ final class PersistentRuleTests: XCTestCase {
         let store = RuleStore(configPath: "/dev/null")
         let builtInRules = store.rules.filter { $0.builtIn }
         XCTAssertEqual(builtInRules.count, RuleStore.seededDefaults.count)
-        // v11: 5 MCP exfil + 1 Bash self-protection + 1 ANTHROPIC_BASE_URL
-        //      + 1 apply_patch self-protection + 2 container bind-mount self-protection
-        //      + 1 scripting + 3 sandbox escape + 2 git safety + 1 commit checkpoint
-        //      + 1 infra apply + 3 scheduler = 21
-        XCTAssertEqual(builtInRules.count, 21)
+        XCTAssertEqual(builtInRules.count, 23)
     }
 
     func testSeededRulesArePromptVerdict() {
@@ -227,6 +223,95 @@ final class PersistentRuleTests: XCTestCase {
             "command": AnyCodable("python3 test_script.py")
         ])
         XCTAssertNil(store.evaluateBuiltInPrompt(payload: payload))
+    }
+
+    // MARK: - Mutating kubectl built-in
+
+    private func kubectlPrompts(_ command: String, file: StaticString = #filePath, line: UInt = #line) {
+        let store = RuleStore(configPath: "/dev/null")
+        let payload = PreToolUsePayload(toolName: "Bash", toolInput: ["command": AnyCodable(command)])
+        let decision = store.evaluateBuiltInPrompt(payload: payload)
+        XCTAssertNotNil(decision, "Expected prompt for: \(command)", file: file, line: line)
+        XCTAssertTrue(decision?.askUser ?? false, file: file, line: line)
+    }
+
+    private func kubectlUngated(_ command: String, file: StaticString = #filePath, line: UInt = #line) {
+        let store = RuleStore(configPath: "/dev/null")
+        let payload = PreToolUsePayload(toolName: "Bash", toolInput: ["command": AnyCodable(command)])
+        XCTAssertNil(store.evaluateBuiltInPrompt(payload: payload), "Expected ungated for: \(command)", file: file, line: line)
+        XCTAssertNil(store.evaluateBuiltInPromptNonOverridable(payload: payload), "Expected ungated for: \(command)", file: file, line: line)
+    }
+
+    func testKubectlRolloutRestartPrompts() {
+        kubectlPrompts("kubectl rollout restart ds/fluent-bit -n monitoring")
+    }
+
+    func testKubectlDeletePrompts() {
+        kubectlPrompts("kubectl delete pod nginx -n default")
+    }
+
+    func testKubectlScaleWithLeadingFlagsPrompts() {
+        kubectlPrompts("kubectl --context balcony-dev -n monitoring scale deploy/web --replicas=0")
+    }
+
+    func testKubectlAliasPrompts() {
+        kubectlPrompts("k drain node-1 --ignore-daemonsets")
+    }
+
+    func testKubectlChainedSegmentPrompts() {
+        kubectlPrompts("kubectl get pods && kubectl delete pod nginx")
+    }
+
+    func testKubectlGetIsUngated() {
+        kubectlUngated("kubectl get pods -n monitoring")
+    }
+
+    func testKubectlLogsIsUngated() {
+        kubectlUngated("kubectl logs deploy/web -n monitoring --tail 100")
+    }
+
+    func testKubectlDescribeOfVerbNamedResourceIsUngated() {
+        kubectlUngated("kubectl describe deployment apply-server -n default")
+    }
+
+    func testKubectlReadPipedToVerbWordIsUngated() {
+        kubectlUngated("kubectl get pods -o yaml | grep apply")
+    }
+
+    func testKubectlProdMutationIsNonOverridable() {
+        let store = RuleStore(configPath: "/dev/null")
+        let payload = PreToolUsePayload(toolName: "Bash", toolInput: [
+            "command": AnyCodable("kubectl --context balcony-prod delete pod nginx")
+        ])
+        let decision = store.evaluateBuiltInPromptNonOverridable(payload: payload)
+        XCTAssertNotNil(decision, "Prod kubectl mutation must hit the non-overridable checkpoint")
+        XCTAssertTrue(decision?.askUser ?? false)
+    }
+
+    func testKubectlProdReadStaysUngated() {
+        let store = RuleStore(configPath: "/dev/null")
+        let payload = PreToolUsePayload(toolName: "Bash", toolInput: [
+            "command": AnyCodable("kubectl --context balcony-prod get pods")
+        ])
+        XCTAssertNil(store.evaluateBuiltInPromptNonOverridable(payload: payload))
+        XCTAssertNil(store.evaluateBuiltInPrompt(payload: payload))
+    }
+
+    func testKubectlProdClusterNameMutationIsNonOverridable() {
+        let store = RuleStore(configPath: "/dev/null")
+        let payload = PreToolUsePayload(toolName: "Bash", toolInput: [
+            "command": AnyCodable("kubectl --cluster prod-east scale deploy/web --replicas=3")
+        ])
+        XCTAssertNotNil(store.evaluateBuiltInPromptNonOverridable(payload: payload))
+    }
+
+    func testKubectlNonProductWordDoesNotTriggerProdTier() {
+        let store = RuleStore(configPath: "/dev/null")
+        let payload = PreToolUsePayload(toolName: "Bash", toolInput: [
+            "command": AnyCodable("kubectl delete pod my-product-cache -n default")
+        ])
+        XCTAssertNil(store.evaluateBuiltInPromptNonOverridable(payload: payload), "\"product\" must not be read as a prod marker")
+        XCTAssertNotNil(store.evaluateBuiltInPrompt(payload: payload), "but it is still a mutating verb → overridable prompt")
     }
 
     // MARK: - Codex apply_patch self-protection built-in


### PR DESCRIPTION
## Problem

Observed in a live EKS session: `kubectl rollout restart ds/fluent-bit -n monitoring` — a state-changing write against a live cluster — ran with **no Gavel prompt**. The existing infra-apply default rule (`RuleStore.swift`) only matched `kubectl apply|delete`, so every other mutating verb (`rollout`, `scale`, `drain`, `cordon`, `patch`, …) slipped through. The same command against a prod cluster would be far more dangerous.

## Change

Two new built-in `PersistentRule`s, modeled on the existing scripting-interpreter rule:

1. **Mutating-verb gate** (overridable prompt) — matches the full verb set (`rollout delete apply scale patch drain cordon uncordon edit replace annotate label set create taint rollback`) in the kubectl **subcommand slot**, using the same flag-skip trick as the git-commit rule so the verb must sit where a real kubectl verb sits. This keeps reads like `kubectl describe deploy apply-server` (resource *named* apply-server) ungated. Covers the `k` alias, `kubectl.<ver>` binaries, and `&&`/`|`/`;` chaining via per-segment matching.

2. **Prod-context gate** (non-overridable prompt) — fires only when a mutating verb **and** a prod marker (`--context …prod…`, `*-prod`/`prod-*` cluster names) appear in the same command segment. Marked `overridable: false`, so it runs before allow-rules and auto-approve (`ApprovalEngine.swift:26`) — prod mutations never auto-pass. Reads against prod stay ungated; `product`-style words don't trip it.

Read verbs (`get`, `logs`, `describe`, `top`, …) remain ungated. `seedVersion` bumped 11→12 so existing `rules.json` files re-seed.

## Tests

13 new cases in `PersistentRuleTests` (alias, leading flags, chained segments, piped-read false-positive, prod non-overridable, prod-read-ungated, `product` non-trigger). Built-in count assertion 21→23. Full suite: 583 passing.

## Verified live

Swapped the build into the running daemon and fired real commands:
- `kubectl rollout restart …` → surfaced an approval (`Default rule:` trigger), approved, ran.
- `kubectl --context …prod… delete …` → surfaced the **`Checkpoint:`** (non-overridable) trigger, denied from phone, execution blocked.