### PR TITLE
fix(matcher): prompt on temp-file exec instead of hard deny

### DIFF
--- a/Sources/Gavel/Approval/PatternMatcher.swift
+++ b/Sources/Gavel/Approval/PatternMatcher.swift
@@ -137,22 +137,11 @@ struct PatternMatcher {
             ("\\$\\(.*\\bbase64\\b.*--decode", "Base64 decode in subshell (command obfuscation)"),
             ("\\bbash\\s*<<", "Heredoc execution (potential obfuscation)"),
 
-            // ── Compiled/scripted exfiltration via temp files ──
-            // Compiling in temp directories
-            ("\\b(gcc|g\\+\\+|clang|clang\\+\\+|rustc|javac|swiftc)\\b.*/tmp/", "Compiling code in temp directory"),
-            ("\\b(go\\s+build|go\\s+run)\\b.*/tmp/", "Building/running Go code from temp directory"),
-            ("\\bcargo\\s+(build|run)\\b.*--manifest-path.*/tmp/", "Building Rust code from temp directory"),
-            // Executing scripts from temp directories
-            ("\\b(perl|ruby|node|swift|php|lua)\\b\\s+/tmp/", "Running script from temp directory"),
-            // Running any executable from /tmp (direct execution)
-            ("^\\s*/tmp/\\S+", "Running executable from temp directory"),
-            ("&&\\s*/tmp/\\S+", "Running executable from temp directory (chained)"),
-            ("\\|\\s*/tmp/\\S+", "Running executable from temp directory (piped)"),
-            (";\\s*/tmp/\\S+", "Running executable from temp directory (sequential)"),
-            // cd to /tmp then execute (bypass /tmp/ path check)
-            ("\\bcd\\s+/tmp\\b.*&&", "Changing to temp directory and executing"),
-            // chmod +x on temp files (making them executable)
-            ("\\bchmod\\b.*\\+x.*/tmp/", "Making temp file executable"),
+            // Note: the temp-file compile/run cluster (gcc/rustc/go/node from /tmp,
+            // chmod +x, cd /tmp && …) lives in rawAskUserBash, not here. Running scratch
+            // code from temp is routine dev work, so a hard deny false-positives constantly
+            // and only trains the agent to route around it; it prompts instead and still
+            // fails closed on timeout for unattended sessions.
         ]
 
         // Destructive/sensitive bash commands — force dialog instead of hard block
@@ -178,6 +167,23 @@ struct PatternMatcher {
             ("\\bcurl\\b.*(?-i:-d|--data|--data-raw|--data-binary|--data-urlencode|-F|--form|--upload-file|-T)\\b", "curl sending data — review for exfiltration"),
             ("\\bcrontab\\b", "crontab reference (broad — review)"),
             ("\\blaunchctl\\b\\s+(load|unload|submit|bootstrap|bootout|enable|disable|kickstart)", "LaunchAgent/Daemon modification"),
+
+            // ── Compiled/scripted exfiltration via temp files (prompt, not hard deny) ──
+            // Compiling in temp directories
+            ("\\b(gcc|g\\+\\+|clang|clang\\+\\+|rustc|javac|swiftc)\\b.*/tmp/", "Compiling code in temp directory"),
+            ("\\b(go\\s+build|go\\s+run)\\b.*/tmp/", "Building/running Go code from temp directory"),
+            ("\\bcargo\\s+(build|run)\\b.*--manifest-path.*/tmp/", "Building Rust code from temp directory"),
+            // Executing scripts from temp directories
+            ("\\b(perl|ruby|node|swift|php|lua)\\b\\s+/tmp/", "Running script from temp directory"),
+            // Running any executable from /tmp (direct execution)
+            ("^\\s*/tmp/\\S+", "Running executable from temp directory"),
+            ("&&\\s*/tmp/\\S+", "Running executable from temp directory (chained)"),
+            ("\\|\\s*/tmp/\\S+", "Running executable from temp directory (piped)"),
+            (";\\s*/tmp/\\S+", "Running executable from temp directory (sequential)"),
+            // cd to /tmp then execute (bypass /tmp/ path check)
+            ("\\bcd\\s+/tmp\\b.*&&", "Changing to temp directory and executing"),
+            // chmod +x on temp files (making them executable)
+            ("\\bchmod\\b.*\\+x.*/tmp/", "Making temp file executable"),
         ]
 
         // Hard block — credentials and persistence vectors that should never be written

--- a/Tests/GavelTests/ApprovalEngineTests.swift
+++ b/Tests/GavelTests/ApprovalEngineTests.swift
@@ -76,6 +76,12 @@ final class ApprovalEngineTests: XCTestCase {
         XCTAssertTrue(decision.askUser, "exfil-content heuristic must prompt, not silently deny")
     }
 
+    func testTempExecutionPromptsRatherThanHardDeny() {
+        let decision = engine.evaluate(payload: payload(command: "node /tmp/scratch.js"), session: session)
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertTrue(decision.askUser, "running from temp must prompt, not silently deny")
+    }
+
     func testBenignTempScriptNotBlocked() {
         let p = PreToolUsePayload(toolName: "Write", toolInput: [
             "file_path": AnyCodable("/tmp/hello.rs"),

--- a/Tests/GavelTests/PatternMatcherTests.swift
+++ b/Tests/GavelTests/PatternMatcherTests.swift
@@ -723,34 +723,38 @@ final class PatternMatcherTests: XCTestCase {
     }
 
     // MARK: - Compiled/scripted temp file execution
+    // These prompt (askUser tier via matchSensitivePath), not hard-deny — running scratch
+    // code from temp is routine dev work, and an unanswered prompt still fails closed.
 
-    func testGccTempBlocked() {
-        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "gcc /tmp/exfil.c -o /tmp/exfil && /tmp/exfil")))
+    func testGccTempPrompts() {
+        XCTAssertNil(matcher.matchDangerous(payload: bashPayload(command: "gcc /tmp/exfil.c -o /tmp/exfil && /tmp/exfil")))
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: bashPayload(command: "gcc /tmp/exfil.c -o /tmp/exfil && /tmp/exfil")))
     }
 
-    func testRustcTempBlocked() {
-        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "rustc /tmp/exfil.rs && /tmp/exfil")))
+    func testRustcTempPrompts() {
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: bashPayload(command: "rustc /tmp/exfil.rs && /tmp/exfil")))
     }
 
-    func testGoRunTempBlocked() {
-        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "go run /tmp/exfil.go")))
+    func testGoRunTempPrompts() {
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: bashPayload(command: "go run /tmp/exfil.go")))
     }
 
-    func testPerlTempBlocked() {
-        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "perl /tmp/exfil.pl")))
+    func testPerlTempPrompts() {
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: bashPayload(command: "perl /tmp/exfil.pl")))
     }
 
-    func testChmodTempBlocked() {
-        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "chmod +x /tmp/exfil && /tmp/exfil")))
+    func testChmodTempPrompts() {
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: bashPayload(command: "chmod +x /tmp/exfil && /tmp/exfil")))
     }
 
-    func testNodeTempBlocked() {
-        XCTAssertNotNil(matcher.matchDangerous(payload: bashPayload(command: "node /tmp/exfil.js")))
+    func testNodeTempPrompts() {
+        XCTAssertNotNil(matcher.matchSensitivePath(payload: bashPayload(command: "node /tmp/exfil.js")))
     }
 
     func testCompileInProjectAllowed() {
-        // Compiling in a project directory is fine
+        // Compiling in a project directory is fine — neither hard-deny nor prompt
         XCTAssertNil(matcher.matchDangerous(payload: bashPayload(command: "gcc src/main.c -o build/main")))
+        XCTAssertNil(matcher.matchSensitivePath(payload: bashPayload(command: "gcc src/main.c -o build/main")))
     }
 
     // MARK: - Write content scanning (polyglot exfil)


### PR DESCRIPTION
## What

The "Compiled/scripted exfiltration via temp files" cluster -- gcc/rustc/go/node run from `/tmp`, `chmod +x /tmp/…`, `cd /tmp && …`, and direct `/tmp/x` execution -- was a **hard deny** the agent couldn't escape.

Running scratch code from a temp dir is routine dev work, so it false-positives constantly. It even hard-blocked a `grep` whose pattern literally contained `|/tmp/` (matched the "piped" variant). A hard deny on a heuristic this broad just trains the agent to route around the matcher instead of surfacing the action.

## Change

Move the entire temp-exec cluster from `rawBash` (hard block) → `rawAskUserBash` (askUser prompt). It's relocated as a **unit** on purpose: splitting "run" from "compile/chmod" is an incoherent half-defense, since you can always pick the path that isn't hard-blocked (`node /tmp/x.js` needs no `chmod`).

## Why it's safe

`ApprovalCoordinator`'s timeout default is fail-closed. An unanswered prompt in an unattended/remote session still **blocks** -- no security regression. An attended human clears a false positive in one tap.

## Trade-off

These fire on routine temp execution, so they prompt often. A human who reflexively approves could wave through a real exfil execute, which a hard-deny can't. Accepted deliberately: the operator does legit temp execution constantly, and the Write side already prompts on script creation.

## Tests

- Retargeted the 6 temp-exec unit tests to `matchSensitivePath`; `testCompileInProjectAllowed` now asserts neither tier fires.
- New engine test `testTempExecutionPromptsRatherThanHardDeny` (block **and** askUser).
- Full suite: 607 tests, 0 failures.