### PR TITLE
fix(session): discover native-install claude sessions with version-named binaries

### DIFF
--- a/Sources/Gavel/System/ProcessTree.swift
+++ b/Sources/Gavel/System/ProcessTree.swift
@@ -19,6 +19,15 @@ struct ProcessTree {
                name.lowercased().contains(target) {
                 return current
             }
+            // Native-install agent binaries are version-named files
+            // (…/claude/versions/2.1.198), so p_comm is the version string and
+            // the name check above never matches. Match an exact path COMPONENT
+            // of the executable instead — component equality, not substring, so
+            // paths like …/claude-gavel/… can't false-positive.
+            if let path = executablePath(pid: current),
+               pathHasComponent(path, matching: target) {
+                return current
+            }
             guard let ppid = parentPid(of: current), ppid > 1 else {
                 break
             }
@@ -143,17 +152,66 @@ struct ProcessTree {
         }
     }
 
-    /// Discover live CLI sessions whose `p_comm` matches `processName` exactly.
-    /// Exact-match (not substring) so we don't pick up helper processes whose
-    /// truncated paths happen to contain the agent name.
+    /// Path of the executable image backing `pid`, via proc_pidpath.
+    /// Resolves to the real vnode path, so a symlink launch
+    /// (~/.local/bin/claude → …/versions/2.1.198) reports the target.
+    static func executablePath(pid: Int32) -> String? {
+        var buf = [CChar](repeating: 0, count: 4096)
+        let n = proc_pidpath(pid, &buf, UInt32(buf.count))
+        guard n > 0 else { return nil }
+        return String(cString: buf)
+    }
+
+    /// True if any path component equals `target` (case-insensitive).
+    /// Component equality, not substring, so …/claude-gavel/… can't
+    /// false-positive against "claude".
+    static func pathHasComponent(_ path: String, matching target: String) -> Bool {
+        path.lowercased().split(separator: "/").contains(Substring(target.lowercased()))
+    }
+
+    /// True if a DIRECTORY component of `path` equals `target` (case-insensitive).
+    /// Excludes the basename: Claude Desktop's binary is
+    /// /Applications/Claude.app/Contents/MacOS/Claude, whose basename lowercases
+    /// to "claude" — only the install-directory component identifies the CLI.
+    static func pathHasDirectoryComponent(_ path: String, matching target: String) -> Bool {
+        path.lowercased().split(separator: "/").dropLast().contains(Substring(target.lowercased()))
+    }
+
+    /// Discover live CLI sessions for the agent named `target`.
+    ///
+    /// A process matches when its `p_comm` equals `target` exactly, or — for
+    /// native-install binaries that are version-named files
+    /// (…/claude/versions/2.1.198, p_comm "2.1.198") — when a directory
+    /// component of its executable path equals `target`. Exact matches only
+    /// (no substring) so helper processes can't false-positive.
+    ///
+    /// Wrapper processes that exec the agent as a direct child (the
+    /// ClaudeCode.app pty-host, the cc-daemon) match too; only the leaf
+    /// process is the session, so candidates that are direct parents of
+    /// other candidates are dropped.
     static func findCliSessions(processName target: String) -> [(pid: Int32, cwd: String)] {
-        var results: [(Int32, String)] = []
+        var candidates: [(pid: Int32, cwd: String)] = []
         for pid in enumerateAllPids() {
-            guard let name = processName(pid: pid), name == target else { continue }
+            guard let name = processName(pid: pid) else { continue }
+            if name != target {
+                guard let path = executablePath(pid: pid),
+                      pathHasDirectoryComponent(path, matching: target) else { continue }
+            }
             guard let cwd = cwd(of: pid) else { continue }
-            results.append((pid, cwd))
+            candidates.append((pid, cwd))
         }
-        return results
+        return dropWrapperParents(candidates)
+    }
+
+    /// Drop candidates that are direct parents of other candidates — a wrapper
+    /// (pty-host, cc-daemon) that spawned the real REPL as its child isn't
+    /// itself a session. `parentOf` is injectable for tests.
+    static func dropWrapperParents(
+        _ candidates: [(pid: Int32, cwd: String)],
+        parentOf: (Int32) -> Int32? = ProcessTree.parentPid(of:)
+    ) -> [(pid: Int32, cwd: String)] {
+        let wrapperPids = Set(candidates.compactMap { parentOf($0.pid) })
+        return candidates.filter { !wrapperPids.contains($0.pid) }
     }
 
     /// Convenience wrapper preserved for existing call sites.

--- a/Tests/GavelTests/ProcessTreeTests.swift
+++ b/Tests/GavelTests/ProcessTreeTests.swift
@@ -35,4 +35,171 @@ final class ProcessTreeTests: XCTestCase {
             XCTAssertTrue(cwd.hasPrefix("/"))
         }
     }
+
+    // MARK: - Executable path matching
+
+    func testExecutablePathOfSelf() {
+        guard let path = ProcessTree.executablePath(pid: getpid()) else {
+            XCTFail("executablePath failed for our own PID")
+            return
+        }
+        XCTAssertTrue(path.hasPrefix("/"))
+    }
+
+    func testPathHasComponentMatchesVersionNamedInstall() {
+        XCTAssertTrue(ProcessTree.pathHasComponent(
+            "/Users/u/.local/share/claude/versions/2.1.198", matching: "claude"))
+    }
+
+    func testPathHasComponentRejectsSubstringComponents() {
+        XCTAssertFalse(ProcessTree.pathHasComponent(
+            "/Users/u/code/claude-gavel/.build/release/gavel", matching: "claude"))
+        XCTAssertFalse(ProcessTree.pathHasComponent(
+            "/Applications/Claude.app/Contents/Helpers/chrome-native-host", matching: "claude"))
+    }
+
+    func testPathHasDirectoryComponentExcludesBasename() {
+        // Claude Desktop's binary basename lowercases to "claude" but its
+        // install dirs don't — must not be discovered as a CLI session.
+        XCTAssertFalse(ProcessTree.pathHasDirectoryComponent(
+            "/Applications/Claude.app/Contents/MacOS/Claude", matching: "claude"))
+        // Ancestor attribution intentionally does match on basename.
+        XCTAssertTrue(ProcessTree.pathHasComponent(
+            "/Applications/Claude.app/Contents/MacOS/Claude", matching: "claude"))
+    }
+
+    func testPathHasDirectoryComponentMatchesInstallDir() {
+        XCTAssertTrue(ProcessTree.pathHasDirectoryComponent(
+            "/Users/u/.local/share/claude/versions/2.1.198", matching: "claude"))
+        XCTAssertTrue(ProcessTree.pathHasDirectoryComponent(
+            "/Users/u/.local/share/claude/ClaudeCode.app/Contents/MacOS/claude", matching: "claude"))
+        XCTAssertFalse(ProcessTree.pathHasDirectoryComponent(
+            "/Users/u/code/claude-gavel/versions/2.1.198", matching: "claude"))
+    }
+
+    // MARK: - Live discovery fixtures
+    //
+    // Copies real binaries into a version-named directory layout mirroring the
+    // native Claude install (…/claude/versions/9.9.9), spawns them, and runs
+    // actual discovery against the live process table.
+
+    private var fixtureRoot: URL!
+    private var spawned: [Process] = []
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        fixtureRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gavel-ptree-\(UUID().uuidString)")
+    }
+
+    override func tearDownWithError() throws {
+        for proc in spawned where proc.isRunning { proc.terminate() }
+        spawned = []
+        if let root = fixtureRoot {
+            try? FileManager.default.removeItem(at: root)
+        }
+        try super.tearDownWithError()
+    }
+
+    /// Copy /bin/sleep to fixtureRoot/<relativePath> and spawn it.
+    private func spawnFixture(_ relativePath: String) throws -> Process {
+        let dest = fixtureRoot.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.copyItem(at: URL(fileURLWithPath: "/bin/sleep"), to: dest)
+        let proc = Process()
+        proc.executableURL = dest
+        proc.arguments = ["30"]
+        proc.currentDirectoryURL = fixtureRoot
+        try proc.run()
+        spawned.append(proc)
+        return proc
+    }
+
+    private func discoveredPids() -> Set<Int32> {
+        Set(ProcessTree.findCliSessions(processName: "claude").map(\.pid))
+    }
+
+    func testDiscoversVersionNamedBinaryInClaudeDir() throws {
+        let proc = try spawnFixture("claude/versions/9.9.9")
+        let sessions = ProcessTree.findCliSessions(processName: "claude")
+        guard let match = sessions.first(where: { $0.pid == proc.processIdentifier }) else {
+            XCTFail("version-named binary under a claude/ dir was not discovered")
+            return
+        }
+        let expectedCwd = (fixtureRoot.path as NSString).resolvingSymlinksInPath
+        XCTAssertEqual((match.cwd as NSString).resolvingSymlinksInPath, expectedCwd)
+    }
+
+    func testDoesNotDiscoverVersionNamedBinaryOutsideClaudeDir() throws {
+        let proc = try spawnFixture("claude-gavel/versions/9.9.9")
+        XCTAssertFalse(discoveredPids().contains(proc.processIdentifier))
+    }
+
+    func testDoesNotDiscoverUppercaseClaudeBasename() throws {
+        // Mirrors Claude Desktop: p_comm "Claude" ≠ "claude", and the basename
+        // must not satisfy the directory-component fallback.
+        let proc = try spawnFixture("desktop/Claude")
+        XCTAssertFalse(discoveredPids().contains(proc.processIdentifier))
+    }
+
+    // MARK: - Wrapper dedupe
+
+    func testDropWrapperParentsKeepsOnlyLeafProcesses() {
+        // Mirrors the live ClaudeCode.app chain: cc-daemon (100) → pty-host
+        // (200) → REPL (300); plus a terminal session (400) whose parent is a
+        // non-candidate shell.
+        let candidates: [(pid: Int32, cwd: String)] = [
+            (100, "/w"), (200, "/w"), (300, "/w"), (400, "/t"),
+        ]
+        let parents: [Int32: Int32] = [200: 100, 300: 200, 400: 999]
+        let kept = ProcessTree.dropWrapperParents(candidates) { parents[$0] }
+        XCTAssertEqual(kept.map(\.pid), [300, 400])
+    }
+
+    func testDropWrapperParentsHandlesUnknownParents() {
+        let candidates: [(pid: Int32, cwd: String)] = [(500, "/a"), (600, "/b")]
+        let kept = ProcessTree.dropWrapperParents(candidates) { _ in nil }
+        XCTAssertEqual(kept.map(\.pid), [500, 600])
+    }
+
+    func testLiveClaudeSessionDiscoveryAgainstPsWitness() throws {
+        // Independent witness: `ps` comm paths. Native-install claude
+        // processes exec via ~/.local/bin/claude or …/share/claude/… — the
+        // exact class findClaudeCliSessions() must discover. Skips when no
+        // claude is running (CI).
+        let ps = Process()
+        ps.executableURL = URL(fileURLWithPath: "/bin/ps")
+        ps.arguments = ["-axo", "pid=,ppid=,comm="]
+        let pipe = Pipe()
+        ps.standardOutput = pipe
+        try ps.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        ps.waitUntilExit()
+
+        var witnesses: [(pid: Int32, ppid: Int32)] = []
+        for line in String(decoding: data, as: UTF8.self).split(separator: "\n") {
+            let fields = line.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true)
+            guard fields.count == 3,
+                  let pid = Int32(fields[0]), let ppid = Int32(fields[1]),
+                  fields[2].contains("/.local/bin/claude") || fields[2].contains("/.local/share/claude/")
+            else { continue }
+            witnesses.append((pid, ppid))
+        }
+        try XCTSkipIf(witnesses.isEmpty, "no native-install claude processes running")
+
+        let witnessPids = Set(witnesses.map(\.pid))
+        let wrapperPids = Set(witnesses.map(\.ppid)).intersection(witnessPids)
+        let leaves = witnessPids.subtracting(wrapperPids)
+        let discovered = discoveredPids()
+
+        for pid in leaves where ProcessTree.isAlive(pid: pid) && ProcessTree.cwd(of: pid) != nil {
+            XCTAssertTrue(discovered.contains(pid),
+                          "live claude session pid \(pid) was not discovered")
+        }
+        for pid in wrapperPids {
+            XCTAssertFalse(discovered.contains(pid),
+                           "wrapper pid \(pid) should not be discovered as a session")
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Found during rule-proposals dogfood (2026-07-02): native-install Claude binaries are version-named files (`~/.local/share/claude/versions/2.1.198`), so `p_comm` is the version string, not `claude`. Two daemon-side victims in `ProcessTree`:

- `findCliSessions` matched `p_comm == target` exactly, so `findClaudeCliSessions()` (used by `SessionManager.discoverRunningSessions()`) found **zero** live terminal sessions — only the `ClaudeCode.app` pty-host wrappers, whose `p_comm` happens to be `claude`.
- `findAncestorPid` matched `p_comm` substring only — same class of miss for daemon-side attribution.

## Fix

Ports the executable-path fallback that shipped for the gavel-hook CLI in c1def3d: when `p_comm` doesn't match, resolve the executable via `proc_pidpath` and match an exact path **component** (`…/claude/versions/2.1.198` → component `claude`), never a substring, so `…/claude-gavel/…` can't false-positive.

Discovery is stricter than attribution in two ways, both driven by the live process table:

- **Directory components only.** Claude Desktop's binary is `/Applications/Claude.app/Contents/MacOS/Claude` — its *basename* lowercases to `claude`, but no directory component does, so the desktop app can't be discovered as a CLI session.
- **Wrapper dedupe.** The path fallback also matches the pty-host/cc-daemon chain (`cc-daemon → pty-host → REPL`, each the direct parent of the next). Discovery now drops candidates that are direct parents of other candidates, keeping only the leaf REPL process.

## Verification

- 658 tests pass, including new pure matcher tests, spawned version-named-binary fixtures exercising real discovery, and a `ps`-witnessed live test (skips in CI when no claude is running).
- Verified against the live system: real sessions (`p_comm` `2.1.198`, e.g. pid 6871) are discovered with correct cwds; pty-host wrappers, cc-daemon, and Claude Desktop are excluded.

## Sequencing

**Do not merge until the `chore(main): release 1.39.0` release-please PR has merged** — this should land as 1.39.1.