### PR TITLE
feat(approval): tighten-only rule proposals with audited accept/reject

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -290,7 +290,7 @@ final class ApprovalCoordinator: ObservableObject {
             let rule = PersistentRule(
                 toolName: current.payload.toolName, pattern: sanitized, isRegex: isRegex,
                 verdict: .block, explanation: explText)
-            ruleStore?.addRule(rule)
+            ruleStore?.addRule(rule, origin: "approval-panel:always-deny")
             var reason = "Always deny: \(current.payload.toolName): \(pattern)"
             if let e = explText { reason += " — \(e)" }
             current.respond(Decision(verdict: .block, reason: reason))
@@ -302,7 +302,7 @@ final class ApprovalCoordinator: ObservableObject {
             let rule = PersistentRule(
                 toolName: current.payload.toolName, pattern: sanitized, isRegex: isRegex,
                 verdict: .allow)
-            ruleStore?.addRule(rule)
+            ruleStore?.addRule(rule, origin: "approval-panel:always-allow")
             current.respond(
                 Decision(
                     verdict: .allow, reason: "Always allow: \(current.payload.toolName): \(pattern)"
@@ -315,7 +315,7 @@ final class ApprovalCoordinator: ObservableObject {
             let rule = PersistentRule(
                 toolName: current.payload.toolName, pattern: sanitized, isRegex: isRegex,
                 verdict: .prompt)
-            ruleStore?.addRule(rule)
+            ruleStore?.addRule(rule, origin: "approval-panel:always-prompt")
             current.respond(
                 Decision(
                     verdict: .allow,

--- a/Sources/Gavel/Approval/ProposalStore.swift
+++ b/Sources/Gavel/Approval/ProposalStore.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+/// A rule Claude proposed via `gavel-hook propose-rule`, pending user adjudication.
+///
+/// Proposals are inert — they change zero matching behavior until the user accepts
+/// one in the Monitor's Rules tab, at which point it becomes a PersistentRule through
+/// the normal RuleStore path (audited, signed, backed up).
+struct RuleProposal: Codable, Identifiable, Equatable {
+    let id: UUID
+    let toolName: String
+    let pattern: String
+    let isRegex: Bool
+    let verdict: DecisionVerdict
+    /// Why Claude thinks this footgun needs a gate — shown on the proposal card.
+    let reason: String
+    /// The concrete command/path that motivated the proposal.
+    let example: String?
+    let sessionPid: Int
+    let sessionId: String?
+    let createdAt: Date
+
+    init(toolName: String, pattern: String, isRegex: Bool, verdict: DecisionVerdict,
+         reason: String, example: String?, sessionPid: Int, sessionId: String?) {
+        self.id = UUID()
+        self.toolName = toolName
+        self.pattern = pattern
+        self.isRegex = isRegex
+        self.verdict = verdict
+        self.reason = reason
+        self.example = example
+        self.sessionPid = sessionPid
+        self.sessionId = sessionId
+        self.createdAt = Date()
+    }
+}
+
+/// Pending-proposal inbox: validation, dedupe, persistence, and adjudication.
+///
+/// The mutation direction is enforced HERE, server-side — `submit` only ever
+/// accepts deny/prompt verdicts, so no client flag or crafted payload can use
+/// the proposal channel to widen permissions. Submit arrives on the socket
+/// worker queue; accept/reject are user actions from the Monitor (main thread).
+/// State is a lock-guarded plain array (not @Published) so worker-thread
+/// mutations never trip SwiftUI's main-thread invariant — UI observers mirror
+/// snapshots via `onChange`, which always fires on main.
+final class ProposalStore {
+    /// Fired on the main thread after any mutation, with a snapshot of pending proposals.
+    var onChange: (([RuleProposal]) -> Void)?
+
+    /// Set at wiring time; used for dedupe against existing rules and for accept.
+    weak var ruleStore: RuleStore?
+
+    static let maxPendingPerSession = 10
+    static let ttl: TimeInterval = 7 * 24 * 3600
+    private static let maxPatternLength = 500
+    private static let maxTextLength = 1000
+
+    private let path: String
+    private let lock = NSLock()
+    private var storage: [RuleProposal] = []
+
+    enum SubmitResult: Equatable {
+        case queued(UUID)
+        case rejected(String)
+    }
+
+    init(path: String? = nil) {
+        self.path = path ?? Self.defaultPath
+        load()
+    }
+
+    static var defaultPath: String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/.claude/gavel/proposals.json"
+    }
+
+    var proposals: [RuleProposal] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    // MARK: - Submit (socket worker queue)
+
+    func submit(toolName: String, pattern: String, isRegex: Bool, verdict rawVerdict: String,
+                reason: String, example: String?, sessionPid: Int, sessionId: String?) -> SubmitResult {
+        let verdict: DecisionVerdict
+        switch rawVerdict.lowercased() {
+        case "deny", "block": verdict = .block
+        case "prompt", "ask": verdict = .prompt
+        case "allow":
+            return .rejected("Proposals are tighten-only: allow rules can't be proposed — ask the user to add one in the Monitor")
+        default:
+            return .rejected("Unknown verdict \"\(rawVerdict)\" — use deny or prompt")
+        }
+
+        let tool = toolName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pat = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
+        let why = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !tool.isEmpty else { return .rejected("Missing tool name") }
+        guard !pat.isEmpty else { return .rejected("Missing pattern") }
+        guard why.count >= 10 else { return .rejected("Reason required — say why this needs a gate") }
+        guard pat.count <= Self.maxPatternLength else { return .rejected("Pattern too long (max \(Self.maxPatternLength) chars)") }
+        guard why.count <= Self.maxTextLength else { return .rejected("Reason too long (max \(Self.maxTextLength) chars)") }
+        guard PersistentRule.compilePattern(pat, isRegex: isRegex) != nil else {
+            return .rejected("Pattern does not compile as \(isRegex ? "regex" : "glob")")
+        }
+
+        if let existing = ruleStore?.rules.first(where: { $0.toolName == tool && $0.pattern == pat && !$0.isDisabled }) {
+            return .rejected("Duplicate of existing rule (\(existing.verdict.rawValue)): \(existing.name)")
+        }
+
+        lock.lock()
+        pruneExpiredLocked()
+        if storage.contains(where: { $0.toolName == tool && $0.pattern == pat }) {
+            lock.unlock()
+            return .rejected("Already proposed and pending review")
+        }
+        if storage.filter({ $0.sessionPid == sessionPid }).count >= Self.maxPendingPerSession {
+            lock.unlock()
+            return .rejected("Too many pending proposals from this session (max \(Self.maxPendingPerSession)) — wait for the user to review")
+        }
+
+        let proposal = RuleProposal(
+            toolName: tool, pattern: pat, isRegex: isRegex, verdict: verdict,
+            reason: why, example: example?.trimmingCharacters(in: .whitespacesAndNewlines),
+            sessionPid: sessionPid, sessionId: sessionId
+        )
+        storage.append(proposal)
+        saveLocked()
+        lock.unlock()
+
+        notifyChanged()
+        return .queued(proposal.id)
+    }
+
+    // MARK: - Adjudication (Monitor UI / remote bridge)
+
+    /// Accept: promote to a PersistentRule via the audited RuleStore path, drop the proposal.
+    @discardableResult
+    func accept(id: UUID, via channel: String = "monitor") -> PersistentRule? {
+        guard let proposal = removeProposal(id: id) else { return nil }
+
+        let rule = PersistentRule(
+            toolName: proposal.toolName, pattern: proposal.pattern, isRegex: proposal.isRegex,
+            verdict: proposal.verdict, explanation: proposal.reason
+        )
+        ruleStore?.addRule(rule, origin: "claude-proposal pid=\(proposal.sessionPid) accepted-via=\(channel)")
+        notifyChanged()
+        return rule
+    }
+
+    func reject(id: UUID, via channel: String = "monitor") {
+        guard let proposal = removeProposal(id: id) else { return }
+
+        ruleStore?.auditLog?.record(
+            action: "proposal_rejected",
+            origin: "claude-proposal pid=\(proposal.sessionPid) rejected-via=\(channel)",
+            toolName: proposal.toolName, pattern: proposal.pattern,
+            verdict: proposal.verdict.rawValue, detail: proposal.reason
+        )
+        notifyChanged()
+    }
+
+    private func removeProposal(id: UUID) -> RuleProposal? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let idx = storage.firstIndex(where: { $0.id == id }) else { return nil }
+        let proposal = storage.remove(at: idx)
+        saveLocked()
+        return proposal
+    }
+
+    // MARK: - Persistence
+
+    private struct ProposalsFile: Codable {
+        var version: Int
+        var proposals: [RuleProposal]
+    }
+
+    private func load() {
+        guard let data = FileManager.default.contents(atPath: path),
+              let file = try? JSONDecoder().decode(ProposalsFile.self, from: data) else { return }
+        storage = file.proposals.filter { Date().timeIntervalSince($0.createdAt) < Self.ttl }
+    }
+
+    private func pruneExpiredLocked() {
+        let kept = storage.filter { Date().timeIntervalSince($0.createdAt) < Self.ttl }
+        if kept.count != storage.count {
+            storage = kept
+            saveLocked()
+        }
+    }
+
+    private func saveLocked() {
+        let dir = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(ProposalsFile(version: 1, proposals: storage)) else { return }
+        try? data.write(to: URL(fileURLWithPath: path))
+    }
+
+    private func notifyChanged() {
+        let snapshot = proposals
+        DispatchQueue.main.async { [weak self] in
+            self?.onChange?(snapshot)
+        }
+    }
+}

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -19,6 +19,13 @@ final class RuleStore: ObservableObject {
 
     private var signaturePath: String { configPath + ".integrity" }
     private var backupPath: String { configPath + ".bak" }
+
+    /// Tamper-evident journal of every authorized rule mutation. Sibling of
+    /// rules.json (rules.audit.jsonl). Nil for /dev/* config paths (tests).
+    private(set) lazy var auditLog: RuleAuditLog? = {
+        guard !configPath.hasPrefix("/dev/") else { return nil }
+        return RuleAuditLog(path: (configPath as NSString).deletingPathExtension + ".audit.jsonl")
+    }()
     private lazy var baseline = ConfigBaseline(
         keyPath: (configPath as NSString).deletingLastPathComponent + "/.integrity-key"
     )
@@ -109,28 +116,32 @@ final class RuleStore: ObservableObject {
 
     /// Toggle a rule's disabled state. Persists immediately so the change
     /// survives a daemon restart (and stays visible in the UI as "off").
-    func setDisabled(id: UUID, isDisabled: Bool) {
+    func setDisabled(id: UUID, isDisabled: Bool, origin: String = "panel") {
         guard let idx = rules.firstIndex(where: { $0.id == id }) else { return }
         rules[idx].isDisabled = isDisabled
         saveRules()
+        audit(action: isDisabled ? "rule_disabled" : "rule_enabled", origin: origin, rule: rules[idx])
     }
 
     // MARK: - Rule Management
 
-    func addRule(_ rule: PersistentRule) {
+    func addRule(_ rule: PersistentRule, origin: String = "panel") {
         rules.append(rule)
         saveRules()
+        audit(action: "rule_added", origin: origin, rule: rule)
     }
 
-    func removeRule(id: UUID) {
-        if let rule = rules.first(where: { $0.id == id }), rule.builtIn {
+    func removeRule(id: UUID, origin: String = "panel") {
+        guard let rule = rules.first(where: { $0.id == id }) else { return }
+        if rule.builtIn {
             deletedBuiltInPatterns.append(rule.pattern)
         }
         rules.removeAll { $0.id == id }
         saveRules()
+        audit(action: "rule_removed", origin: origin, rule: rule)
     }
 
-    func updateRule(id: UUID, pattern: String, isRegex: Bool, verdict: DecisionVerdict, explanation: String?) {
+    func updateRule(id: UUID, pattern: String, isRegex: Bool, verdict: DecisionVerdict, explanation: String?, origin: String = "panel") {
         guard let idx = rules.firstIndex(where: { $0.id == id }) else { return }
         let old = rules[idx]
         rules[idx] = PersistentRule(
@@ -138,6 +149,16 @@ final class RuleStore: ObservableObject {
             verdict: verdict, explanation: explanation
         )
         saveRules()
+        audit(action: "rule_updated", origin: origin, rule: rules[idx],
+              detail: old.pattern == pattern ? nil : "was: \(old.pattern)")
+    }
+
+    private func audit(action: String, origin: String, rule: PersistentRule, detail: String? = nil) {
+        auditLog?.record(
+            action: action, origin: origin,
+            toolName: rule.toolName, pattern: rule.pattern,
+            verdict: rule.verdict.rawValue, detail: detail
+        )
     }
 
     var denyRules: [PersistentRule] {

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -11,6 +11,8 @@ final class HookRouter {
     let approvalEngine: ApprovalEngine
     let approvalCoordinator: ApprovalCoordinator
     var onFeedEvent: ((FeedEntry) -> Void)?
+    /// Pending rule-proposal inbox (set at wiring time; nil in tests that don't exercise proposals).
+    var proposalStore: ProposalStore?
 
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
@@ -87,8 +89,61 @@ final class HookRouter {
             let errType = payload.errorType ?? "unknown"
             emitFeed(.system("Stop failure: \(errType)", pid: session.pid, at: ts))
 
+        case .proposeRule(let payload):
+            handleProposeRule(payload: payload, session: session, timestamp: ts, respond: respond)
+
         case .passthrough(let eventName):
             emitFeed(.system(eventName, pid: session.pid, at: ts))
+        }
+    }
+
+    // MARK: - ProposeRule
+
+    /// Queue a tighten-only rule proposal for user review. Always responds
+    /// (the propose-rule CLI waits for the ack) — either a queued id or a
+    /// rejection reason Claude can act on.
+    private func handleProposeRule(
+        payload: ProposeRulePayload,
+        session: Session,
+        timestamp: Date,
+        respond: ((Data) -> Void)?
+    ) {
+        let result: ProposalStore.SubmitResult
+        if let store = proposalStore {
+            result = store.submit(
+                toolName: payload.toolName ?? "",
+                pattern: payload.pattern ?? "",
+                isRegex: payload.isRegex ?? true,
+                verdict: payload.verdict ?? "",
+                reason: payload.reason ?? "",
+                example: payload.example,
+                sessionPid: session.pid,
+                sessionId: payload.sessionId
+            )
+        } else {
+            result = .rejected("Proposal inbox unavailable")
+        }
+
+        let response: [String: Any]
+        switch result {
+        case .queued(let id):
+            let summary = "\(payload.toolName ?? "?"): \(payload.pattern ?? "?") (\(payload.verdict ?? "?"))"
+            emitFeed(.system("⚑ Claude proposed rule: \(summary) — pending review in Rules tab", pid: session.pid, at: timestamp))
+            GavelNotifications.notify(
+                title: "Gavel — Rule Proposed",
+                body: "\(summary)\n\(payload.reason ?? "")",
+                sound: false
+            )
+            response = ["status": "queued", "id": id.uuidString,
+                        "message": "Proposal queued for user review in the Gavel Monitor"]
+        case .rejected(let reason):
+            emitFeed(.system("⚑ Rule proposal rejected: \(reason)", pid: session.pid, at: timestamp))
+            response = ["status": "rejected", "reason": reason]
+        }
+
+        if let respond = respond,
+           let data = try? JSONSerialization.data(withJSONObject: response) {
+            respond(data)
         }
     }
 

--- a/Sources/Gavel/Models/HookEvent.swift
+++ b/Sources/Gavel/Models/HookEvent.swift
@@ -12,6 +12,7 @@ enum HookType: String, Codable {
     case subagentStart = "SubagentStart"
     case subagentStop = "SubagentStop"
     case permissionRequest = "PermissionRequest"
+    case proposeRule = "ProposeRule"
     case unknown
 }
 
@@ -58,6 +59,7 @@ enum HookPayload: Codable {
     case userPromptSubmit(UserPromptSubmitPayload)
     case notification(NotificationPayload)
     case stopFailure(StopFailurePayload)
+    case proposeRule(ProposeRulePayload)
     case passthrough(String) // Unhandled event types — store hook_event_name
 
     private enum CodingKeys: String, CodingKey {
@@ -82,6 +84,8 @@ enum HookPayload: Codable {
             self = .notification(try NotificationPayload(from: decoder))
         case "StopFailure":
             self = .stopFailure(try StopFailurePayload(from: decoder))
+        case "ProposeRule":
+            self = .proposeRule(try ProposeRulePayload(from: decoder))
         default:
             self = .passthrough(type)
         }
@@ -95,6 +99,7 @@ enum HookPayload: Codable {
         case .userPromptSubmit(let p): try p.encode(to: encoder)
         case .notification(let p): try p.encode(to: encoder)
         case .stopFailure(let p): try p.encode(to: encoder)
+        case .proposeRule(let p): try p.encode(to: encoder)
         case .stop, .passthrough: break
         }
     }
@@ -214,6 +219,28 @@ struct StopFailurePayload: Codable {
 
     enum CodingKeys: String, CodingKey {
         case errorType = "error_type"
+        case sessionId = "session_id"
+    }
+}
+
+/// A tighten-only rule proposal from `gavel-hook propose-rule`.
+/// Verdict is validated server-side in ProposalStore — never trust this payload.
+struct ProposeRulePayload: Codable {
+    let toolName: String?
+    let pattern: String?
+    let isRegex: Bool?
+    let verdict: String?
+    let reason: String?
+    let example: String?
+    let sessionId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case toolName = "tool_name"
+        case pattern
+        case isRegex = "is_regex"
+        case verdict
+        case reason
+        case example
         case sessionId = "session_id"
     }
 }

--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -16,6 +16,11 @@ final class MonitorViewModel: ObservableObject {
     @Published var testerTestString: String = ""
     @Published var testerIsRegex: Bool = true
 
+    /// Main-thread mirror of ProposalStore's pending inbox (the store itself is
+    /// lock-guarded, not @Published — submits arrive on the socket queue).
+    @Published var pendingProposals: [RuleProposal] = []
+    private var proposalStore: ProposalStore?
+
     let approvalCoordinator: ApprovalCoordinator
     let sessionManager: SessionManager
     private let maxFeedEntries = GavelConstants.maxFeedEntries
@@ -31,6 +36,24 @@ final class MonitorViewModel: ObservableObject {
 
     deinit {
         statsTimer?.invalidate()
+    }
+
+    func attachProposalStore(_ store: ProposalStore) {
+        proposalStore = store
+        pendingProposals = store.proposals
+        store.onChange = { [weak self] snapshot in
+            self?.pendingProposals = snapshot
+        }
+    }
+
+    func acceptProposal(id: UUID) {
+        proposalStore?.accept(id: id, via: "monitor")
+        noteInteraction()
+    }
+
+    func rejectProposal(id: UUID) {
+        proposalStore?.reject(id: id, via: "monitor")
+        noteInteraction()
     }
 
     func appendFeedEntry(_ entry: FeedEntry) {
@@ -145,7 +168,7 @@ final class MonitorViewModel: ObservableObject {
         let rules = try JSONDecoder().decode([PersistentRule].self, from: data)
         guard !rules.isEmpty else { return 0 }
         for rule in rules {
-            approvalCoordinator.ruleStore?.addRule(rule)
+            approvalCoordinator.ruleStore?.addRule(rule, origin: "import")
         }
         return rules.count
     }

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -149,7 +149,10 @@ struct MonitorWindow: View {
             // Tab picker
             Picker("", selection: $selectedTab) {
                 Text("Feed").tag(MonitorTab.feed)
-                Text("Rules (\(viewModel.ruleCount))").tag(MonitorTab.rules)
+                Text(viewModel.pendingProposals.isEmpty
+                     ? "Rules (\(viewModel.ruleCount))"
+                     : "Rules (\(viewModel.ruleCount) · ⚑\(viewModel.pendingProposals.count))")
+                    .tag(MonitorTab.rules)
                 Text("Sessions").tag(MonitorTab.sessions)
                 Text("Context").tag(MonitorTab.context)
                 Text("Tester").tag(MonitorTab.tester)
@@ -888,6 +891,14 @@ struct RulesView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            // Pending Claude proposals — inert until accepted here
+            if !viewModel.pendingProposals.isEmpty {
+                proposalsSection
+                    .padding(10)
+                    .background(Color.orange.opacity(0.08))
+                Divider()
+            }
+
             // Add rule form
             addRuleForm
                 .padding(10)
@@ -964,6 +975,72 @@ struct RulesView: View {
             .font(.system(.caption, design: .monospaced))
             .background(Color(nsColor: .textBackgroundColor))
         }
+    }
+
+    // MARK: - Pending Proposals
+
+    private var proposalsSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label("Claude proposed \(viewModel.pendingProposals.count) rule\(viewModel.pendingProposals.count == 1 ? "" : "s") — no effect until accepted", systemImage: "flag.fill")
+                .font(.caption.bold())
+                .foregroundColor(.orange)
+
+            ForEach(viewModel.pendingProposals) { proposal in
+                proposalRow(proposal)
+            }
+        }
+    }
+
+    private func proposalRow(_ proposal: RuleProposal) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(verdictLabel(proposal.verdict))
+                        .font(.caption2.bold())
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(verdictColor(proposal.verdict).opacity(0.2))
+                        .foregroundColor(verdictColor(proposal.verdict))
+                        .cornerRadius(3)
+                    Text("\(proposal.toolName): \(proposal.isRegex ? "/" : "")\(proposal.pattern)\(proposal.isRegex ? "/" : "")")
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                }
+                Text(proposal.reason)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                if let example = proposal.example, !example.isEmpty {
+                    Text("e.g. \(example)")
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundColor(.secondary.opacity(0.7))
+                        .lineLimit(2)
+                        .textSelection(.enabled)
+                }
+                Text("from session \(Text(verbatim: String(proposal.sessionPid))) · \(proposal.createdAt.formatted(date: .abbreviated, time: .shortened))")
+                    .font(.caption2)
+                    .foregroundColor(.secondary.opacity(0.6))
+            }
+
+            Spacer()
+
+            Button(action: { viewModel.acceptProposal(id: proposal.id) }) {
+                Label("Accept", systemImage: "checkmark.circle")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.green)
+            .controlSize(.small)
+            .help("Add as a persistent \(verdictLabel(proposal.verdict)) rule (audited)")
+
+            Button(action: { viewModel.rejectProposal(id: proposal.id) }) {
+                Label("Reject", systemImage: "xmark.circle")
+            }
+            .buttonStyle(.bordered)
+            .tint(.red)
+            .controlSize(.small)
+        }
+        .padding(6)
+        .background(Color(nsColor: .textBackgroundColor))
+        .cornerRadius(6)
     }
 
     // MARK: - Add Rule Form

--- a/Sources/Gavel/System/RuleAuditLog.swift
+++ b/Sources/Gavel/System/RuleAuditLog.swift
@@ -1,0 +1,133 @@
+import CryptoKit
+import Foundation
+
+/// Append-only, tamper-evident journal of rule mutations (rules-audit.jsonl).
+///
+/// Every authorized change to rules.json — panel adds/edits/deletes, approval-panel
+/// "Always allow/deny", accepted/rejected Claude proposals — appends one JSON line.
+/// Each entry carries `prev` (the previous entry's hash) and `hash` (SHA-256 over the
+/// entry's own canonical JSON), forming a chain: rewriting or deleting a historical
+/// line breaks every hash after it, so tampering is detectable via `verifyChain()`
+/// even by a reader who only trusts the latest entry.
+final class RuleAuditLog {
+    struct Entry: Codable {
+        let seq: Int
+        let ts: Date
+        let action: String
+        let origin: String
+        let toolName: String
+        let pattern: String
+        let verdict: String
+        let detail: String?
+        var prev: String
+        var hash: String
+    }
+
+    static let genesisHash = String(repeating: "0", count: 64)
+
+    private let path: String
+    private let lock = NSLock()
+    private var lastHash: String
+    private var lastSeq: Int
+
+    init(path: String) {
+        self.path = path
+        (lastSeq, lastHash) = Self.readTail(path: path)
+    }
+
+    var filePath: String { path }
+
+    func record(action: String, origin: String, toolName: String, pattern: String, verdict: String, detail: String? = nil) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var entry = Entry(
+            seq: lastSeq + 1, ts: Date(), action: action, origin: origin,
+            toolName: toolName, pattern: pattern, verdict: verdict, detail: detail,
+            prev: lastHash, hash: ""
+        )
+        entry.hash = Self.computeHash(entry)
+
+        guard let line = Self.encodeLine(entry) else {
+            gavelLog("RuleAuditLog: failed to encode entry seq=\(entry.seq)")
+            return
+        }
+        append(line: line)
+        lastSeq = entry.seq
+        lastHash = entry.hash
+    }
+
+    /// Recompute the full chain. Returns the first broken sequence number, or nil if intact.
+    func verifyChain() -> Int? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var prev = Self.genesisHash
+        for entry in Self.readEntries(path: path) {
+            if entry.prev != prev || Self.computeHash(entry) != entry.hash {
+                return entry.seq
+            }
+            prev = entry.hash
+        }
+        return nil
+    }
+
+    func entries() -> [Entry] {
+        lock.lock()
+        defer { lock.unlock() }
+        return Self.readEntries(path: path)
+    }
+
+    // MARK: - Hashing / encoding
+
+    /// Hash over the canonical (sorted-keys) JSON of the entry with `hash` zeroed,
+    /// so encoder field order can never affect chain validity.
+    private static func computeHash(_ entry: Entry) -> String {
+        var unhashed = entry
+        unhashed.hash = ""
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(unhashed) else { return "" }
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func encodeLine(_ entry: Entry) -> Data? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        encoder.dateEncodingStrategy = .iso8601
+        guard var data = try? encoder.encode(entry) else { return nil }
+        data.append(0x0A)
+        return data
+    }
+
+    private static func readEntries(path: String) -> [Entry] {
+        guard let data = FileManager.default.contents(atPath: path),
+              let text = String(data: data, encoding: .utf8) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return text.split(separator: "\n").compactMap { line in
+            try? decoder.decode(Entry.self, from: Data(line.utf8))
+        }
+    }
+
+    private static func readTail(path: String) -> (seq: Int, hash: String) {
+        guard let last = readEntries(path: path).last else { return (0, genesisHash) }
+        return (last.seq, last.hash)
+    }
+
+    private func append(line: Data) {
+        let dir = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        if !FileManager.default.fileExists(atPath: path) {
+            FileManager.default.createFile(atPath: path, contents: nil)
+        }
+        guard let handle = FileHandle(forWritingAtPath: path) else {
+            gavelLog("RuleAuditLog: cannot open \(path) for append")
+            return
+        }
+        defer { try? handle.close() }
+        handle.seekToEndOfFile()
+        handle.write(line)
+    }
+}

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -19,14 +19,18 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
     let sessionManager = SessionManager()
     let approvalEngine = ApprovalEngine()
     let approvalCoordinator = ApprovalCoordinator()
+    let proposalStore = ProposalStore()
     lazy var hookRouter: HookRouter = {
         approvalCoordinator.ruleStore = approvalEngine.ruleStore
         approvalCoordinator.sessionManager = sessionManager
-        return HookRouter(
+        proposalStore.ruleStore = approvalEngine.ruleStore
+        let router = HookRouter(
             sessionManager: sessionManager,
             approvalEngine: approvalEngine,
             approvalCoordinator: approvalCoordinator
         )
+        router.proposalStore = proposalStore
+        return router
     }()
     lazy var viewModel = MonitorViewModel(
         sessionManager: sessionManager,
@@ -354,6 +358,8 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func setupHookRouter() {
+        viewModel.attachProposalStore(proposalStore)
+
         hookRouter.onFeedEvent = { [weak self] entry in
             self?.viewModel.appendFeedEntry(entry)
 

--- a/Sources/GavelHook/main.swift
+++ b/Sources/GavelHook/main.swift
@@ -361,10 +361,26 @@ func findAgentPid(from startPid: Int32, named needle: String) -> Int32? {
            name.lowercased().contains(target) {
             return current
         }
+        // Native-install agent binaries are version-named files
+        // (…/claude/versions/2.1.198), so p_comm is the version string and the
+        // name check above never matches. Match an exact path COMPONENT of the
+        // executable instead — component equality, not substring, so paths like
+        // …/claude-gavel/… can't false-positive.
+        if let path = executablePath(pid: current),
+           path.lowercased().split(separator: "/").contains(Substring(target)) {
+            return current
+        }
         guard let ppid = parentPid(of: current), ppid > 1 else { break }
         current = ppid
     }
     return nil
+}
+
+func executablePath(pid: Int32) -> String? {
+    var buf = [CChar](repeating: 0, count: 4096)
+    let n = proc_pidpath(pid, &buf, UInt32(buf.count))
+    guard n > 0 else { return nil }
+    return String(cString: buf)
 }
 
 func parentPid(of pid: Int32) -> Int32? {

--- a/Sources/GavelHook/main.swift
+++ b/Sources/GavelHook/main.swift
@@ -16,6 +16,12 @@ import GavelHookCore
 let socketPath = FileManager.default.homeDirectoryForCurrentUser
     .appendingPathComponent(".claude/gavel/gavel.sock").path
 
+// propose-rule is a flag-driven subcommand, not a hook shim — branch BEFORE the
+// stdin read below, which would block forever on a terminal with no redirect.
+if CommandLine.arguments.count > 1, CommandLine.arguments[1] == "propose-rule" {
+    runProposeRule()
+}
+
 // stderr is preserved by the bash shim — we write deny reasons there.
 
 // Read stdin
@@ -183,6 +189,156 @@ if needsResponse {
     exit(2)
 } else {
     close(fd)
+}
+
+// MARK: - propose-rule subcommand
+
+/// `gavel-hook propose-rule --tool <name> --pattern <p> --verdict <deny|prompt> --reason <why> [--example <cmd>] [--glob]`
+///
+/// Submits a tighten-only rule proposal to the daemon's pending inbox. The
+/// daemon re-validates everything (verdict direction, regex compile, dedupe) —
+/// this function is just transport + a readable result. Never returns.
+func runProposeRule() -> Never {
+    var tool: String?
+    var pattern: String?
+    var verdict: String?
+    var reason: String?
+    var example: String?
+    var isRegex = true
+
+    var args = CommandLine.arguments.dropFirst(2).makeIterator()
+    while let flag = args.next() {
+        switch flag {
+        case "--tool": tool = args.next()
+        case "--pattern": pattern = args.next()
+        case "--verdict": verdict = args.next()
+        case "--reason": reason = args.next()
+        case "--example": example = args.next()
+        case "--glob": isRegex = false
+        default:
+            FileHandle.standardError.write(Data("Unknown flag: \(flag)\n".utf8))
+            exit(1)
+        }
+    }
+
+    guard let tool, let pattern, let verdict, let reason else {
+        let usage = """
+        Usage: gavel-hook propose-rule --tool <name|*> --pattern <regex> --verdict <deny|prompt> \
+        --reason <why this needs a gate> [--example <triggering command>] [--glob]
+
+        Proposes a persistent Gavel rule for the user to review in the Monitor's Rules tab.
+        Tighten-only: allow rules cannot be proposed. The proposal changes nothing until accepted.
+        """
+        FileHandle.standardError.write(Data((usage + "\n").utf8))
+        exit(1)
+    }
+
+    // Attribute the proposal to the agent session that spawned this call.
+    let pid = getppid()
+    let sessionPid = findAgentPid(from: pid, named: "claude")
+        ?? findAgentPid(from: pid, named: "codex")
+        ?? pid
+
+    var payload: [String: Any] = [
+        "type": "ProposeRule",
+        "tool_name": tool,
+        "pattern": pattern,
+        "is_regex": isRegex,
+        "verdict": verdict,
+        "reason": reason,
+    ]
+    if let example { payload["example"] = example }
+
+    let envelope: [String: Any] = [
+        "hookType": "ProposeRule",
+        "sessionPid": Int(sessionPid),
+        "agent": "claude",
+        "timestamp": Date().timeIntervalSince1970,
+        "payload": payload,
+    ]
+
+    guard let envelopeData = try? JSONSerialization.data(withJSONObject: envelope) else {
+        FileHandle.standardError.write(Data("propose-rule: failed to serialize proposal\n".utf8))
+        exit(1)
+    }
+
+    guard let fd = daemonConnect() else {
+        FileHandle.standardError.write(Data("propose-rule: Gavel daemon not running — proposal not submitted\n".utf8))
+        exit(1)
+    }
+
+    envelopeData.withUnsafeBytes { ptr in
+        _ = write(fd, ptr.baseAddress!, envelopeData.count)
+    }
+    shutdown(fd, SHUT_WR)
+
+    var response = Data()
+    let bufSize = 4096
+    let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: bufSize)
+    defer { buf.deallocate() }
+    var timeout = timeval(tv_sec: 30, tv_usec: 0)
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+    while true {
+        let n = read(fd, buf, bufSize)
+        if n <= 0 { break }
+        response.append(buf, count: n)
+    }
+    close(fd)
+
+    guard let json = try? JSONSerialization.jsonObject(with: response) as? [String: Any] else {
+        FileHandle.standardError.write(Data("propose-rule: no valid response from daemon\n".utf8))
+        exit(1)
+    }
+    guard let status = json["status"] as? String else {
+        // A verdict-shaped reply means an older daemon routed this through the
+        // hook fallback — it predates rule proposals entirely.
+        let hint = json["verdict"] != nil
+            ? "running Gavel daemon predates rule proposals — update/restart Gavel and retry"
+            : "no valid response from daemon"
+        FileHandle.standardError.write(Data("propose-rule: \(hint)\n".utf8))
+        exit(1)
+    }
+
+    if status == "queued" {
+        let id = (json["id"] as? String) ?? "?"
+        print("Proposal queued for user review in the Gavel Monitor (id \(id)). It has no effect until accepted.")
+        exit(0)
+    } else {
+        let why = (json["reason"] as? String) ?? "unknown"
+        print("Proposal rejected: \(why)")
+        exit(1)
+    }
+}
+
+/// Connect to the daemon socket. Returns nil when no daemon is listening.
+func daemonConnect() -> Int32? {
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard fd >= 0 else { return nil }
+
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    let pathBytes = socketPath.utf8CString
+    guard pathBytes.count <= MemoryLayout.size(ofValue: addr.sun_path) else {
+        close(fd)
+        return nil
+    }
+    withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+        ptr.withMemoryRebound(to: CChar.self, capacity: pathBytes.count) { dest in
+            for (i, byte) in pathBytes.enumerated() {
+                dest[i] = byte
+            }
+        }
+    }
+    let result = withUnsafePointer(to: &addr) { ptr in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    guard result == 0 else {
+        close(fd)
+        return nil
+    }
+    return fd
 }
 
 // MARK: - Helpers

--- a/Tests/GavelTests/ProposalStoreTests.swift
+++ b/Tests/GavelTests/ProposalStoreTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+
+@testable import Gavel
+
+final class ProposalStoreTests: XCTestCase {
+    private var dir: String!
+    private var store: ProposalStore!
+    private var ruleStore: RuleStore!
+
+    override func setUpWithError() throws {
+        dir = NSTemporaryDirectory() + "proposals-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        ruleStore = RuleStore(configPath: dir + "/rules.json")
+        store = ProposalStore(path: dir + "/proposals.json")
+        store.ruleStore = ruleStore
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(atPath: dir)
+    }
+
+    private func submit(
+        tool: String = "Bash", pattern: String = "\\blaunchctl\\b\\s+bootstrap",
+        isRegex: Bool = true, verdict: String = "prompt",
+        reason: String = "launchctl bootstrap plants persistent execution",
+        example: String? = "launchctl bootstrap gui/501 evil.plist", pid: Int = 4242
+    ) -> ProposalStore.SubmitResult {
+        store.submit(
+            toolName: tool, pattern: pattern, isRegex: isRegex, verdict: verdict,
+            reason: reason, example: example, sessionPid: pid, sessionId: nil)
+    }
+
+    // MARK: - Direction enforcement (the security property)
+
+    func testAllowVerdictRejectedServerSide() {
+        let result = submit(verdict: "allow")
+        guard case .rejected(let reason) = result else {
+            return XCTFail("allow proposals must never queue")
+        }
+        XCTAssertTrue(reason.contains("tighten-only"))
+        XCTAssertTrue(store.proposals.isEmpty)
+    }
+
+    func testUnknownVerdictRejected() {
+        guard case .rejected = submit(verdict: "yolo") else {
+            return XCTFail("unknown verdict must be rejected")
+        }
+    }
+
+    func testDenyAndPromptBothQueue() {
+        guard case .queued = submit(verdict: "deny") else { return XCTFail("deny should queue") }
+        guard case .queued = submit(pattern: "other", verdict: "prompt") else { return XCTFail("prompt should queue") }
+        XCTAssertEqual(store.proposals.map(\.verdict), [.block, .prompt])
+    }
+
+    // MARK: - Validation
+
+    func testBadRegexRejected() {
+        guard case .rejected(let reason) = submit(pattern: "([unclosed") else {
+            return XCTFail("non-compiling regex must be rejected")
+        }
+        XCTAssertTrue(reason.contains("compile"))
+    }
+
+    func testEmptyReasonRejected() {
+        guard case .rejected = submit(reason: "") else {
+            return XCTFail("reason is required")
+        }
+    }
+
+    func testDuplicateOfExistingRuleRejected() {
+        ruleStore.addRule(PersistentRule(toolName: "Bash", pattern: "already-covered", isRegex: true, verdict: .prompt))
+        guard case .rejected(let reason) = submit(pattern: "already-covered") else {
+            return XCTFail("duplicate of an existing rule must be rejected")
+        }
+        XCTAssertTrue(reason.contains("Duplicate"))
+    }
+
+    func testDuplicatePendingRejected() {
+        guard case .queued = submit() else { return XCTFail() }
+        guard case .rejected(let reason) = submit() else {
+            return XCTFail("second identical proposal must be rejected")
+        }
+        XCTAssertTrue(reason.contains("Already proposed"))
+    }
+
+    func testPerSessionPendingCap() {
+        for i in 0..<ProposalStore.maxPendingPerSession {
+            guard case .queued = submit(pattern: "pattern-\(i)") else {
+                return XCTFail("proposal \(i) should queue")
+            }
+        }
+        guard case .rejected(let reason) = submit(pattern: "one-too-many") else {
+            return XCTFail("cap must reject")
+        }
+        XCTAssertTrue(reason.contains("Too many"))
+
+        // A different session is not capped by this one's backlog.
+        guard case .queued = submit(pattern: "other-session", pid: 9999) else {
+            return XCTFail("cap is per-session")
+        }
+    }
+
+    // MARK: - Adjudication
+
+    func testAcceptCreatesAuditedRuleAndDropsProposal() throws {
+        guard case .queued(let id) = submit(verdict: "deny") else { return XCTFail() }
+
+        let rule = try XCTUnwrap(store.accept(id: id, via: "monitor"))
+        XCTAssertEqual(rule.verdict, .block)
+        XCTAssertEqual(rule.pattern, "\\blaunchctl\\b\\s+bootstrap")
+        XCTAssertEqual(rule.explanation, "launchctl bootstrap plants persistent execution")
+        XCTAssertTrue(store.proposals.isEmpty)
+        XCTAssertTrue(ruleStore.rules.contains { $0.id == rule.id })
+
+        let audit = try XCTUnwrap(ruleStore.auditLog)
+        let entry = try XCTUnwrap(audit.entries().last)
+        XCTAssertEqual(entry.action, "rule_added")
+        XCTAssertTrue(entry.origin.contains("claude-proposal pid=4242"))
+        XCTAssertTrue(entry.origin.contains("accepted-via=monitor"))
+        XCTAssertNil(audit.verifyChain())
+    }
+
+    func testRejectDropsProposalAndAudits() throws {
+        guard case .queued(let id) = submit() else { return XCTFail() }
+
+        store.reject(id: id, via: "monitor")
+        XCTAssertTrue(store.proposals.isEmpty)
+        XCTAssertFalse(ruleStore.rules.contains { $0.pattern == "\\blaunchctl\\b\\s+bootstrap" })
+
+        let entry = try XCTUnwrap(ruleStore.auditLog?.entries().last)
+        XCTAssertEqual(entry.action, "proposal_rejected")
+        XCTAssertTrue(entry.origin.contains("rejected-via=monitor"))
+    }
+
+    func testAcceptUnknownIdIsNoOp() {
+        XCTAssertNil(store.accept(id: UUID()))
+        XCTAssertTrue(ruleStore.rules.filter { !$0.builtIn }.isEmpty)
+    }
+
+    // MARK: - Persistence
+
+    func testProposalsSurviveRestart() throws {
+        guard case .queued(let id) = submit() else { return XCTFail() }
+
+        let reloaded = ProposalStore(path: dir + "/proposals.json")
+        XCTAssertEqual(reloaded.proposals.map(\.id), [id])
+        XCTAssertEqual(reloaded.proposals.first?.reason, "launchctl bootstrap plants persistent execution")
+    }
+
+    func testOnChangeFiresOnMainWithSnapshot() {
+        let expectation = expectation(description: "onChange")
+        var received: [RuleProposal]?
+        store.onChange = { snapshot in
+            XCTAssertTrue(Thread.isMainThread)
+            received = snapshot
+            expectation.fulfill()
+        }
+        guard case .queued = submit() else { return XCTFail() }
+        wait(for: [expectation], timeout: 2)
+        XCTAssertEqual(received?.count, 1)
+    }
+}

--- a/Tests/GavelTests/ProposeRuleWireTests.swift
+++ b/Tests/GavelTests/ProposeRuleWireTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+
+@testable import Gavel
+
+/// Wire-level coverage for the ProposeRule channel: a raw gavel-hook envelope
+/// through HookRouter to the ProposalStore and back out as a JSON ack.
+final class ProposeRuleWireTests: XCTestCase {
+    private var dir: String!
+    private var ruleStore: RuleStore!
+    private var proposalStore: ProposalStore!
+    private var router: HookRouter!
+
+    override func setUpWithError() throws {
+        dir = NSTemporaryDirectory() + "propose-wire-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        ruleStore = RuleStore(configPath: dir + "/rules.json")
+        proposalStore = ProposalStore(path: dir + "/proposals.json")
+        proposalStore.ruleStore = ruleStore
+
+        let engine = ApprovalEngine(patternMatcher: PatternMatcher(), ruleStore: ruleStore)
+        router = HookRouter(
+            sessionManager: SessionManager(),
+            approvalEngine: engine,
+            approvalCoordinator: ApprovalCoordinator()
+        )
+        router.proposalStore = proposalStore
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(atPath: dir)
+    }
+
+    private func send(verdict: String, pattern: String = "\\\\blaunchctl\\\\b", reason: String = "plants persistent execution outside the session") -> [String: Any]? {
+        let json = """
+        {
+            "hookType": "ProposeRule",
+            "sessionPid": 77001,
+            "timestamp": 1712600000.0,
+            "payload": {
+                "type": "ProposeRule",
+                "tool_name": "Bash",
+                "pattern": "\(pattern)",
+                "is_regex": true,
+                "verdict": "\(verdict)",
+                "reason": "\(reason)",
+                "example": "launchctl bootstrap gui/501 evil.plist",
+                "session_id": "wire-test"
+            }
+        }
+        """
+        var response: [String: Any]?
+        router.handle(data: json.data(using: .utf8)!) { data in
+            response = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        }
+        return response
+    }
+
+    func testProposalQueuesOverTheWire() {
+        let response = send(verdict: "prompt")
+        XCTAssertEqual(response?["status"] as? String, "queued")
+        XCTAssertNotNil(response?["id"] as? String)
+
+        XCTAssertEqual(proposalStore.proposals.count, 1)
+        XCTAssertEqual(proposalStore.proposals.first?.verdict, .prompt)
+        XCTAssertEqual(proposalStore.proposals.first?.sessionPid, 77001)
+        XCTAssertEqual(proposalStore.proposals.first?.example, "launchctl bootstrap gui/501 evil.plist")
+        // Inert until accepted: no rule was created.
+        XCTAssertFalse(ruleStore.rules.contains { $0.pattern.contains("launchctl") })
+    }
+
+    func testAllowVerdictRejectedOverTheWire() {
+        let response = send(verdict: "allow")
+        XCTAssertEqual(response?["status"] as? String, "rejected")
+        XCTAssertTrue((response?["reason"] as? String ?? "").contains("tighten-only"))
+        XCTAssertTrue(proposalStore.proposals.isEmpty)
+    }
+
+    func testMissingProposalStoreFailsClosed() {
+        router.proposalStore = nil
+        let response = send(verdict: "deny")
+        XCTAssertEqual(response?["status"] as? String, "rejected")
+    }
+
+    func testProposeRuleEnvelopeDecodes() throws {
+        let json = """
+        {
+            "hookType": "ProposeRule",
+            "sessionPid": 1,
+            "timestamp": 1712600000.0,
+            "payload": {
+                "type": "ProposeRule",
+                "tool_name": "*",
+                "pattern": "^CronCreate$",
+                "is_regex": true,
+                "verdict": "deny",
+                "reason": "scheduler tools plant delayed execution"
+            }
+        }
+        """
+        let event = try JSONDecoder().decode(HookEvent.self, from: Data(json.utf8))
+        XCTAssertEqual(event.hookType, .proposeRule)
+        guard case .proposeRule(let payload) = event.payload else {
+            return XCTFail("expected proposeRule payload, got \(event.payload)")
+        }
+        XCTAssertEqual(payload.toolName, "*")
+        XCTAssertEqual(payload.pattern, "^CronCreate$")
+        XCTAssertEqual(payload.isRegex, true)
+        XCTAssertEqual(payload.verdict, "deny")
+    }
+}

--- a/Tests/GavelTests/RuleAuditLogTests.swift
+++ b/Tests/GavelTests/RuleAuditLogTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+
+@testable import Gavel
+
+final class RuleAuditLogTests: XCTestCase {
+    private var dir: String!
+    private var path: String!
+
+    override func setUpWithError() throws {
+        dir = NSTemporaryDirectory() + "audit-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        path = dir + "/rules.audit.jsonl"
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(atPath: dir)
+    }
+
+    func testChainLinksAndVerifies() {
+        let log = RuleAuditLog(path: path)
+        log.record(action: "rule_added", origin: "panel", toolName: "Bash", pattern: "a", verdict: "block")
+        log.record(action: "rule_removed", origin: "panel", toolName: "Bash", pattern: "a", verdict: "block")
+        log.record(action: "rule_added", origin: "import", toolName: "*", pattern: "b", verdict: "prompt")
+
+        let entries = log.entries()
+        XCTAssertEqual(entries.count, 3)
+        XCTAssertEqual(entries[0].prev, RuleAuditLog.genesisHash)
+        XCTAssertEqual(entries[1].prev, entries[0].hash)
+        XCTAssertEqual(entries[2].prev, entries[1].hash)
+        XCTAssertEqual(entries.map(\.seq), [1, 2, 3])
+        XCTAssertNil(log.verifyChain())
+    }
+
+    func testChainSurvivesReopen() {
+        let first = RuleAuditLog(path: path)
+        first.record(action: "rule_added", origin: "panel", toolName: "Bash", pattern: "a", verdict: "block")
+
+        let reopened = RuleAuditLog(path: path)
+        reopened.record(action: "rule_removed", origin: "panel", toolName: "Bash", pattern: "a", verdict: "block")
+
+        XCTAssertNil(reopened.verifyChain())
+        XCTAssertEqual(reopened.entries().count, 2)
+        XCTAssertEqual(reopened.entries()[1].prev, reopened.entries()[0].hash)
+    }
+
+    func testTamperedLineBreaksChain() throws {
+        let log = RuleAuditLog(path: path)
+        log.record(action: "rule_added", origin: "panel", toolName: "Bash", pattern: "safe", verdict: "block")
+        log.record(action: "rule_added", origin: "panel", toolName: "Bash", pattern: "second", verdict: "prompt")
+
+        // Attacker rewrites history: change entry 1's pattern in place.
+        let text = try String(contentsOfFile: path, encoding: .utf8)
+        let tampered = text.replacingOccurrences(of: "safe", with: "evil")
+        try tampered.write(toFile: path, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(RuleAuditLog(path: path).verifyChain(), 1)
+    }
+
+    func testDeletedMiddleLineBreaksChain() throws {
+        let log = RuleAuditLog(path: path)
+        log.record(action: "rule_added", origin: "panel", toolName: "Bash", pattern: "one", verdict: "block")
+        log.record(action: "rule_added", origin: "panel", toolName: "Bash", pattern: "two", verdict: "block")
+        log.record(action: "rule_added", origin: "panel", toolName: "Bash", pattern: "three", verdict: "block")
+
+        let lines = try String(contentsOfFile: path, encoding: .utf8)
+            .split(separator: "\n")
+        let withoutMiddle = [lines[0], lines[2]].joined(separator: "\n") + "\n"
+        try withoutMiddle.write(toFile: path, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(RuleAuditLog(path: path).verifyChain(), 3)
+    }
+
+    func testRuleStoreMutationsAreAudited() throws {
+        let configPath = dir + "/rules.json"
+        let store = RuleStore(configPath: configPath)
+        let audit = try XCTUnwrap(store.auditLog)
+
+        let rule = PersistentRule(toolName: "Bash", pattern: "audit-me", verdict: .block)
+        store.addRule(rule, origin: "test")
+        store.updateRule(id: rule.id, pattern: "audit-me-2", isRegex: false, verdict: .block, explanation: nil, origin: "test")
+        store.setDisabled(id: rule.id, isDisabled: true, origin: "test")
+        store.removeRule(id: rule.id, origin: "test")
+
+        let actions = audit.entries().map(\.action)
+        XCTAssertEqual(actions, ["rule_added", "rule_updated", "rule_disabled", "rule_removed"])
+        XCTAssertTrue(audit.entries().allSatisfy { $0.origin == "test" })
+        XCTAssertNil(audit.verifyChain())
+    }
+
+    func testDevNullConfigSkipsAudit() {
+        XCTAssertNil(RuleStore(configPath: "/dev/null").auditLog)
+    }
+}


### PR DESCRIPTION
## What

Claude can now propose persistent Gavel rules from inside a session:

```
gavel-hook propose-rule --tool Bash --pattern '\blaunchctl\b\s+(bootstrap|load)'   --verdict prompt --reason 'plants persistent execution'   --example 'launchctl bootstrap gui/501 evil.plist'
```

Proposals are **inert** -- they queue in a pending inbox (`~/.claude/gavel/proposals.json`) and change zero matching behavior until accepted in the Monitor's Rules tab. Arrival posts a feed line + macOS notification; the Rules tab badges the pending count and shows Accept/Reject cards.

## Security model

- **Tighten-only, enforced server-side**: `ProposalStore.submit` only queues deny/prompt verdicts. `allow` is rejected at the socket layer, so no client flag or crafted payload can widen permissions through this channel. The API simply has no loosening surface.
- **Validation**: regex must compile, dedupe vs existing rules + pending proposals, per-session pending cap (10), 7-day TTL, length caps, reason required.
- **Audit journal**: every rule mutation (panel add/edit/delete/disable, imports, approval-panel always-\*, proposal accept/reject) appends to `rules.audit.jsonl` with origin + SHA-256 hash chain -- rewriting or deleting history breaks every subsequent hash (`verifyChain()`).
- Accepted proposals go through the normal `RuleStore.addRule` path (uchg write-window, signature, backup).

## Testing

- 23 new tests (ProposalStoreTests, RuleAuditLogTests, ProposeRuleWireTests -- the wire suite drives a raw gavel-hook envelope through HookRouter to the store and back). Full suite: 647 passed.
- Built CLI exercised: usage path, and graceful old-daemon detection (a 1.38 daemon replies verdict-shaped; CLI now says 'daemon predates rule proposals' instead of a cryptic error).

## Dogfood notes

- Full E2E needs the new daemon running: `just dev-daemon`, then have a session propose something and accept it in the Rules tab.
- Follow-ups (not in this PR): Telegram Accept/Reject buttons, note-back-to-session on adjudication, Edit-before-accept.