### PR TITLE
feat(matcher): extend unconditional tier to outbound + exec-persistence vectors

### DIFF
--- a/Sources/Gavel/Approval/PatternMatcher.swift
+++ b/Sources/Gavel/Approval/PatternMatcher.swift
@@ -224,6 +224,9 @@ struct PatternMatcher {
         let rawUnconditionalPaths: [(pattern: String, reason: String)] = [
             ("\\.claude/gavel/", "Unconditional: Gavel config (Allow-once only)"),
             ("\\.claude/(settings\\.json|settings\\.local\\.json|hooks/)", "Unconditional: Claude Code settings/hooks (Allow-once only)"),
+            ("\\.mcp\\.json$", "Unconditional: MCP server config (Allow-once only)"),
+            ("\\.git/hooks/", "Unconditional: Git hook — runs on git ops (Allow-once only)"),
+            ("\\.github/workflows/", "Unconditional: CI workflow — runs with repo secrets (Allow-once only)"),
         ]
 
         bashPatterns = rawBash.compactMap { entry in

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -24,7 +24,7 @@ final class RuleStore: ObservableObject {
     )
 
     /// Current seed version — bump when adding new default rules.
-    private static let seedVersion = 12
+    private static let seedVersion = 13
 
     /// Built-in patterns replaced by a corrected/broadened seeded rule. On re-seed
     /// these are dropped from existing rules.json so a pattern fix swaps cleanly
@@ -33,7 +33,9 @@ final class RuleStore: ObservableObject {
         "\\bgit\\s+commit\\b",  // broadened to catch `git -C <path> commit` etc.
         "\\.claude/(gavel/|settings|hooks/)",  // trailing-slash form missed `-v ~/.claude/gavel:/dst` (colon)
         "\\.claude/(gavel|settings|hooks)\\b|\\.codex/(config|hooks)\\b",  // broadened to cover .mcp.json
-        "\\.claude/(gavel/|settings|hooks/)|\\.codex/(config|hooks)|\\.(zshrc|bashrc|bash_profile|profile)\\b"  // apply_patch: + .mcp.json
+        "\\.claude/(gavel/|settings|hooks/)|\\.codex/(config|hooks)|\\.(zshrc|bashrc|bash_profile|profile)\\b",  // apply_patch: + .mcp.json
+        "\\bgit\\b(\\s+-{1,2}\\S+(\\s+\\S+)?)*\\s+commit\\b",  // re-seed commit checkpoint as nonSuppressible
+        "git\\s+push\\b.*\\b(main|master)\\b"  // replaced by any-branch nonSuppressible push checkpoint
     ]
 
     init(configPath: String? = nil) {
@@ -95,7 +97,7 @@ final class RuleStore: ObservableObject {
     func evaluateBuiltInPromptNonOverridable(payload: PreToolUsePayload) -> Decision? {
         for i in rules.indices where rules[i].verdict == .prompt && rules[i].builtIn && !rules[i].overridable && !rules[i].isDisabled {
             if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
-                return Decision(verdict: .block, reason: "Checkpoint: \(rules[i].name)", askUser: true, triggeringRuleId: rules[i].id)
+                return Decision(verdict: .block, reason: "Checkpoint: \(rules[i].name)", askUser: true, triggeringRuleId: rules[i].id, nonSuppressible: rules[i].nonSuppressible)
             }
         }
         return nil
@@ -295,7 +297,7 @@ final class RuleStore: ObservableObject {
             builtIn: true
         ),
 
-        // ── Git safety: destructive reset and push to main ──
+        // ── Git safety: destructive reset (discards uncommitted work) ──
         PersistentRule(
             toolName: "Bash",
             pattern: "\\bgit\\s+(reset\\s+--hard|checkout\\s+--\\s+\\.|clean\\s+-[fd]|restore\\s+--staged\\s+\\.)",
@@ -304,16 +306,44 @@ final class RuleStore: ObservableObject {
             explanation: "Destructive git operation — discards uncommitted work",
             builtIn: true
         ),
+
+        // ── Outbound git: push / remote repoint — Allow-once only (the publish/exfil moment) ──
+        // Any-branch push, not just main: pushing a feature branch still sends code off-machine.
+        // Same git-global-option tolerance as the commit pattern so `git -C /repo push` can't slip past.
         PersistentRule(
-            toolName: "*",
-            pattern: "git\\s+push\\b.*\\b(main|master)\\b",
+            toolName: "Bash",
+            pattern: "\\bgit\\b(\\s+-{1,2}\\S+(\\s+\\S+)?)*\\s+push\\b",
             isRegex: true,
             verdict: .prompt,
-            explanation: "Push to main/master — verify changes before pushing",
-            builtIn: true
+            explanation: "Push checkpoint — code leaves the machine; review before publishing",
+            builtIn: true,
+            overridable: false,
+            nonSuppressible: true
+        ),
+        PersistentRule(
+            toolName: "Bash",
+            pattern: "\\bgit\\b(\\s+-{1,2}\\S+(\\s+\\S+)?)*\\s+remote\\s+(add|set-url)\\b",
+            isRegex: true,
+            verdict: .prompt,
+            explanation: "Git remote repoint — changes where pushes go",
+            builtIn: true,
+            overridable: false,
+            nonSuppressible: true
         ),
 
-        // ── Commit checkpoint (non-overridable: a broad allow rule can't silence it) ──
+        // ── Supply-chain publish: outbound artifact — Allow-once only ──
+        PersistentRule(
+            toolName: "Bash",
+            pattern: "\\b(npm\\s+publish|yarn\\s+publish|pnpm\\s+publish|twine\\s+upload|cargo\\s+publish|docker\\s+push|gh\\s+release\\s+create|gh\\s+gist\\s+create)\\b",
+            isRegex: true,
+            verdict: .prompt,
+            explanation: "Publish/upload — outbound artifact (supply chain)",
+            builtIn: true,
+            overridable: false,
+            nonSuppressible: true
+        ),
+
+        // ── Commit checkpoint — Allow-once only (identity-attributing; can't be session-allowed) ──
         // Tolerates git global options before the subcommand (`-C <path>`, `-c k=v`,
         // `--no-pager`) so `git -C /repo commit` can't slip past the bare-form pattern.
         PersistentRule(
@@ -323,7 +353,8 @@ final class RuleStore: ObservableObject {
             verdict: .prompt,
             explanation: "Commit checkpoint — review staged changes before recording history",
             builtIn: true,
-            overridable: false
+            overridable: false,
+            nonSuppressible: true
         ),
 
         PersistentRule(
@@ -540,6 +571,10 @@ struct PersistentRule: Codable, Identifiable {
     let builtIn: Bool
     /// When true (default), a user allow rule can override this built-in prompt; false marks a hard checkpoint (e.g. git commit) that allow rules can't silence.
     let overridable: Bool
+    /// When true, this checkpoint is Allow-once only: the router won't let a session-allow or
+    /// suppressed-rule short-circuit it, and the coordinator refuses session/persistent allow on it.
+    /// Hard-coded on built-in rules guarding irreversible/outbound actions (commit, push, publish).
+    let nonSuppressible: Bool
     /// Skip this rule during evaluation when true. Persisted so the disable
     /// survives daemon restarts (so a forgotten "temporarily off" rule still
     /// surfaces in the UI rather than silently re-engaging on reboot). Toggle
@@ -558,11 +593,11 @@ struct PersistentRule: Codable, Identifiable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, toolName, pattern, isRegex, verdict, createdAt, explanation, builtIn, overridable, isDisabled
+        case id, name, toolName, pattern, isRegex, verdict, createdAt, explanation, builtIn, overridable, isDisabled, nonSuppressible
     }
 
-    /// Backward-compatible decoding — isRegex, explanation, builtIn, isDisabled
-    /// all default for old rules.json files lacking the field.
+    /// Backward-compatible decoding — isRegex, explanation, builtIn, isDisabled,
+    /// nonSuppressible all default for old rules.json files lacking the field.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         id = try c.decode(UUID.self, forKey: .id)
@@ -576,6 +611,7 @@ struct PersistentRule: Codable, Identifiable {
         builtIn = try c.decodeIfPresent(Bool.self, forKey: .builtIn) ?? false
         overridable = try c.decodeIfPresent(Bool.self, forKey: .overridable) ?? true
         isDisabled = try c.decodeIfPresent(Bool.self, forKey: .isDisabled) ?? false
+        nonSuppressible = try c.decodeIfPresent(Bool.self, forKey: .nonSuppressible) ?? false
     }
 
     init(
@@ -586,7 +622,8 @@ struct PersistentRule: Codable, Identifiable {
         explanation: String? = nil,
         builtIn: Bool = false,
         overridable: Bool = true,
-        isDisabled: Bool = false
+        isDisabled: Bool = false,
+        nonSuppressible: Bool = false
     ) {
         self.id = UUID()
         self.toolName = toolName
@@ -599,6 +636,7 @@ struct PersistentRule: Codable, Identifiable {
         self.builtIn = builtIn
         self.overridable = overridable
         self.isDisabled = isDisabled
+        self.nonSuppressible = nonSuppressible
         self._compiledRegex = Self.compilePattern(pattern, isRegex: isRegex)
     }
 
@@ -615,6 +653,7 @@ struct PersistentRule: Codable, Identifiable {
         self.builtIn = old.builtIn
         self.overridable = old.overridable
         self.isDisabled = old.isDisabled
+        self.nonSuppressible = old.nonSuppressible
         self._compiledRegex = Self.compilePattern(pattern, isRegex: isRegex)
     }
 

--- a/Tests/GavelTests/ApprovalEngineTests.swift
+++ b/Tests/GavelTests/ApprovalEngineTests.swift
@@ -181,6 +181,33 @@ final class ApprovalEngineTests: XCTestCase {
         XCTAssertTrue(decision.askUser)
     }
 
+    // Outbound / identity-attributing git + supply-chain publish are Allow-once only.
+    func testOutboundAndCommitCheckpointsAreNonSuppressible() {
+        for cmd in [
+            "git commit -m \"wip\"",
+            "git push origin feature/x",
+            "git -C /repo push",
+            "git remote add evil https://attacker.example/r.git",
+            "git remote set-url origin https://attacker.example/r.git",
+            "npm publish",
+            "docker push registry.example/img:tag",
+            "gh release create v1.2.3",
+            "gh gist create secret.txt",
+        ] {
+            let decision = engine.evaluate(payload: payload(command: cmd), session: session)
+            XCTAssertEqual(decision.verdict, .block, "should checkpoint: \(cmd)")
+            XCTAssertTrue(decision.askUser, "should prompt: \(cmd)")
+            XCTAssertTrue(decision.nonSuppressible, "should be Allow-once only: \(cmd)")
+        }
+    }
+
+    func testOrdinaryGitAndBuildAreNotNonSuppressible() {
+        for cmd in ["git status", "git add -A", "git fetch origin", "npm install", "npm run build"] {
+            let decision = engine.evaluate(payload: payload(command: cmd), session: session)
+            XCTAssertFalse(decision.nonSuppressible, "should not be unconditional: \(cmd)")
+        }
+    }
+
     func testCommitCheckpointCatchesGitGlobalOptionForms() {
         session.autoApproveUntil = Date().addingTimeInterval(300)
         for cmd in [

--- a/Tests/GavelTests/PatternMatcherTests.swift
+++ b/Tests/GavelTests/PatternMatcherTests.swift
@@ -539,6 +539,12 @@ final class PatternMatcherTests: XCTestCase {
         XCTAssertNotNil(matcher.matchUnconditionalPromptPath(payload: editPayload(filePath: "/Users/x/.claude/hooks/pre_tool_use.sh")))
     }
 
+    func testMcpAndGitHookAndWorkflowWritesAreUnconditional() {
+        XCTAssertNotNil(matcher.matchUnconditionalPromptPath(payload: writePayload(filePath: "/Users/x/project/.mcp.json")))
+        XCTAssertNotNil(matcher.matchUnconditionalPromptPath(payload: writePayload(filePath: "/Users/x/project/.git/hooks/pre-commit")))
+        XCTAssertNotNil(matcher.matchUnconditionalPromptPath(payload: editPayload(filePath: "/Users/x/project/.github/workflows/ci.yml")))
+    }
+
     func testReadingUnconditionalPathIsNotUnconditional() {
         // Writes only — reads fall through to the regular sensitive-read prompts.
         let read = PreToolUsePayload(toolName: "Read", toolInput: ["file_path": AnyCodable("/Users/x/.claude/gavel/rules.json")])

--- a/Tests/GavelTests/PersistentRuleTests.swift
+++ b/Tests/GavelTests/PersistentRuleTests.swift
@@ -185,7 +185,7 @@ final class PersistentRuleTests: XCTestCase {
         let store = RuleStore(configPath: "/dev/null")
         let builtInRules = store.rules.filter { $0.builtIn }
         XCTAssertEqual(builtInRules.count, RuleStore.seededDefaults.count)
-        XCTAssertEqual(builtInRules.count, 23)
+        XCTAssertEqual(builtInRules.count, 25)
     }
 
     func testSeededRulesArePromptVerdict() {

--- a/Tests/GavelTests/PromptOverrideTest.swift
+++ b/Tests/GavelTests/PromptOverrideTest.swift
@@ -50,12 +50,13 @@ final class PromptOverrideTest: XCTestCase {
         let path = NSTemporaryDirectory() + "promptoverride-\(UUID().uuidString).json"
         defer { try? FileManager.default.removeItem(atPath: path) }
         let store = RuleStore(configPath: path)
-        store.addRule(PersistentRule(toolName: "Bash", pattern: "git push*", verdict: .prompt))
+        // Neutral command: git push is now a nonSuppressible checkpoint and would reach the dialog.
+        store.addRule(PersistentRule(toolName: "Bash", pattern: "mytool sync*", verdict: .prompt))
 
         let session = Session(pid: 88881)
-        session.sessionRules.append(SessionRule(toolName: "Bash", pattern: "git push*"))
+        session.sessionRules.append(SessionRule(toolName: "Bash", pattern: "mytool sync*"))
 
-        let response = runRouter(session: session, store: store, toolInputJson: bashInput("git push origin main"))
+        let response = runRouter(session: session, store: store, toolInputJson: bashInput("mytool sync --all"))
         XCTAssertEqual(response?["verdict"] as? String, "allow",
                        "Session allow should override user always-prompt rule. Got: \(String(describing: response))")
     }
@@ -64,12 +65,13 @@ final class PromptOverrideTest: XCTestCase {
         let path = NSTemporaryDirectory() + "promptoverride-\(UUID().uuidString).json"
         defer { try? FileManager.default.removeItem(atPath: path) }
         let store = RuleStore(configPath: path)
-        store.addRule(PersistentRule(toolName: "Bash", pattern: "git push*", isRegex: false, verdict: .prompt, builtIn: true))
+        // Overridable built-in prompt on a neutral command (real git push is now nonSuppressible).
+        store.addRule(PersistentRule(toolName: "Bash", pattern: "mytool sync*", isRegex: false, verdict: .prompt, builtIn: true))
 
         let session = Session(pid: 88882)
-        session.sessionRules.append(SessionRule(toolName: "Bash", pattern: "git push*"))
+        session.sessionRules.append(SessionRule(toolName: "Bash", pattern: "mytool sync*"))
 
-        let response = runRouter(session: session, store: store, toolInputJson: bashInput("git push origin main"))
+        let response = runRouter(session: session, store: store, toolInputJson: bashInput("mytool sync --all"))
         XCTAssertEqual(response?["verdict"] as? String, "allow",
                        "Session allow should override built-in prompt rule. Got: \(String(describing: response))")
     }


### PR DESCRIPTION
## What

Extends the Allow-once-only (`nonSuppressible`) tier from 1.36.0 to the rest of the threat model: vectors where one session-allow would let the agent act silently and harmfully.

**Path writes** (`matchUnconditionalPromptPath`):
- `.mcp.json` -- MCP server definition (plants a tool that runs code)
- `.git/hooks/` -- runs on the next git op (parallel to `.claude/hooks`; was uncovered)
- `.github/workflows/` -- runs in CI with repo secrets, supply chain (was uncovered)

**Command checkpoints** (built-in `nonSuppressible` rules):
- `git commit` -- was non-overridable but still session-suppressible; now Allow-once
- `git push` (any branch) + `git remote add/set-url` -- the outbound/exfil moment; replaces the old `main`/`master`-only, fully-suppressible push rule
- `npm`/`yarn`/`pnpm publish`, `twine upload`, `cargo publish`, `docker push`, `gh release create`, `gh gist create` -- outbound artifacts

## Mechanism

New `PersistentRule.nonSuppressible` (backward-compatible `decodeIfPresent` default `false`) flows through `evaluateBuiltInPromptNonOverridable` into `Decision.nonSuppressible` -- reusing the exact router/coordinator/UI enforcement shipped in 1.36.0. `seedVersion` 12→13; the old commit and push-to-main patterns are added to `supersededBuiltInPatterns` so an existing `rules.json` swaps cleanly instead of keeping the stale rule.

## Test note

`git push`/`commit` are now non-suppressible, so two `PromptOverrideTest` router tests that used `git push` as a generic prompt trigger would reach the dialog and hang on the 86400s timeout -- switched to a neutral command (they test the session-allow *override mechanism*, not git). Added engine-level assertions that the new vectors are `nonSuppressible`, and that ordinary git (`status`/`add`/`fetch`) and `npm install`/`build` are **not**. **620 tests, 0 failures.**

## Known trade-off

The push pattern is unanchored (same as the commit checkpoint, for `git -C /repo push` tolerance), so a benign command containing the substring `git push` (e.g. an `echo`) can trigger a spurious prompt. Pre-existing behavior for the commit checkpoint; accepted for consistency.