### PR TITLE
feat(monitor): session history viewer + Forget Short triage

### DIFF
--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -10,6 +10,9 @@ struct MonitorWindow: View {
     @State private var selectedTab: MonitorTab = .feed
     @State private var sessionFilter: String = ""
     @State private var hideTombstones: Bool = false
+    @State private var historySession: Session?
+    @State private var shortCandidates: [String] = []
+    @State private var showForgetShort = false
 
     enum MonitorTab {
         case feed, rules, sessions, context, tester, reference
@@ -30,6 +33,44 @@ struct MonitorWindow: View {
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)) { _ in
             collapseOnDeactivate()
         }
+        .sheet(item: $historySession) { session in
+            TranscriptView(session: session, viewModel: viewModel)
+        }
+        .alert("Forget \(shortCandidates.count) short session\(shortCandidates.count == 1 ? "" : "s")?",
+               isPresented: $showForgetShort) {
+            Button("Forget", role: .destructive, action: forgetShort)
+            Button("Cancel", role: .cancel) { shortCandidates = [] }
+        } message: {
+            Text("Sleeping sessions with one message or fewer (aborted/empty). Removes the rows only — transcripts stay on disk.")
+        }
+    }
+
+    /// Background-scan every tombstone's transcript and queue the ≤1-message ones
+    /// for the confirm dialog. Parsing 200 files off the main thread keeps the click
+    /// responsive; an empty result notifies instead of opening an empty dialog.
+    private func scanShortSleeping() {
+        let targets = viewModel.sessionManager.deadSessions.map { (sid: $0.key, cwd: $0.value.cwd ?? "") }
+        DispatchQueue.global(qos: .userInitiated).async {
+            let short = targets
+                .filter { TranscriptReader.messages(cwd: $0.cwd, sessionId: $0.sid).count <= 1 }
+                .map(\.sid)
+            DispatchQueue.main.async {
+                shortCandidates = short
+                if short.isEmpty {
+                    GavelNotifications.notify(title: "Gavel — Forget Short", body: "No sleeping sessions with ≤1 message")
+                } else {
+                    showForgetShort = true
+                }
+            }
+        }
+    }
+
+    private func forgetShort() {
+        for sid in shortCandidates {
+            viewModel.sessionManager.forgetTombstone(sessionId: sid)
+        }
+        viewModel.noteInteraction()
+        shortCandidates = []
     }
 
     private func collapseOnDeactivate() {
@@ -213,7 +254,8 @@ struct MonitorWindow: View {
                             SessionRow(
                                 session: session,
                                 viewModel: viewModel,
-                                alternate: index.isMultiple(of: 2)
+                                alternate: index.isMultiple(of: 2),
+                                onHistory: { historySession = $0 }
                             )
                         }
                     }
@@ -247,6 +289,14 @@ struct MonitorWindow: View {
                 .buttonStyle(.bordered)
                 .tint(.gray)
                 .help("Remove every sleeping (tombstoned) session from the monitor.")
+
+                Button("Forget Short") {
+                    scanShortSleeping()
+                    viewModel.noteInteraction()
+                }
+                .buttonStyle(.bordered)
+                .tint(.gray)
+                .help("Forget sleeping sessions with ≤1 message (aborted/empty). Shows a count first; transcripts stay on disk.")
 
                 Button("Name Unnamed") {
                     viewModel.sessionManager.nameUnnamedSessions()
@@ -415,6 +465,7 @@ private struct SessionRow: View {
     @ObservedObject var session: Session
     let viewModel: MonitorViewModel
     let alternate: Bool
+    let onHistory: (Session) -> Void
 
     var body: some View {
         HStack(spacing: 8) {
@@ -589,6 +640,16 @@ private struct SessionRow: View {
             .tint(session.isPaused ? .green : .orange)
             .frame(width: 76)
 
+            Button("History") {
+                onHistory(session)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .tint(.teal)
+            .frame(width: 70)
+            .disabled(session.sessionId == nil)
+            .help("Read this session's transcript in a scrollable window.")
+
             Button("Sleep") {
                 if viewModel.sessionManager.isProcessAlive(pid: session.pid, cwd: session.cwd) {
                     kill(Int32(session.pid), SIGINT)
@@ -613,10 +674,20 @@ private struct SessionRow: View {
                 Text("asleep \(Self.relativeTime(ended))")
                     .font(.caption2)
                     .foregroundColor(.secondary)
-                    .frame(width: 222, alignment: .trailing)
+                    .frame(width: 146, alignment: .trailing)
             } else {
-                Spacer().frame(width: 222)
+                Spacer().frame(width: 146)
             }
+
+            Button("History") {
+                onHistory(session)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .tint(.teal)
+            .frame(width: 70)
+            .disabled(session.sessionId == nil)
+            .help("Read this session's transcript to decide whether to name or forget it.")
 
             Button("Resume") {
                 copyResumeCommand()

--- a/Sources/Gavel/Monitor/TranscriptView.swift
+++ b/Sources/Gavel/Monitor/TranscriptView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+/// History viewer for a session: renders its transcript so an unrecognized
+/// (often sleeping) row can be named or forgotten without resuming it — resuming
+/// would respawn a dead session just to read it. Rename + Forget live here so the
+/// whole name-or-ditch decision happens in one place.
+struct TranscriptView: View {
+    @ObservedObject var session: Session
+    let viewModel: MonitorViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var messages: [TranscriptMessage] = []
+    @State private var loaded = false
+    @State private var draftName: String = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            transcriptBody
+            Divider()
+            footer
+        }
+        .frame(width: 640, height: 560)
+        .onAppear(perform: load)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            TextField("Name this session", text: $draftName)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit(rename)
+            Button("Rename", action: rename)
+                .disabled(draftName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+        .padding(10)
+    }
+
+    @ViewBuilder
+    private var transcriptBody: some View {
+        if !loaded {
+            ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if messages.isEmpty {
+            VStack(spacing: 6) {
+                Text("No readable transcript")
+                Text("The transcript is gone or held only tool activity — nothing to read.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 12) {
+                    ForEach(messages) { TranscriptBubble(message: $0) }
+                }
+                .padding(12)
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            if !session.isAlive, session.sessionId != nil {
+                Button("Forget", role: .destructive, action: forget)
+            }
+            Spacer()
+            Button("Close") { dismiss() }
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(10)
+    }
+
+    private func load() {
+        draftName = session.label
+        guard let sid = session.sessionId, let cwd = session.cwd else {
+            loaded = true
+            return
+        }
+        // Parsing reads the whole .jsonl off disk; keep it off the main thread.
+        DispatchQueue.global(qos: .userInitiated).async {
+            let parsed = TranscriptReader.messages(cwd: cwd, sessionId: sid)
+            DispatchQueue.main.async {
+                messages = parsed
+                loaded = true
+            }
+        }
+    }
+
+    private func rename() {
+        let trimmed = draftName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        viewModel.sessionManager.updateLabel(trimmed, on: session)
+        viewModel.noteInteraction()
+    }
+
+    private func forget() {
+        guard let sid = session.sessionId else { return }
+        viewModel.sessionManager.forgetTombstone(sessionId: sid)
+        viewModel.noteInteraction()
+        dismiss()
+    }
+}
+
+private struct TranscriptBubble: View {
+    let message: TranscriptMessage
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(message.role == .user ? "👤 You" : "🤖 Claude")
+                .font(.caption).bold()
+                .foregroundColor(message.role == .user ? .blue : .purple)
+            Text(message.text)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(8)
+        .background(message.role == .user ? Color.blue.opacity(0.08) : Color.gray.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}

--- a/Sources/Gavel/System/JsonlRenameReader.swift
+++ b/Sources/Gavel/System/JsonlRenameReader.swift
@@ -7,7 +7,7 @@ import Foundation
 /// return nil.
 enum JsonlRenameReader {
     static func latestRename(cwd: String, sessionId: String) -> String? {
-        guard let text = transcript(cwd: cwd, sessionId: sessionId) else { return nil }
+        guard let text = transcriptText(cwd: cwd, sessionId: sessionId) else { return nil }
 
         let patterns = [
             #"<command-message>rename</command-message>[\s\S]*?<command-args>(.+?)</command-args>"#,
@@ -36,7 +36,7 @@ enum JsonlRenameReader {
 
     /// Derive a short title from the first real user prompt in the transcript.
     static func firstPromptTitle(cwd: String, sessionId: String) -> String? {
-        guard let text = transcript(cwd: cwd, sessionId: sessionId) else { return nil }
+        guard let text = transcriptText(cwd: cwd, sessionId: sessionId) else { return nil }
         for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
             guard let prompt = userPromptText(fromLine: String(line)) else { continue }
             if let title = condense(prompt) { return title }
@@ -46,14 +46,19 @@ enum JsonlRenameReader {
 
     private static let maxTitleLength = 60
 
-    private static func transcript(cwd: String, sessionId: String) -> String? {
+    /// Path Claude Code writes a session transcript to: cwd with `/` and `.`
+    /// flattened to `-`, under `~/.claude/projects/<encoded>/<sessionId>.jsonl`.
+    static func transcriptPath(cwd: String, sessionId: String) -> String {
         let encoded = cwd
             .replacingOccurrences(of: "/", with: "-")
             .replacingOccurrences(of: ".", with: "-")
-        let path = (NSHomeDirectory() as NSString)
+        return (NSHomeDirectory() as NSString)
             .appendingPathComponent(".claude/projects")
             .appending("/\(encoded)/\(sessionId).jsonl")
-        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { return nil }
+    }
+
+    static func transcriptText(cwd: String, sessionId: String) -> String? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: transcriptPath(cwd: cwd, sessionId: sessionId))) else { return nil }
         return String(data: data, encoding: .utf8)
     }
 

--- a/Sources/Gavel/System/TranscriptReader.swift
+++ b/Sources/Gavel/System/TranscriptReader.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// One conversational turn extracted from a transcript for the History viewer.
+struct TranscriptMessage: Identifiable {
+    enum Role { case user, assistant }
+    let id: Int
+    let role: Role
+    let text: String
+}
+
+/// Parses a Claude Code JSONL transcript into a readable user/assistant message
+/// list. Tool calls, tool results, meta lines, and `<…>`-wrapped envelopes
+/// (system reminders, slash-command tags) are dropped — only conversational text
+/// survives, so a session can be recognized at a glance. Best-effort: a missing
+/// file or a malformed line yields fewer messages, never a throw.
+enum TranscriptReader {
+    /// Per-message cap so one giant paste can't make the viewer unscrollable.
+    static let maxMessageLength = 4000
+
+    static func messages(cwd: String, sessionId: String) -> [TranscriptMessage] {
+        guard let text = JsonlRenameReader.transcriptText(cwd: cwd, sessionId: sessionId) else { return [] }
+        var messages: [TranscriptMessage] = []
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let (role, body) = turn(fromLine: String(line)) else { continue }
+            messages.append(TranscriptMessage(id: messages.count, role: role, text: body))
+        }
+        return messages
+    }
+
+    private static func turn(fromLine line: String) -> (TranscriptMessage.Role, String)? {
+        guard let data = line.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              (obj["isMeta"] as? Bool) != true,
+              let message = obj["message"] as? [String: Any] else { return nil }
+
+        let role: TranscriptMessage.Role
+        switch obj["type"] as? String {
+        case "user": role = .user
+        case "assistant": role = .assistant
+        default: return nil
+        }
+
+        guard let body = conversationalText(message["content"]) else { return nil }
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        // A user line that only carried a tool_result, or a system-reminder /
+        // slash-command envelope, has no conversation — drop it.
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("<") else { return nil }
+        return (role, truncate(trimmed))
+    }
+
+    private static func conversationalText(_ content: Any?) -> String? {
+        if let str = content as? String { return str }
+        guard let parts = content as? [[String: Any]] else { return nil }
+        let texts = parts.compactMap { part -> String? in
+            (part["type"] as? String) == "text" ? part["text"] as? String : nil
+        }
+        return texts.isEmpty ? nil : texts.joined(separator: "\n\n")
+    }
+
+    private static func truncate(_ text: String) -> String {
+        guard text.count > maxMessageLength else { return text }
+        return String(text.prefix(maxMessageLength)) + "…"
+    }
+}

--- a/Tests/GavelTests/TranscriptReaderTests.swift
+++ b/Tests/GavelTests/TranscriptReaderTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import Gavel
+
+/// Covers the History-viewer transcript parse: conversational user/assistant
+/// text is kept in order; tool/meta/envelope noise is dropped.
+final class TranscriptReaderTests: XCTestCase {
+
+    private var writtenPaths: [String] = []
+
+    override func tearDown() {
+        for path in writtenPaths {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+        writtenPaths.removeAll()
+        super.tearDown()
+    }
+
+    func testKeepsUserAndAssistantTextInOrder() {
+        let (cwd, sid) = writeTranscript(lines: [
+            #"{"type":"user","message":{"content":"enable logging on the web ACL"}}"#,
+            #"{"type":"assistant","message":{"content":[{"type":"text","text":"On it."}]}}"#
+        ])
+        let messages = TranscriptReader.messages(cwd: cwd, sessionId: sid)
+        XCTAssertEqual(messages.count, 2)
+        XCTAssertEqual(messages[0].role, .user)
+        XCTAssertEqual(messages[0].text, "enable logging on the web ACL")
+        XCTAssertEqual(messages[1].role, .assistant)
+        XCTAssertEqual(messages[1].text, "On it.")
+    }
+
+    func testDropsMetaReminderAndToolNoise() {
+        let (cwd, sid) = writeTranscript(lines: [
+            #"{"type":"user","isMeta":true,"message":{"content":"injected context"}}"#,
+            #"{"type":"user","message":{"content":"<system-reminder>noise</system-reminder>"}}"#,
+            #"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{}}]}}"#,
+            #"{"type":"user","message":{"content":[{"type":"tool_result","content":"output"}]}}"#,
+            #"{"type":"user","message":{"content":"the only real message"}}"#
+        ])
+        let messages = TranscriptReader.messages(cwd: cwd, sessionId: sid)
+        XCTAssertEqual(messages.map(\.text), ["the only real message"])
+    }
+
+    func testTruncatesAnOverlongMessage() {
+        let huge = String(repeating: "x", count: TranscriptReader.maxMessageLength + 500)
+        let (cwd, sid) = writeTranscript(lines: [
+            #"{"type":"user","message":{"content":"\#(huge)"}}"#
+        ])
+        let messages = TranscriptReader.messages(cwd: cwd, sessionId: sid)
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].text.count, TranscriptReader.maxMessageLength + 1, "Truncated body plus the ellipsis")
+        XCTAssertTrue(messages[0].text.hasSuffix("…"))
+    }
+
+    func testReturnsEmptyWhenTranscriptMissing() {
+        let cwd = "/tmp/gavel-transcript-missing-\(UUID().uuidString)"
+        XCTAssertTrue(TranscriptReader.messages(cwd: cwd, sessionId: UUID().uuidString).isEmpty)
+    }
+
+    private func writeTranscript(lines: [String]) -> (cwd: String, sessionId: String) {
+        let cwd = "/tmp/gavel-transcript-test-\(UUID().uuidString)"
+        let sid = UUID().uuidString
+        let encoded = cwd
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+        let dir = (NSHomeDirectory() as NSString)
+            .appendingPathComponent(".claude/projects")
+            .appending("/\(encoded)")
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let path = dir + "/\(sid).jsonl"
+        try? (lines.joined(separator: "\n") + "\n").write(toFile: path, atomically: true, encoding: .utf8)
+        writtenPaths.append(path)
+        return (cwd, sid)
+    }
+}


### PR DESCRIPTION
## Why
Triaging unrecognized sleeping sessions had no path: Resume just copies a relaunch command, and `claude --resume` *respawns* a dead session you only wanted to read. So a pile of tombstones (e.g. 200 from a runaway loop) couldn't be told apart to name-or-ditch.

## What
- **History** button on every row (live + asleep) → scrollable transcript sheet (`TranscriptView`): user/assistant text only, tool/meta/`<…>`-envelope noise stripped, long messages truncated. **Rename** + **Forget** live in the sheet so the decision happens in one place.
- **`TranscriptReader`** parses the JSONL into ordered conversational turns; reuses the path convention via `JsonlRenameReader.transcriptText` (no duplication).
- **Forget Short** bottom-bar button forgets sleeping sessions with **≤1 conversational message** (aborted/empty), behind a count confirmation. Removes rows only — transcripts stay on disk. Scans off the main thread.

## Tests
4 new in `TranscriptReaderTests` (order, noise-drop, truncate, missing). Full suite **604/604**.

## Verified
Dogfooded on the live dev daemon against the real 200-row tombstone pile before shipping.