### PR TITLE
fix(codex): drop permissionDecision on codex fail-open allow (0.142 wire contract)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,14 +20,19 @@ let package = Package(
                 .linkedFramework("Security"),
             ]
         ),
+        .target(
+            name: "GavelHookCore",
+            dependencies: [],
+            path: "Sources/GavelHookCore"
+        ),
         .executableTarget(
             name: "GavelHook",
-            dependencies: [],
+            dependencies: ["GavelHookCore"],
             path: "Sources/GavelHook"
         ),
         .testTarget(
             name: "GavelTests",
-            dependencies: ["Gavel"],
+            dependencies: ["Gavel", "GavelHookCore"],
             path: "Tests/GavelTests"
         ),
     ]

--- a/Sources/GavelHook/main.swift
+++ b/Sources/GavelHook/main.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GavelHookCore
 
 /// gavel-hook — Thin CLI shim for Claude Code hooks.
 ///
@@ -86,7 +87,7 @@ guard let envelopeData = try? JSONSerialization.data(withJSONObject: envelope) e
 let fd = socket(AF_UNIX, SOCK_STREAM, 0)
 guard fd >= 0 else {
     // No socket — daemon not running. Fail OPEN so Claude works without gavel.
-    if needsResponse { printAllow() }
+    if needsResponse { printAllow(isCodex: isCodexAgent) }
     exit(0)
 }
 
@@ -115,7 +116,7 @@ let connectResult = withUnsafePointer(to: &addr) { ptr in
 guard connectResult == 0 else {
     close(fd)
     // Can't connect — daemon not running. Fail OPEN so Claude works without gavel.
-    if needsResponse { printAllow() }
+    if needsResponse { printAllow(isCodex: isCodexAgent) }
     exit(0)
 }
 
@@ -165,32 +166,16 @@ if needsResponse {
 
         // Build structured allow response — format depends on hook type
         if hookType == "PermissionRequest" {
-            printPermissionAllow()
+            print(HookWireFormat.permissionRequestAllow())
             exit(0)
         }
 
-        // Codex's PreToolUseHookSpecificOutputWire rejects both
-        // permissionDecision:"allow" and updatedInput as unsupported; the allow
-        // path is signaled by emitting hookEventName only (with optional
-        // additionalContext). Claude wants permissionDecision:"allow" and
-        // honors updatedInput. NOTE: this drops user-edited commands on Codex
-        // sessions silently — the edit UI should be gated agent-side.
-        var output: [String: Any] = ["hookEventName": "PreToolUse"]
-        if let ctx = json["additionalContext"] as? String, !ctx.isEmpty {
-            output["additionalContext"] = ctx
-        }
-        if !isCodexAgent {
-            output["permissionDecision"] = "allow"
-            if let updated = json["updatedInput"] as? [String: Any] {
-                output["updatedInput"] = updated
-            }
-        }
-        let wrapper: [String: Any] = ["hookSpecificOutput": output]
-        if let data = try? JSONSerialization.data(withJSONObject: wrapper),
-           let str = String(data: data, encoding: .utf8) {
-            print(str)
-            exit(0)
-        }
+        print(HookWireFormat.preToolUseAllow(
+            isCodex: isCodexAgent,
+            additionalContext: json["additionalContext"] as? String,
+            updatedInput: json["updatedInput"] as? [String: Any]
+        ))
+        exit(0)
     }
 
     // Daemon was reachable but response was empty/unparseable — FAIL CLOSED
@@ -202,12 +187,8 @@ if needsResponse {
 
 // MARK: - Helpers
 
-func printAllow() {
-    print(#"{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}"#)
-}
-
-func printPermissionAllow() {
-    print(#"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}"#)
+func printAllow(isCodex: Bool) {
+    print(HookWireFormat.preToolUseAllow(isCodex: isCodex))
 }
 
 func printBlock(_ reason: String) {

--- a/Sources/GavelHookCore/HookWireFormat.swift
+++ b/Sources/GavelHookCore/HookWireFormat.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Translates a Gavel allow-verdict into the stdout JSON each agent's hook contract accepts.
+public enum HookWireFormat {
+    /// PreToolUse allow stdout; Codex (0.142+) rejects `permissionDecision`/`updatedInput`, so allow is `hookEventName` only.
+    public static func preToolUseAllow(
+        isCodex: Bool,
+        additionalContext: String? = nil,
+        updatedInput: [String: Any]? = nil
+    ) -> String {
+        var output: [String: Any] = ["hookEventName": "PreToolUse"]
+        if let ctx = additionalContext, !ctx.isEmpty {
+            output["additionalContext"] = ctx
+        }
+        if !isCodex {
+            output["permissionDecision"] = "allow"
+            if let updated = updatedInput {
+                output["updatedInput"] = updated
+            }
+        }
+        let wrapper: [String: Any] = ["hookSpecificOutput": output]
+        guard let data = try? JSONSerialization.data(withJSONObject: wrapper),
+              let str = String(data: data, encoding: .utf8) else {
+            return codexSafeAllow
+        }
+        return str
+    }
+
+    /// PermissionRequest allow stdout (Claude-only; Codex registers no PermissionRequest hook).
+    public static func permissionRequestAllow() -> String {
+        #"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}"#
+    }
+
+    /// Minimal allow no agent rejects, used as the serialization fallback.
+    public static let codexSafeAllow = #"{"hookSpecificOutput":{"hookEventName":"PreToolUse"}}"#
+}

--- a/Tests/GavelTests/WireFormatTests.swift
+++ b/Tests/GavelTests/WireFormatTests.swift
@@ -1,7 +1,57 @@
 import XCTest
 @testable import Gavel
+import GavelHookCore
 
 final class WireFormatTests: XCTestCase {
+
+    // MARK: - HookWireFormat allow shape (daemon verdict → agent stdout)
+
+    private func parse(_ str: String) throws -> [String: Any] {
+        try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(str.utf8)) as? [String: Any])
+    }
+
+    func testCodexAllowOmitsPermissionDecision() throws {
+        let out = try parse(HookWireFormat.preToolUseAllow(isCodex: true))
+        let hso = try XCTUnwrap(out["hookSpecificOutput"] as? [String: Any])
+        XCTAssertEqual(hso["hookEventName"] as? String, "PreToolUse")
+        XCTAssertNil(hso["permissionDecision"], "Codex 0.142 runtime-rejects permissionDecision:allow")
+    }
+
+    func testClaudeAllowEmitsPermissionDecision() throws {
+        let out = try parse(HookWireFormat.preToolUseAllow(isCodex: false))
+        let hso = try XCTUnwrap(out["hookSpecificOutput"] as? [String: Any])
+        XCTAssertEqual(hso["permissionDecision"] as? String, "allow")
+    }
+
+    func testCodexAllowDropsUpdatedInput() throws {
+        let out = try parse(HookWireFormat.preToolUseAllow(
+            isCodex: true, updatedInput: ["command": "ls -la"]))
+        let hso = try XCTUnwrap(out["hookSpecificOutput"] as? [String: Any])
+        XCTAssertNil(hso["updatedInput"], "Codex has no allow slot to carry updatedInput")
+        XCTAssertNil(hso["permissionDecision"])
+    }
+
+    func testClaudeAllowKeepsUpdatedInput() throws {
+        let out = try parse(HookWireFormat.preToolUseAllow(
+            isCodex: false, updatedInput: ["command": "ls -la"]))
+        let hso = try XCTUnwrap(out["hookSpecificOutput"] as? [String: Any])
+        let updated = try XCTUnwrap(hso["updatedInput"] as? [String: Any])
+        XCTAssertEqual(updated["command"] as? String, "ls -la")
+    }
+
+    func testCodexAllowKeepsAdditionalContext() throws {
+        let out = try parse(HookWireFormat.preToolUseAllow(
+            isCodex: true, additionalContext: "note from gavel"))
+        let hso = try XCTUnwrap(out["hookSpecificOutput"] as? [String: Any])
+        XCTAssertEqual(hso["additionalContext"] as? String, "note from gavel")
+        XCTAssertNil(hso["permissionDecision"])
+    }
+
+    func testEmptyAdditionalContextOmitted() throws {
+        let out = try parse(HookWireFormat.preToolUseAllow(isCodex: false, additionalContext: ""))
+        let hso = try XCTUnwrap(out["hookSpecificOutput"] as? [String: Any])
+        XCTAssertNil(hso["additionalContext"])
+    }
 
     /// Build an ApprovalEngine that does NOT load the user's real rules.json.
     /// Without this, any prompt rule the user has installed (e.g. "always


### PR DESCRIPTION
## Problem

A Codex 0.142 session surfaced:
- 1× `PreToolUse hook (failed)` — `PreToolUse hook returned unsupported permissionDecision:allow`
- "doesn't honor rules in automode"

## Root cause (confirmed from the installed codex 0.142.0 binary's embedded schema + runtime error strings)

Codex 0.142's PreToolUse hook output contract:
- **Allow** = emit `{"hookSpecificOutput":{"hookEventName":"PreToolUse"}}` only. `permissionDecision:"allow"`, `permissionDecision:"ask"`, `decision:"approve"`, `continue:false`, `stopReason`, and `updatedInput` are all **runtime-rejected** (the schema enum lists allow/deny/ask, but the runtime only accepts `deny`).
- **Deny** = `permissionDecision:"deny"` + non-empty `permissionDecisionReason`, OR `exit 2` + stderr reason — gavel's existing `printBlock`+exit2 is honored.
- INPUT still carries `turn_id` → the `isCodexAgent` discriminator is still valid.

The hook's *normal* codex allow/deny paths were already correct. The only path emitting `permissionDecision:"allow"` to Codex was the **fail-open `printAllow()`** (daemon unreachable), which always wrote the Claude shape — producing the error and an ungoverned fail-open whenever the daemon was momentarily unreachable (e.g. a dev-daemon bounce window).

## Fix

- New pure, dependency-free `GavelHookCore` target (`HookWireFormat`) shared by the hook executable and the test target — keeps AppKit out of the per-call hook binary.
- Route **both** the fail-open path and the daemon-reachable allow path through one codex-aware builder, so they can't drift apart again (the original bug was a second hand-written allow string).

## Verification

- 576 unit tests green (6 new `WireFormatTests` cases asserting the codex allow shape omits `permissionDecision`/`updatedInput`).
- E2E against the live daemon: codex-shaped → no `permissionDecision`; claude-shaped → `permissionDecision:"allow"`.
- Fail-open branch (bogus `$HOME`): codex now emits no `permissionDecision` (the bug).

## Follow-up (separate)

The `daemon returned invalid response` cluster (a 0-byte/EOF read — fail-closed, safe) points to a daemon-bounce window and/or a structural starvation risk (`approvalTimeoutSeconds = 86400` pins a socket-worker thread per pending approval; accept+handle share one GCD queue, backlog 32). Spiked separately, not in this PR.