### PR TITLE
feat(notifications): allow-with-note ForceReply on phone approvals

### DIFF
--- a/Sources/Gavel/Remote/RemoteApprovalBridge.swift
+++ b/Sources/Gavel/Remote/RemoteApprovalBridge.swift
@@ -27,7 +27,7 @@ final class RemoteApprovalBridge {
     private let redact: (String) -> String
     private let lock = NSLock()
     private var byNonce: [String: Correlation] = [:]
-    private var promptToNonce: [Int: String] = [:]
+    private var promptReplies: [Int: PendingReply] = [:]
     private var pendingOrder: [String] = []
     private var offset = 0
     private var running = false
@@ -106,7 +106,8 @@ final class RemoteApprovalBridge {
             [TelegramButton(text: "✅ Allow once", callbackData: "a:\(nonce)"),
              TelegramButton(text: "🛑 Deny", callbackData: "d:\(nonce)")],
             [TelegramButton(text: "✅ Allow for session", callbackData: "s:\(nonce)")],
-            [TelegramButton(text: "🛑 Deny w/ reason", callbackData: "dr:\(nonce)")]
+            [TelegramButton(text: "✅ Allow w/ note", callbackData: "ar:\(nonce)"),
+             TelegramButton(text: "🛑 Deny w/ reason", callbackData: "dr:\(nonce)")]
         ]
         if offerCommentClean {
             keyboard.append([TelegramButton(text: "🧹 Clean comments & re-propose", callbackData: "c:\(nonce)")])
@@ -204,13 +205,13 @@ final class RemoteApprovalBridge {
             return
         }
         switch typedReplyTarget(replyTo: message.replyToMessageId) {
-        case .target(let corr):
+        case .target(let corr, let kind):
             forget(corr.nonce)
-            let decision = Decision(verdict: .block, reason: "Denied from phone — \(text)")
+            let decision = Self.typedReplyDecision(kind: kind, text: text)
             let won = corr.resolvable.resolve(decision, from: .telegram)
-            remoteLog?("resolved pid=\(corr.pid) nonce=\(corr.nonce) action=deny-reason won=\(won)")
+            remoteLog?("resolved pid=\(corr.pid) nonce=\(corr.nonce) action=\(Self.typedReplyAction(kind)) won=\(won)")
             if won, let mid = corr.messageId {
-                transport.editMessageText(chatId: pinned, messageId: mid, text: "🛑 Denied from phone — \(text)", completion: nil)
+                transport.editMessageText(chatId: pinned, messageId: mid, text: Self.typedReplyResolvedText(kind: kind, text: text), completion: nil)
             }
         case .ambiguous(let count):
             transport.sendMessage(chatId: pinned, text: "\(count) approvals pending — swipe-reply the specific one you mean, or tap its buttons.", keyboard: nil, completion: { _ in })
@@ -242,7 +243,11 @@ final class RemoteApprovalBridge {
         }
 
         if action == "dr" {
-            promptForDenyReason(corr: corr, callbackId: callback.id, chat: pinned)
+            promptForReply(corr: corr, kind: .deny, callbackId: callback.id, chat: pinned)
+            return
+        }
+        if action == "ar" {
+            promptForReply(corr: corr, kind: .allow, callbackId: callback.id, chat: pinned)
             return
         }
         forget(nonce)
@@ -260,13 +265,14 @@ final class RemoteApprovalBridge {
         }
     }
 
-    private func promptForDenyReason(corr: Correlation, callbackId: String, chat: Int64) {
-        transport.answerCallbackQuery(id: callbackId, text: "Reply with a reason", completion: nil)
+    private func promptForReply(corr: Correlation, kind: ReplyKind, callbackId: String, chat: Int64) {
+        transport.answerCallbackQuery(id: callbackId, text: kind == .allow ? "Reply with a note" : "Reply with a reason", completion: nil)
         let target = corr.toolName.isEmpty ? "this approval" : corr.toolName
-        transport.sendForceReply(chatId: chat, text: "Reply with a reason to deny \(target)…") { [weak self] result in
+        let prompt = kind == .allow ? "Reply with a note approving \(target)…" : "Reply with a reason to deny \(target)…"
+        transport.sendForceReply(chatId: chat, text: prompt) { [weak self] result in
             guard let self, case .success(let mid) = result else { return }
-            self.lock.lock(); self.promptToNonce[mid] = corr.nonce; self.lock.unlock()
-            self.remoteLog?("deny-reason prompt pid=\(corr.pid) nonce=\(corr.nonce) promptMid=\(mid)")
+            self.lock.lock(); self.promptReplies[mid] = PendingReply(nonce: corr.nonce, kind: kind); self.lock.unlock()
+            self.remoteLog?("\(Self.typedReplyAction(kind)) prompt pid=\(corr.pid) nonce=\(corr.nonce) promptMid=\(mid)")
         }
     }
 
@@ -297,6 +303,24 @@ final class RemoteApprovalBridge {
         }
     }
 
+    private static func typedReplyDecision(kind: ReplyKind, text: String) -> Decision {
+        switch kind {
+        case .deny: return Decision(verdict: .block, reason: "Denied from phone — \(text)")
+        case .allow: return Decision(verdict: .allow, reason: "Approved from phone", additionalContext: "Approver note from phone: \(text)")
+        }
+    }
+
+    private static func typedReplyResolvedText(kind: ReplyKind, text: String) -> String {
+        switch kind {
+        case .deny: return "🛑 Denied from phone — \(text)"
+        case .allow: return "✅ Approved from phone — \(text)"
+        }
+    }
+
+    private static func typedReplyAction(_ kind: ReplyKind) -> String {
+        kind == .allow ? "allow-note" : "deny-reason"
+    }
+
     private static func phoneResolvedText(_ action: String) -> String {
         switch action {
         case "d": return "🛑 Denied from phone"
@@ -309,12 +333,19 @@ final class RemoteApprovalBridge {
         lock.lock()
         byNonce.removeValue(forKey: nonce)
         pendingOrder.removeAll { $0 == nonce }
-        promptToNonce = promptToNonce.filter { $0.value != nonce }
+        promptReplies = promptReplies.filter { $0.value.nonce != nonce }
         lock.unlock()
     }
 
+    private enum ReplyKind { case allow, deny }
+
+    private struct PendingReply {
+        let nonce: String
+        let kind: ReplyKind
+    }
+
     private enum TypedReplyTarget {
-        case target(Correlation)
+        case target(Correlation, ReplyKind)
         case ambiguous(Int)
         case none
     }
@@ -322,13 +353,13 @@ final class RemoteApprovalBridge {
     private func typedReplyTarget(replyTo: Int?) -> TypedReplyTarget {
         lock.lock(); defer { lock.unlock() }
         if let replyTo {
-            if let promptNonce = promptToNonce[replyTo], let corr = byNonce[promptNonce] { return .target(corr) }
-            if let match = byNonce.values.first(where: { $0.messageId == replyTo }) { return .target(match) }
+            if let pending = promptReplies[replyTo], let corr = byNonce[pending.nonce] { return .target(corr, pending.kind) }
+            if let match = byNonce.values.first(where: { $0.messageId == replyTo }) { return .target(match, .deny) }
             return .none
         }
         switch pendingOrder.count {
         case 0: return .none
-        case 1: return byNonce[pendingOrder[0]].map { .target($0) } ?? .none
+        case 1: return byNonce[pendingOrder[0]].map { .target($0, .deny) } ?? .none
         default: return .ambiguous(pendingOrder.count)
         }
     }

--- a/Tests/GavelTests/RemoteApprovalBridgeTests.swift
+++ b/Tests/GavelTests/RemoteApprovalBridgeTests.swift
@@ -322,6 +322,61 @@ final class RemoteApprovalBridgeTests: XCTestCase {
         XCTAssertEqual(resolved?.reason, "denied on mac")
     }
 
+    func testAllowWithNoteButtonOffered() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        bridge.notify(resolvable: ResolvableApproval { _ in }, text: "approve?", allowSession: nil)
+        XCTAssertTrue(fake.lastCallbackData.contains { $0.hasPrefix("ar:") })
+    }
+
+    func testAllowWithNoteButtonIssuesForceReplyWithoutResolving() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var resolved: Decision?
+        let approval = ResolvableApproval { resolved = $0 }
+
+        bridge.notify(resolvable: approval, text: "approve?", toolName: "Bash", allowSession: nil)
+        let n = nonce(from: fake.lastCallbackData)
+        bridge.handle(callbackUpdate(action: "ar", nonce: n, fromId: owner, chatId: owner, messageId: fake.lastSentMessageId))
+
+        XCTAssertNil(resolved)
+        XCTAssertEqual(fake.forceReplies.count, 1)
+        XCTAssertTrue(fake.forceReplies.last?.text.contains("Bash") == true)
+        XCTAssertEqual(fake.answers.last?.text, "Reply with a note")
+    }
+
+    func testReplyToAllowNotePromptApprovesWithContext() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var resolved: Decision?
+        bridge.notify(resolvable: ResolvableApproval { resolved = $0 }, text: "approve?", toolName: "Bash", allowSession: nil)
+        let n = nonce(from: fake.lastCallbackData)
+
+        bridge.handle(callbackUpdate(action: "ar", nonce: n, fromId: owner, chatId: owner, messageId: 100))
+        let promptMid = fake.forceReplies.last!.messageId
+        bridge.handle(typedReply("ship it, ran the migration", replyTo: promptMid))
+
+        XCTAssertEqual(resolved?.verdict, .allow)
+        XCTAssertEqual(resolved?.additionalContext, "Approver note from phone: ship it, ran the migration")
+    }
+
+    func testReplyToAllowNotePromptTargetsCorrectApprovalWhenMultiplePending() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var r1: Decision?
+        var r2: Decision?
+        bridge.notify(resolvable: ResolvableApproval { r1 = $0 }, text: "a1", allowSession: nil)
+        let firstNonce = nonce(from: fake.lastCallbackData)
+        bridge.notify(resolvable: ResolvableApproval { r2 = $0 }, text: "a2", allowSession: nil)
+
+        bridge.handle(callbackUpdate(action: "ar", nonce: firstNonce, fromId: owner, chatId: owner, messageId: 100))
+        let promptMid = fake.forceReplies.last!.messageId
+        bridge.handle(typedReply("approved", replyTo: promptMid))
+
+        XCTAssertEqual(r1?.verdict, .allow)
+        XCTAssertNil(r2)
+    }
+
     func testWithheldApprovalIsResolvableFromPhoneWithButtons() {
         let fake = FakeTelegramTransport()
         let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)


### PR DESCRIPTION
## Problem

Surfaced while verifying #167: a phone **approval** sends nothing back to the Claude session, while a phone **deny-with-reason** delivers its text. Two causes, both in the remote-approval plumbing:

1. **Wire protocol is asymmetric.** On allow (exit 0), the hook shim only forwards text to Claude via a non-empty `additionalContext` (`GavelHook/main.swift`); the allow `reason` is daemon-side logging only. On deny (exit 2) the reason goes to stderr, which Claude always sees.
2. **No approve-with-note path.** The Telegram bridge only had a deny-reason ForceReply (`dr`). The allow buttons (`a`/`s`) couldn't attach anything, so `additionalContext` was never populated from the phone. (The Mac panel's note-to-Claude already fills it — phone had no equivalent.)

Net effect: approving from the phone is invisible to the agent; only a deny could explain itself.

## Change

Add a symmetric **`✅ Allow w/ note`** button (callback `ar`) paired with `🛑 Deny w/ reason`. It issues a ForceReply, and the typed reply resolves the approval as `.allow` with the note carried as `additionalContext` — which the existing `Decision.toJSON` → hook path already serializes to Claude (same field the Mac note uses). Plain `Allow` / `Allow for session` stay silent (routine approvals shouldn't inject a line).

Implementation:
- Generalize `promptForDenyReason` → `promptForReply(kind:)`.
- Thread a `ReplyKind` through the typed-reply state (`promptReplies: [Int: PendingReply]`) so a reply to the allow prompt approves-with-context, while a reply to the deny prompt — or a bare swipe-reply — still denies (unchanged behavior).

## Tests

4 new cases in `RemoteApprovalBridgeTests`: button offered, `ar` issues ForceReply without resolving, reply approves with the note as `additionalContext`, and correct-target routing when multiple approvals are pending. Deny-reason tests unchanged and green. Full suite: 574 passing.

## Note

Receiving end needs no change — `additionalContext` already flows allow → `Decision.toJSON` → hook shim → Claude. This is purely a bridge-side addition.