### PR TITLE
feat(matcher): gate .aws/config + close the Bash-bypass of guardrail paths

### DIFF
--- a/Sources/Gavel/Approval/PatternMatcher.swift
+++ b/Sources/Gavel/Approval/PatternMatcher.swift
@@ -197,8 +197,10 @@ struct PatternMatcher {
             ("\\.ssh/(id_|authorized_keys|config)", "Protected: SSH keys/config"),
             // GPG keys
             ("\\.gnupg/", "Protected: GPG keys"),
-            // AWS/cloud credentials
-            ("\\.aws/(credentials|config)", "Protected: AWS credentials"),
+            // AWS/cloud credentials — the secret file stays hard-blocked; .aws/config
+            // (profiles/SSO/role config) is unconditional-prompt instead, since it's
+            // legitimately edited but can repoint a profile to a hostile role.
+            ("\\.aws/credentials", "Protected: AWS credentials"),
             ("\\.kube/config", "Protected: Kubernetes config"),
             // Environment files
             ("\\.env$", "Protected: Environment file"),
@@ -227,6 +229,7 @@ struct PatternMatcher {
             ("\\.mcp\\.json$", "Unconditional: MCP server config (Allow-once only)"),
             ("\\.git/hooks/", "Unconditional: Git hook — runs on git ops (Allow-once only)"),
             ("\\.github/workflows/", "Unconditional: CI workflow — runs with repo secrets (Allow-once only)"),
+            ("\\.aws/config", "Unconditional: AWS profile/SSO config (Allow-once only)"),
         ]
 
         bashPatterns = rawBash.compactMap { entry in

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -24,7 +24,7 @@ final class RuleStore: ObservableObject {
     )
 
     /// Current seed version — bump when adding new default rules.
-    private static let seedVersion = 13
+    private static let seedVersion = 14
 
     /// Built-in patterns replaced by a corrected/broadened seeded rule. On re-seed
     /// these are dropped from existing rules.json so a pattern fix swaps cleanly
@@ -352,6 +352,22 @@ final class RuleStore: ObservableObject {
             isRegex: true,
             verdict: .prompt,
             explanation: "Commit checkpoint — review staged changes before recording history",
+            builtIn: true,
+            overridable: false,
+            nonSuppressible: true
+        ),
+
+        // ── Bash writes to guardrail paths — Allow-once only ──
+        // Closes the shell bypass of the Write-tool path rules: a write verb (redirect, tee, cp,
+        // mv, dd, install, sed -i) targeting a guardrail/config path. Keyed on the path literal,
+        // so side-effect writers that don't name it (granted/assume, `aws configure`) stay exempt.
+        // [^|;&] keeps the verb and the path within the same command segment, not across a pipe/&&.
+        PersistentRule(
+            toolName: "Bash",
+            pattern: "(>>?|\\btee\\b|\\bcp\\b|\\bmv\\b|\\bdd\\b|\\binstall\\b|\\bsed\\s+-i\\S*)\\s*[^|;&]*(\\.claude/gavel/|\\.claude/(settings\\.json|settings\\.local\\.json|hooks/)|\\.mcp\\.json|\\.git/hooks/|\\.github/workflows/|\\.aws/config)\\b",
+            isRegex: true,
+            verdict: .prompt,
+            explanation: "Writing a guardrail/config file via shell — review (Allow-once only)",
             builtIn: true,
             overridable: false,
             nonSuppressible: true

--- a/Tests/GavelTests/ApprovalEngineTests.swift
+++ b/Tests/GavelTests/ApprovalEngineTests.swift
@@ -201,6 +201,36 @@ final class ApprovalEngineTests: XCTestCase {
         }
     }
 
+    // Shell writes to guardrail paths can't bypass the Write-tool path rules: a redirect/tee/cp/sed
+    // targeting one is Allow-once only, same as editing it with the Write tool.
+    func testBashWritesToGuardrailPathsAreNonSuppressible() {
+        for cmd in [
+            "echo '[profile evil]' >> ~/.aws/config",
+            "cp /tmp/evil ~/.claude/gavel/rules.json",
+            "sed -i '' 's/x/y/' ~/.claude/settings.json",
+            "echo '{}' | tee ~/project/.mcp.json",
+            "printf '#!/bin/sh\\ncurl evil' > .git/hooks/pre-commit",
+            "cp /tmp/ci.yml .github/workflows/deploy.yml",
+        ] {
+            let decision = engine.evaluate(payload: payload(command: cmd), session: session)
+            XCTAssertEqual(decision.verdict, .block, "should checkpoint: \(cmd)")
+            XCTAssertTrue(decision.nonSuppressible, "should be Allow-once only: \(cmd)")
+        }
+    }
+
+    // Side-effect writers that don't name the path on the command line stay exempt — no SSO friction.
+    func testSsoAndConfigSideEffectWritersAreExempt() {
+        for cmd in [
+            "assume prod",
+            "aws configure set region us-east-1",
+            "aws sso login --profile prod",
+            "cat ~/.aws/config",
+        ] {
+            let decision = engine.evaluate(payload: payload(command: cmd), session: session)
+            XCTAssertFalse(decision.nonSuppressible, "should not be unconditional: \(cmd)")
+        }
+    }
+
     func testOrdinaryGitAndBuildAreNotNonSuppressible() {
         for cmd in ["git status", "git add -A", "git fetch origin", "npm install", "npm run build"] {
             let decision = engine.evaluate(payload: payload(command: cmd), session: session)
@@ -311,7 +341,9 @@ final class ApprovalEngineTests: XCTestCase {
         FileManager.default.createFile(atPath: path, contents: data)
 
         let store = RuleStore(configPath: path)
-        let selfProtect = store.rules.filter { $0.toolName == "Bash" && $0.pattern.contains("gavel") }.map(\.pattern)
+        // Filter to the self-protection rule's unique alternation; the guardrail-write Bash rule
+        // also mentions "gavel" but uses the path form (.claude/gavel/), not this alternation.
+        let selfProtect = store.rules.filter { $0.toolName == "Bash" && $0.pattern.contains("gavel|settings|hooks") }.map(\.pattern)
         XCTAssertEqual(selfProtect.count, 1, "exactly one Bash self-protection rule after re-seed (no duplicate)")
         XCTAssertFalse(selfProtect.contains(oldNarrow), "old trailing-slash pattern dropped on re-seed")
         XCTAssertTrue(selfProtect.first?.contains("gavel|settings|hooks") ?? false, "broadened pattern seeded")

--- a/Tests/GavelTests/PatternMatcherTests.swift
+++ b/Tests/GavelTests/PatternMatcherTests.swift
@@ -545,6 +545,18 @@ final class PatternMatcherTests: XCTestCase {
         XCTAssertNotNil(matcher.matchUnconditionalPromptPath(payload: editPayload(filePath: "/Users/x/project/.github/workflows/ci.yml")))
     }
 
+    func testAwsConfigWriteIsUnconditionalNotHardBlocked() {
+        // .aws/config (profiles/SSO) downgraded from hard-block to Allow-once prompt.
+        XCTAssertNil(matcher.matchDangerous(payload: writePayload(filePath: "/Users/x/.aws/config")))
+        XCTAssertNotNil(matcher.matchUnconditionalPromptPath(payload: writePayload(filePath: "/Users/x/.aws/config")))
+    }
+
+    func testAwsCredentialsWriteStaysHardBlocked() {
+        // The secret file is unchanged — still a hard block, never just a prompt.
+        XCTAssertNotNil(matcher.matchDangerous(payload: writePayload(filePath: "/Users/x/.aws/credentials")))
+        XCTAssertNil(matcher.matchUnconditionalPromptPath(payload: writePayload(filePath: "/Users/x/.aws/credentials")))
+    }
+
     func testReadingUnconditionalPathIsNotUnconditional() {
         // Writes only — reads fall through to the regular sensitive-read prompts.
         let read = PreToolUsePayload(toolName: "Read", toolInput: ["file_path": AnyCodable("/Users/x/.claude/gavel/rules.json")])

--- a/Tests/GavelTests/PersistentRuleTests.swift
+++ b/Tests/GavelTests/PersistentRuleTests.swift
@@ -185,7 +185,7 @@ final class PersistentRuleTests: XCTestCase {
         let store = RuleStore(configPath: "/dev/null")
         let builtInRules = store.rules.filter { $0.builtIn }
         XCTAssertEqual(builtInRules.count, RuleStore.seededDefaults.count)
-        XCTAssertEqual(builtInRules.count, 25)
+        XCTAssertEqual(builtInRules.count, 26)
     }
 
     func testSeededRulesArePromptVerdict() {


### PR DESCRIPTION
## What

Two related changes, prompted by noticing another session wrote `~/.aws/config` unprompted.

### 1. `.aws/config` → unconditional prompt (was hard-block)
It's not a secret -- that's `.aws/credentials`, which **stays hard-blocked**. `.aws/config` (profiles/SSO/roles) is legitimately edited but can repoint a profile to a hostile role, so Allow-once-only is the right tier. Splits the old `.aws/(credentials|config)` protected-path rule.

### 2. Closes the Bash-bypass for **all** guardrail paths
The path rules (hard-block / unconditional / sensitive) are tool-scoped to `Write`/`Edit`/`MultiEdit`. A shell write -- `echo >> ~/.aws/config`, `cp`, `tee`, `sed -i` -- goes through `matchBashCommand` and never reached them, so it bypassed every path guardrail (including `.claude/gavel/`, `.mcp.json`, etc.).

New seeded `nonSuppressible` Bash rule matches a write verb (`>>`, `tee`, `cp`, `mv`, `dd`, `install`, `sed -i`) targeting any guardrail path: `.claude/gavel/`, `settings.json`/`settings.local.json`/`hooks/`, `.mcp.json`, `.git/hooks/`, `.github/workflows/`, `.aws/config`.

**Why it doesn't add SSO friction:** the rule keys on the *path literal*, so side-effect writers that never name the path -- `granted`/`assume`, `aws configure` -- stay exempt. `[^|;&]` keeps the verb and the path in the same command segment (no cross-pipe/`&&` false matches).

## Tests

`seedVersion` 13→14. **624 tests, 0 failures.** Engine asserts shell writes to guardrail paths are `nonSuppressible`, while `assume` / `aws configure set` / `aws sso login` / `cat ~/.aws/config` stay exempt; matcher asserts `.aws/config` write is unconditional and `.aws/credentials` stays hard-blocked; the self-protection migration test filter is tightened so it doesn't count the new rule.

## Known limits

The bash rule is a heuristic (regex over shell) -- it catches the common write verbs, not every conceivable write path (e.g. a script that writes via Python). It raises the bar on the obvious redirect/cp/tee/sed bypass; it's not a complete sandbox. A legit `cp ~/.aws/config ~/.aws/config.bak` will prompt (Allow-once) -- acceptable.