### PR TITLE
fix(session): cap and TTL-evict dead-session tombstones

### DIFF
--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -56,6 +56,7 @@ final class SessionManager: ObservableObject {
 
         loadDefaults()
         loadActiveSessions()
+        pruneDeadSessions()
         if autoDiscover { discoverRunningSessions() }
         if autoStartTimers {
             startCleanupTimer()
@@ -232,10 +233,11 @@ final class SessionManager: ObservableObject {
 
     func forgetTombstone(sessionId: String) {
         lock.lock()
-        if deadSessions.removeValue(forKey: sessionId) != nil {
-            saveActiveSessionsLocked()
-        }
+        let droppedTombstone = deadSessions.removeValue(forKey: sessionId) != nil
+        let droppedLabel = sessionLabels.removeValue(forKey: sessionId) != nil
+        if droppedTombstone { saveActiveSessionsLocked() }
         lock.unlock()
+        if droppedLabel { saveDefaults() }
     }
 
     /// Re-derive a name for every still-blank session (live or asleep) by re-reading its transcript; catches sessions that were empty when first seen but have since produced a first prompt, which the one-shot seed guard never retries.
@@ -275,11 +277,13 @@ final class SessionManager: ObservableObject {
             sessions.removeValue(forKey: pid)
         }
         let hadTombstones = !deadSessions.isEmpty
+        for sid in deadSessions.keys { sessionLabels.removeValue(forKey: sid) }
         deadSessions.removeAll()
         if !strayPids.isEmpty || hadTombstones {
             saveActiveSessionsLocked()
         }
         lock.unlock()
+        if hadTombstones { saveDefaults() }
     }
 
     // MARK: - Active session persistence
@@ -501,6 +505,43 @@ final class SessionManager: ObservableObject {
                 session.endedAt = now
             }
         }
+        pruneDeadSessions()
+    }
+
+    /// Bound the append-only tombstone store and persist if it shrank. Runs every
+    /// cleanup tick (cheap for a few-hundred-entry dict) so TTL aging happens even
+    /// on ticks where nothing newly died.
+    func pruneDeadSessions() {
+        lock.lock()
+        let changed = pruneDeadSessionsLocked()
+        if changed { saveActiveSessionsLocked() }
+        lock.unlock()
+        if changed { saveDefaults() }
+    }
+
+    /// Drop tombstones past the TTL, then keep only the most-recent `maxDeadSessions`,
+    /// evicting each dropped session's saved label alongside it. Returns whether
+    /// anything changed. Caller holds `lock`. Mutates `deadSessions` off-main under
+    /// lock, matching the promotion path above.
+    ///
+    /// `endedAt` is set on a deferred main-thread block right after a tombstone is
+    /// created, so a just-promoted session can still be nil here — treat nil as
+    /// "now" so a fresh tombstone is never mistaken for an aged-out one.
+    @discardableResult
+    private func pruneDeadSessionsLocked() -> Bool {
+        let recency: (Session) -> Date = { $0.endedAt ?? Date() }
+        let cutoff = Date().addingTimeInterval(-GavelConstants.deadSessionTTL)
+        var survivors = deadSessions.filter { recency($0.value) >= cutoff }
+        if survivors.count > GavelConstants.maxDeadSessions {
+            let kept = survivors.sorted { recency($0.value) > recency($1.value) }
+                .prefix(GavelConstants.maxDeadSessions)
+            survivors = Dictionary(uniqueKeysWithValues: kept.map { ($0.key, $0.value) })
+        }
+        guard survivors.count != deadSessions.count else { return false }
+        let evicted = Set(deadSessions.keys).subtracting(survivors.keys)
+        deadSessions = survivors
+        for sid in evicted { sessionLabels.removeValue(forKey: sid) }
+        return true
     }
 
     // MARK: - Bulk prompt mode

--- a/Sources/Gavel/System/Constants.swift
+++ b/Sources/Gavel/System/Constants.swift
@@ -32,6 +32,13 @@ enum GavelConstants {
     /// Session cleanup check interval in seconds.
     static let sessionCleanupInterval: TimeInterval = 5.0
 
+    /// Tombstone retention. The dead-session store is otherwise append-only, so a
+    /// runaway respawn loop (e.g. a `/loop` spawning a fresh CLI every ~90s) can
+    /// pile up thousands of permanent rows. Keep at most this many tombstones, and
+    /// drop any older than the TTL — whichever removes more.
+    static let maxDeadSessions = 200
+    static let deadSessionTTL: TimeInterval = 14 * 24 * 60 * 60
+
     /// Minimum content length to scan for dangerous patterns.
     /// Short content can't contain both file I/O and network code.
     static let minContentScanLength = 50

--- a/Tests/GavelTests/SessionLifecycleTests.swift
+++ b/Tests/GavelTests/SessionLifecycleTests.swift
@@ -154,6 +154,75 @@ final class SessionLifecycleTests: XCTestCase {
         XCTAssertNotNil(manager.sessions[livePid], "Live session must survive clearDead")
     }
 
+    // MARK: - Retention (prune)
+
+    /// Tombstone `count` distinct dead PIDs and return their sids in creation order.
+    @discardableResult
+    private func makeTombstones(_ count: Int, sidPrefix: String = "prune-sid") -> [String] {
+        var sids: [String] = []
+        for i in 0..<count {
+            let session = manager.session(for: deadPid + i)
+            session.sessionId = "\(sidPrefix)-\(i)"
+            sids.append("\(sidPrefix)-\(i)")
+        }
+        manager.cleanupDeadSessions()
+        return sids
+    }
+
+    /// Read the labels actually written to disk, since `sessionLabels` is file-private.
+    private func persistedLabels() -> [String: String] {
+        let path = tmpHome.appendingPathComponent(".claude/gavel/session-defaults.json")
+        guard let data = try? Data(contentsOf: path),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let labels = json["sessionLabels"] as? [String: String] else { return [:] }
+        return labels
+    }
+
+    func testTombstonesPastTTLAreEvicted() {
+        let sids = makeTombstones(2)
+        manager.deadSessions[sids[0]]?.endedAt = Date(timeIntervalSinceNow: -GavelConstants.deadSessionTTL - 3600)
+        manager.deadSessions[sids[1]]?.endedAt = Date()
+
+        manager.pruneDeadSessions()
+
+        XCTAssertNil(manager.deadSessions[sids[0]], "A tombstone older than the TTL is evicted")
+        XCTAssertNotNil(manager.deadSessions[sids[1]], "A recent tombstone survives")
+    }
+
+    func testTombstonesAreCappedAtMax() {
+        makeTombstones(GavelConstants.maxDeadSessions + 5)
+        XCTAssertEqual(manager.deadSessions.count, GavelConstants.maxDeadSessions,
+                       "Tombstones beyond the cap are dropped — a runaway loop can't grow unbounded")
+    }
+
+    func testFreshTombstoneSurvivesTheCleanupTickPrune() {
+        let sids = makeTombstones(1)
+        XCTAssertNotNil(manager.deadSessions[sids[0]],
+                        "endedAt is set on a deferred block, so a just-promoted tombstone must not read as aged-out")
+    }
+
+    func testForgetTombstoneAlsoDropsSavedLabel() {
+        let sid = makeTombstones(1)[0]
+        manager.setLabel("keep-me", for: sid)
+        XCTAssertEqual(persistedLabels()[sid], "keep-me")
+
+        manager.forgetTombstone(sessionId: sid)
+
+        XCTAssertNil(manager.deadSessions[sid])
+        XCTAssertNil(persistedLabels()[sid], "Forgetting a tombstone must not leak its label")
+    }
+
+    func testPruneEvictsLabelAlongsideAgedOutTombstone() {
+        let sid = makeTombstones(1)[0]
+        manager.setLabel("old-name", for: sid)
+        manager.deadSessions[sid]?.endedAt = Date(timeIntervalSinceNow: -GavelConstants.deadSessionTTL - 3600)
+
+        manager.pruneDeadSessions()
+
+        XCTAssertNil(manager.deadSessions[sid])
+        XCTAssertNil(persistedLabels()[sid], "An aged-out tombstone must not leak its label")
+    }
+
     // MARK: - Promotion
 
     func testRecordSessionIdPromotesMatchingTombstoneToLive() {


### PR DESCRIPTION
## Problem
The dead-session store was append-only: `cleanupDeadSessions()` only ever promoted exited sessions into `deadSessions` and never removed anything. A runaway respawn loop (612 sessions spawned ~every 96s by a `/loop`, observed live in `active-sessions.json`) piled up **1088 permanent tombstones + 801 orphaned labels**, rewriting a 343KB state file on every session change — and rendering 600+ near-identical "asleep" rows in the monitor.

## Fix
- **Cap + TTL eviction** (`maxDeadSessions=200`, `deadSessionTTL=14d`, whichever removes more) on the existing 5s cleanup tick **and** once at startup, so an already-bloated file is trimmed on next launch.
- Each evicted tombstone's saved label is dropped with it; `forgetTombstone` and `clearDeadSessions` now drop labels too, so labels track tombstones 1:1.
- `endedAt` is set on a deferred main-thread block right after a tombstone is created, so the prune treats `nil endedAt` as "now" — otherwise a just-promoted tombstone reads as 14 days old and is deleted the instant it's born.

## Tests
5 new (TTL evict, cap, fresh-tombstone-survives-tick, label-drop-on-forget, label-evict-with-tombstone). Full suite **600/600**.

## Note
Root cause of the 612 sessions was an external runaway loop (stopped 34h ago, not a launchd job) — Gavel faithfully recorded real deaths; the bug is that it never forgot them. Existing bloat clears on next daemon restart (startup prune) or via Forget All Sleeping.