### PR TITLE
feat(matcher): unconditional-prompt tier for guardrail-mutation writes

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -21,6 +21,16 @@ final class ApprovalCoordinator: ObservableObject {
         case alwaysDenyPattern(pattern: String, isRegex: Bool, explanation: String?)
         case alwaysAllowPattern(pattern: String, isRegex: Bool)
         case alwaysPromptPattern(pattern: String, isRegex: Bool)
+
+        /// Actions that grant a durable (non-Allow-once) allow — refused on nonSuppressible approvals.
+        var createsDurableAllow: Bool {
+            switch self {
+            case .allowPatternForSession, .suppressRuleForSession, .alwaysAllowPattern:
+                return true
+            default:
+                return false
+            }
+        }
     }
 
     /// RuleStore for persistent always-deny/always-allow rules.
@@ -47,6 +57,8 @@ final class ApprovalCoordinator: ObservableObject {
         let triggeringRuleId: UUID?
         let triggeringRulePattern: String?
         let triggeringRuleIsRegex: Bool
+        /// Allow-once only: the coordinator refuses session/persistent-allow actions for this approval.
+        let nonSuppressible: Bool
         let resolvable: ResolvableApproval
         let respond: (Decision) -> Void
     }
@@ -87,7 +99,8 @@ final class ApprovalCoordinator: ObservableObject {
         forceDialog: Bool = false,
         forceRemoteMirror: Bool = false,
         triggerReason: String? = nil,
-        triggeringRuleId: UUID? = nil
+        triggeringRuleId: UUID? = nil,
+        nonSuppressible: Bool = false
     ) -> Decision {
         if !forceDialog && session.isAutoApproveEnabled {
             return Decision(verdict: .allow, reason: "Auto-approved")
@@ -112,6 +125,7 @@ final class ApprovalCoordinator: ObservableObject {
             triggeringRuleId: triggeringRuleId,
             triggeringRulePattern: firingRule?.pattern,
             triggeringRuleIsRegex: firingRule?.isRegex ?? false,
+            nonSuppressible: nonSuppressible,
             resolvable: resolvable
         ) { decision in
             resolvable.resolve(decision, from: .mac)
@@ -156,7 +170,9 @@ final class ApprovalCoordinator: ObservableObject {
         if let withheld {
             gavelLog("[remote-gate] withheld command — pid=\(session.pid) trigger=\(withheld.logDescription)")
         }
-        let allowSession: () -> Void = {
+        // Allow-once-only approvals omit the closure so the phone's "Allow for session" button
+        // is never offered (and a stale press is a no-op — RemoteApprovalBridge guards on nil).
+        let allowSession: (() -> Void)? = pending.nonSuppressible ? nil : {
             let pattern = payload.command ?? payload.filePath ?? "*"
             let rule = SessionRule(toolName: payload.toolName, pattern: pattern)
             DispatchQueue.main.async { session.sessionRules.append(rule) }
@@ -190,6 +206,18 @@ final class ApprovalCoordinator: ObservableObject {
             "[approval] action pid=\(sessionPanel.pid) currentApproval=\(presentMarker) action=\(actionLogTag(action))"
         )
         guard let current = sessionPanel.currentApproval else { return }
+
+        // Guardrail-mutation paths are Allow-once only: refuse any durable-allow action and make
+        // the user re-decide. The HookRouter already won't consult session rules for these, so a
+        // rule created here would be dead anyway — failing loudly is clearer than silently no-op.
+        if current.nonSuppressible, action.createsDurableAllow {
+            gavelLog("[approval] refused durable-allow on nonSuppressible path pid=\(sessionPanel.pid) action=\(actionLogTag(action))")
+            current.respond(Decision(
+                verdict: .block,
+                reason: "Allow-once only for this path (Gavel/Claude config) — session and persistent allow are refused"))
+            advanceQueue(on: sessionPanel)
+            return
+        }
 
         // Build updatedInput if user modified the command
         func buildUpdatedInput(_ updatedCommand: String?) -> [String: AnyCodable]? {

--- a/Sources/Gavel/Approval/ApprovalEngine.swift
+++ b/Sources/Gavel/Approval/ApprovalEngine.swift
@@ -34,6 +34,12 @@ final class ApprovalEngine {
             return Decision(verdict: .block, reason: reason, askUser: true)
         }
 
+        // Guardrail-mutation writes prompt unconditionally: Allow-once only, never suppressible
+        // by a session/persistent allow. Must precede the regular sensitive-path tier.
+        if let reason = patternMatcher.matchUnconditionalPromptPath(payload: payload) {
+            return Decision(verdict: .block, reason: reason, askUser: true, nonSuppressible: true)
+        }
+
         if let reason = patternMatcher.matchSensitivePath(payload: payload) {
             return Decision(verdict: .block, reason: reason, askUser: true)
         }

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -562,14 +562,17 @@ struct ApprovalPanelView: View {
                 .tint(.red)
                 .keyboardShortcut("d", modifiers: [.command, .shift])
 
-                Button(action: {
-                    coordinator.handleAction(.alwaysAllowPattern(pattern: sessionPattern, isRegex: isRegexMode), on: sessionPanel)
-                }) {
-                    Label("Always Allow", systemImage: "shield.checkered")
+                // Durable-allow controls are hidden for Allow-once-only (guardrail-mutation) paths.
+                if !approval.nonSuppressible {
+                    Button(action: {
+                        coordinator.handleAction(.alwaysAllowPattern(pattern: sessionPattern, isRegex: isRegexMode), on: sessionPanel)
+                    }) {
+                        Label("Always Allow", systemImage: "shield.checkered")
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.blue)
+                    .keyboardShortcut("a", modifiers: [.command, .shift])
                 }
-                .buttonStyle(.bordered)
-                .tint(.blue)
-                .keyboardShortcut("a", modifiers: [.command, .shift])
 
                 Button(action: {
                     coordinator.handleAction(.alwaysPromptPattern(pattern: sessionPattern, isRegex: isRegexMode), on: sessionPanel)
@@ -594,22 +597,24 @@ struct ApprovalPanelView: View {
                 .tint(.pink)
                 .keyboardShortcut("d", modifiers: [.command])
 
-                Button(action: {
-                    coordinator.handleAction(.allowPatternForSession(
-                        pattern: sessionPattern,
-                        context: noteState.noteForAllowContext,
-                        updatedCommand: cmdIfModified,
-                        updatedInput: updatedInputIfModified
-                    ), on: sessionPanel)
-                    coordinator.sessionManager?.noteInteraction()
-                }) {
-                    Label("Session Allow", systemImage: "checkmark.shield")
+                if !approval.nonSuppressible {
+                    Button(action: {
+                        coordinator.handleAction(.allowPatternForSession(
+                            pattern: sessionPattern,
+                            context: noteState.noteForAllowContext,
+                            updatedCommand: cmdIfModified,
+                            updatedInput: updatedInputIfModified
+                        ), on: sessionPanel)
+                        coordinator.sessionManager?.noteInteraction()
+                    }) {
+                        Label("Session Allow", systemImage: "checkmark.shield")
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.purple)
+                    .keyboardShortcut("s", modifiers: [.command])
                 }
-                .buttonStyle(.bordered)
-                .tint(.purple)
-                .keyboardShortcut("s", modifiers: [.command])
 
-                if let ruleId = approval.triggeringRuleId {
+                if let ruleId = approval.triggeringRuleId, !approval.nonSuppressible {
                     Button(action: {
                         coordinator.handleAction(.suppressRuleForSession(
                             ruleId: ruleId,

--- a/Sources/Gavel/Approval/PatternMatcher.swift
+++ b/Sources/Gavel/Approval/PatternMatcher.swift
@@ -41,6 +41,11 @@ struct PatternMatcher {
     /// Pre-compiled protected file path patterns — force dialog (config, hooks, shell).
     private let askUserPaths: [(regex: NSRegularExpression, reason: String)]
 
+    /// Pre-compiled guardrail-mutation write paths — force dialog AND forbid any session/persistent
+    /// allow (Allow-once only). Hard-coded so the agent can't durably allow-list edits to Gavel's
+    /// own config or Claude Code's settings/hooks after one approval. See matchUnconditionalPromptPath.
+    private let unconditionalPromptPaths: [(regex: NSRegularExpression, reason: String)]
+
     /// Pre-compiled sensitive read patterns — hard block (actual secrets).
     private let sensitiveReads: [(regex: NSRegularExpression, reason: String)]
 
@@ -213,6 +218,14 @@ struct PatternMatcher {
             ("LaunchDaemons/", "Sensitive: LaunchDaemon (persistence vector)"),
         ]
 
+        // Unconditional prompt — guardrail-mutation writes. Allow-once ONLY: no session-allow,
+        // no persistent-allow, no rule suppression. These paths control Gavel's own behavior or
+        // Claude Code's hook/settings surface, so a durable allow on them is a guardrail escape.
+        let rawUnconditionalPaths: [(pattern: String, reason: String)] = [
+            ("\\.claude/gavel/", "Unconditional: Gavel config (Allow-once only)"),
+            ("\\.claude/(settings\\.json|settings\\.local\\.json|hooks/)", "Unconditional: Claude Code settings/hooks (Allow-once only)"),
+        ]
+
         bashPatterns = rawBash.compactMap { entry in
             guard let regex = try? NSRegularExpression(pattern: entry.pattern, options: [.caseInsensitive]) else {
                 return nil
@@ -235,6 +248,13 @@ struct PatternMatcher {
         }
 
         askUserPaths = rawAskUserPaths.compactMap { entry in
+            guard let regex = try? NSRegularExpression(pattern: entry.pattern, options: [.caseInsensitive]) else {
+                return nil
+            }
+            return (regex, entry.reason)
+        }
+
+        unconditionalPromptPaths = rawUnconditionalPaths.compactMap { entry in
             guard let regex = try? NSRegularExpression(pattern: entry.pattern, options: [.caseInsensitive]) else {
                 return nil
             }
@@ -336,8 +356,22 @@ struct PatternMatcher {
         }
     }
 
+    /// Guardrail-mutation writes that may be approved Allow-once ONLY (no session/persistent allow).
+    /// Writes only — reads of these paths fall through to the regular sensitive-read prompts.
+    func matchUnconditionalPromptPath(payload: PreToolUsePayload) -> String? {
+        guard ["Write", "Edit", "MultiEdit"].contains(payload.toolName),
+              let path = payload.filePath else { return nil }
+        let range = NSRange(path.startIndex..., in: path)
+        for (regex, reason) in unconditionalPromptPaths {
+            if regex.firstMatch(in: path, range: range) != nil {
+                return reason
+            }
+        }
+        return nil
+    }
+
     /// Check sensitive paths that require user confirmation (gavel config, hooks, shell config).
-    /// Called from ApprovalEngine AFTER allow rules — returns askUser decision.
+    /// Returns an askUser decision; runs before allow rules in ApprovalEngine.
     func matchSensitivePath(payload: PreToolUsePayload) -> String? {
         // Bash: check askUser destructive patterns (rm -rf etc.)
         if payload.toolName == "Bash", let command = payload.command {

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -164,26 +164,30 @@ final class HookRouter {
         let engineDecision = approvalEngine.evaluate(payload: payload, session: session)
         if engineDecision.verdict == .block {
             if engineDecision.askUser {
-                // Rule suppressed for session — covers the rule's full regex scope.
-                if let ruleId = engineDecision.triggeringRuleId,
-                   session.suppressedRuleIds.contains(ruleId) {
-                    session.stats.incrementAllow()
-                    emitFeed(.decision(badge: .allow, reason: "Rule suppressed for session", pid: session.pid, at: timestamp))
-                    sendResponse(Decision(verdict: .allow, reason: "Rule suppressed for session"), payload: payload, session: session, respond: respond)
-                    return
-                }
+                // Unconditional prompts (guardrail-mutation writes) can't be short-circuited by a
+                // session-allow or a suppressed rule — they always reach the dialog, Allow-once only.
+                if !engineDecision.nonSuppressible {
+                    // Rule suppressed for session — covers the rule's full regex scope.
+                    if let ruleId = engineDecision.triggeringRuleId,
+                       session.suppressedRuleIds.contains(ruleId) {
+                        session.stats.incrementAllow()
+                        emitFeed(.decision(badge: .allow, reason: "Rule suppressed for session", pid: session.pid, at: timestamp))
+                        sendResponse(Decision(verdict: .allow, reason: "Rule suppressed for session"), payload: payload, session: session, respond: respond)
+                        return
+                    }
 
-                // Before forcing dialog, check if a session rule already covers this.
-                // Session Allow from a previous dialog should skip re-prompting.
-                if let rule = session.matchesSessionRule(
-                    toolName: payload.toolName,
-                    command: payload.command,
-                    filePath: payload.filePath
-                ) {
-                    session.stats.incrementAllow()
-                    emitFeed(.decision(badge: .allow, reason: "Session rule: \(rule.toolName): \(rule.pattern)", pid: session.pid, at: timestamp))
-                    sendResponse(Decision(verdict: .allow, reason: "Session rule: \(rule.pattern)"), payload: payload, session: session, respond: respond)
-                    return
+                    // Before forcing dialog, check if a session rule already covers this.
+                    // Session Allow from a previous dialog should skip re-prompting.
+                    if let rule = session.matchesSessionRule(
+                        toolName: payload.toolName,
+                        command: payload.command,
+                        filePath: payload.filePath
+                    ) {
+                        session.stats.incrementAllow()
+                        emitFeed(.decision(badge: .allow, reason: "Session rule: \(rule.toolName): \(rule.pattern)", pid: session.pid, at: timestamp))
+                        sendResponse(Decision(verdict: .allow, reason: "Session rule: \(rule.pattern)"), payload: payload, session: session, respond: respond)
+                        return
+                    }
                 }
 
                 // MCP-style block: jump straight to interactive dialog
@@ -193,7 +197,8 @@ final class HookRouter {
                     payload: payload, session: session, timestamp: timestamp,
                     forceDialog: true,
                     triggerReason: engineDecision.reason,
-                    triggeringRuleId: engineDecision.triggeringRuleId
+                    triggeringRuleId: engineDecision.triggeringRuleId,
+                    nonSuppressible: engineDecision.nonSuppressible
                 )
                 switch decision.verdict {
                 case .allow, .prompt:

--- a/Sources/Gavel/Models/Decision.swift
+++ b/Sources/Gavel/Models/Decision.swift
@@ -23,14 +23,21 @@ struct Decision: Codable {
     let askUser: Bool
     /// Set when a persistent prompt rule fired — used by per-session rule suppression.
     let triggeringRuleId: UUID?
+    /// When true, this prompt may only be satisfied by Allow-once: the router must not let a
+    /// session-allow or suppressed-rule short-circuit it, and the coordinator must refuse any
+    /// attempt to create a session/persistent allow for it. Hard-coded for guardrail-mutation
+    /// paths (Gavel config, Claude settings/hooks) so the agent can't durably allow-list its
+    /// own self-mutation after a single approval.
+    let nonSuppressible: Bool
 
-    init(verdict: DecisionVerdict, reason: String?, additionalContext: String? = nil, updatedInput: [String: AnyCodable]? = nil, askUser: Bool = false, triggeringRuleId: UUID? = nil) {
+    init(verdict: DecisionVerdict, reason: String?, additionalContext: String? = nil, updatedInput: [String: AnyCodable]? = nil, askUser: Bool = false, triggeringRuleId: UUID? = nil, nonSuppressible: Bool = false) {
         self.verdict = verdict
         self.reason = reason
         self.additionalContext = additionalContext
         self.updatedInput = updatedInput
         self.askUser = askUser
         self.triggeringRuleId = triggeringRuleId
+        self.nonSuppressible = nonSuppressible
     }
 
     /// Internal protocol JSON sent to the gavel-hook shim via socket.

--- a/Sources/Gavel/Remote/RemoteApprovalBridge.swift
+++ b/Sources/Gavel/Remote/RemoteApprovalBridge.swift
@@ -105,10 +105,13 @@ final class RemoteApprovalBridge {
         var keyboard: [[TelegramButton]] = [
             [TelegramButton(text: "✅ Allow once", callbackData: "a:\(nonce)"),
              TelegramButton(text: "🛑 Deny", callbackData: "d:\(nonce)")],
-            [TelegramButton(text: "✅ Allow for session", callbackData: "s:\(nonce)")],
-            [TelegramButton(text: "✅ Allow w/ note", callbackData: "ar:\(nonce)"),
-             TelegramButton(text: "🛑 Deny w/ reason", callbackData: "dr:\(nonce)")]
         ]
+        // Allow-once-only approvals (nil allowSession) omit the session button entirely.
+        if allowSession != nil {
+            keyboard.append([TelegramButton(text: "✅ Allow for session", callbackData: "s:\(nonce)")])
+        }
+        keyboard.append([TelegramButton(text: "✅ Allow w/ note", callbackData: "ar:\(nonce)"),
+                         TelegramButton(text: "🛑 Deny w/ reason", callbackData: "dr:\(nonce)")])
         if offerCommentClean {
             keyboard.append([TelegramButton(text: "🧹 Clean comments & re-propose", callbackData: "c:\(nonce)")])
         }

--- a/Tests/GavelTests/ApprovalEngineTests.swift
+++ b/Tests/GavelTests/ApprovalEngineTests.swift
@@ -76,10 +76,74 @@ final class ApprovalEngineTests: XCTestCase {
         XCTAssertTrue(decision.askUser, "exfil-content heuristic must prompt, not silently deny")
     }
 
+    // The backstop in ApprovalCoordinator.handleAction refuses exactly these actions on a
+    // nonSuppressible approval. Allow-once and all deny/prompt actions must stay permitted.
+    func testCreatesDurableAllowClassification() {
+        typealias A = ApprovalCoordinator.Action
+        XCTAssertTrue(A.allowPatternForSession(pattern: "*", context: nil, updatedCommand: nil, updatedInput: nil).createsDurableAllow)
+        XCTAssertTrue(A.suppressRuleForSession(ruleId: UUID(), context: nil, updatedCommand: nil, updatedInput: nil).createsDurableAllow)
+        XCTAssertTrue(A.alwaysAllowPattern(pattern: "*", isRegex: false).createsDurableAllow)
+
+        XCTAssertFalse(A.allow(context: nil, updatedCommand: nil, updatedInput: nil).createsDurableAllow)
+        XCTAssertFalse(A.deny(context: nil).createsDurableAllow)
+        XCTAssertFalse(A.denyPatternForSession(pattern: "*", explanation: nil).createsDurableAllow)
+        XCTAssertFalse(A.alwaysDenyPattern(pattern: "*", isRegex: false, explanation: nil).createsDurableAllow)
+        XCTAssertFalse(A.alwaysPromptPattern(pattern: "*", isRegex: false).createsDurableAllow)
+    }
+
     func testTempExecutionPromptsRatherThanHardDeny() {
         let decision = engine.evaluate(payload: payload(command: "node /tmp/scratch.js"), session: session)
         XCTAssertEqual(decision.verdict, .block)
         XCTAssertTrue(decision.askUser, "running from temp must prompt, not silently deny")
+    }
+
+    func testGavelConfigWriteIsNonSuppressiblePrompt() {
+        let p = PreToolUsePayload(toolName: "Write", toolInput: [
+            "file_path": AnyCodable("/Users/x/.claude/gavel/rules.json"),
+            "content": AnyCodable("[]"),
+        ])
+        let decision = engine.evaluate(payload: p, session: session)
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertTrue(decision.askUser)
+        XCTAssertTrue(decision.nonSuppressible, "Gavel config writes must be Allow-once only")
+    }
+
+    func testClaudeSettingsWriteIsNonSuppressiblePrompt() {
+        let p = PreToolUsePayload(toolName: "Write", toolInput: [
+            "file_path": AnyCodable("/Users/x/.claude/settings.json"),
+            "content": AnyCodable("{}"),
+        ])
+        let decision = engine.evaluate(payload: p, session: session)
+        XCTAssertTrue(decision.nonSuppressible)
+    }
+
+    func testClaudeHookWriteIsNonSuppressiblePrompt() {
+        let p = PreToolUsePayload(toolName: "Write", toolInput: [
+            "file_path": AnyCodable("/Users/x/.claude/hooks/pre_tool_use.sh"),
+            "content": AnyCodable("#!/bin/bash"),
+        ])
+        let decision = engine.evaluate(payload: p, session: session)
+        XCTAssertTrue(decision.nonSuppressible)
+    }
+
+    func testReadingGavelConfigIsNotNonSuppressible() {
+        // Reads stay regular sensitive-prompts — only writes are unconditional.
+        let p = PreToolUsePayload(toolName: "Read", toolInput: [
+            "file_path": AnyCodable("/Users/x/.claude/gavel/rules.json"),
+        ])
+        let decision = engine.evaluate(payload: p, session: session)
+        XCTAssertFalse(decision.nonSuppressible)
+    }
+
+    func testOrdinarySensitiveWriteIsNotNonSuppressible() {
+        let p = PreToolUsePayload(toolName: "Write", toolInput: [
+            "file_path": AnyCodable("/Users/x/.zshrc"),
+            "content": AnyCodable("export X=1"),
+        ])
+        let decision = engine.evaluate(payload: p, session: session)
+        XCTAssertEqual(decision.verdict, .block)
+        XCTAssertTrue(decision.askUser)
+        XCTAssertFalse(decision.nonSuppressible, "shell config prompts but stays suppressible")
     }
 
     func testBenignTempScriptNotBlocked() {

--- a/Tests/GavelTests/PatternMatcherTests.swift
+++ b/Tests/GavelTests/PatternMatcherTests.swift
@@ -526,6 +526,30 @@ final class PatternMatcherTests: XCTestCase {
         XCTAssertNil(matcher.matchDangerous(payload: writePayload(filePath: "/Users/x/project/src/main.swift")))
     }
 
+    // MARK: - Unconditional prompt paths (Allow-once only)
+
+    func testGavelConfigWriteIsUnconditional() {
+        XCTAssertNotNil(matcher.matchUnconditionalPromptPath(payload: writePayload(filePath: "/Users/x/.claude/gavel/rules.json")))
+        XCTAssertNotNil(matcher.matchUnconditionalPromptPath(payload: writePayload(filePath: "/Users/x/.claude/gavel/session-context.md")))
+    }
+
+    func testClaudeSettingsAndHooksWriteIsUnconditional() {
+        XCTAssertNotNil(matcher.matchUnconditionalPromptPath(payload: writePayload(filePath: "/Users/x/.claude/settings.json")))
+        XCTAssertNotNil(matcher.matchUnconditionalPromptPath(payload: writePayload(filePath: "/Users/x/.claude/settings.local.json")))
+        XCTAssertNotNil(matcher.matchUnconditionalPromptPath(payload: editPayload(filePath: "/Users/x/.claude/hooks/pre_tool_use.sh")))
+    }
+
+    func testReadingUnconditionalPathIsNotUnconditional() {
+        // Writes only — reads fall through to the regular sensitive-read prompts.
+        let read = PreToolUsePayload(toolName: "Read", toolInput: ["file_path": AnyCodable("/Users/x/.claude/gavel/rules.json")])
+        XCTAssertNil(matcher.matchUnconditionalPromptPath(payload: read))
+    }
+
+    func testOrdinarySensitiveAndNormalWritesAreNotUnconditional() {
+        XCTAssertNil(matcher.matchUnconditionalPromptPath(payload: writePayload(filePath: "/Users/x/.zshrc")))
+        XCTAssertNil(matcher.matchUnconditionalPromptPath(payload: writePayload(filePath: "/Users/x/project/src/main.swift")))
+    }
+
     // MARK: - Edit protected paths
 
     func testEditClaudeSettingsBlocked() {


### PR DESCRIPTION
## What

Adds a new hard-coded **unconditional prompt** tier: writes to Gavel's own config (`~/.claude/gavel/` -- rules.json, session-context.md) and Claude Code's settings/hooks (`~/.claude/settings.json`, `settings.local.json`, `hooks/`) may be approved **Allow-once only**. Session-allow, persistent-allow, and rule-suppression are refused.

## Why -- a real self-mutation escape

A write to `rules.json` already prompted. But picking **"Allow for session"** created a `SessionRule` that `HookRouter` consults *before* showing the dialog (lines 176-187), so every subsequent write was silently allowed. `suppressedRuleIds` had the same effect. That let the agent durably allow-list edits to its own guardrail after a single approval. (Persistent-allow couldn't do this -- the engine checks sensitive paths before `evaluateAllow` -- but session-allow and suppression could.)

## Implementation

- **`PatternMatcher.matchUnconditionalPromptPath`** -- hard-coded guardrail-set list, **writes only** (`Write`/`Edit`/`MultiEdit`). Reads fall through to the regular, suppressible sensitive-read prompts.
- **`Decision.nonSuppressible`** -- set by `ApprovalEngine` before the regular sensitive-path tier.
- **`HookRouter`** -- skips the session-rule / suppressed-rule bypass when `nonSuppressible`, so these always reach the dialog.
- **`ApprovalCoordinator.handleAction`** -- refuses durable-allow actions (`block` + error) via a `createsDurableAllow` classifier. The HookRouter wouldn't honor such a rule anyway, so failing loudly beats a silent no-op.
- **Mac UI** hides Always Allow / Session Allow / Allow Rule for these approvals; **Telegram** omits the "Allow for session" button and no-ops a stale press.

## Scope

Guardrail set only (chosen deliberately: a session-allow on `settings.json` or a hook can disable Gavel entirely -- same hole as rules.json). Credential hard-denies are unchanged. Reads stay regular sensitive-prompts.

## Tests

Matcher (gavel/settings/hooks writes match; reads and ordinary paths don't), engine `nonSuppressible` flag, and the `createsDurableAllow` classifier the backstop keys on. The router suppression-skip and coordinator refusal aren't unit-tested because a `nonSuppressible` decision always reaches the dialog and the 86400s approval timeout would hang the runner -- the existing suite has the same constraint. **617 tests, 0 failures.**