### PR TITLE
feat(approval): site-scoped browsing lease for claude-in-chrome

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -21,11 +21,13 @@ final class ApprovalCoordinator: ObservableObject {
         case alwaysDenyPattern(pattern: String, isRegex: Bool, explanation: String?)
         case alwaysAllowPattern(pattern: String, isRegex: Bool)
         case alwaysPromptPattern(pattern: String, isRegex: Bool)
+        case allowSiteForSession(domain: String, context: String?)
 
         /// Actions that grant a durable (non-Allow-once) allow — refused on nonSuppressible approvals.
         var createsDurableAllow: Bool {
             switch self {
-            case .allowPatternForSession, .suppressRuleForSession, .alwaysAllowPattern:
+            case .allowPatternForSession, .suppressRuleForSession, .alwaysAllowPattern,
+                .allowSiteForSession:
                 return true
             default:
                 return false
@@ -259,6 +261,17 @@ final class ApprovalCoordinator: ObservableObject {
                     reason: "User approved (\(current.payload.toolName): \(pattern))",
                     additionalContext: ctx, updatedInput: updated))
 
+        case .allowSiteForSession(let domain, let context):
+            ctx = context
+            updated = nil
+            current.session.grantBrowsingLease(domain: domain)
+            gavelLog("[lease] granted pid=\(current.session.pid) domain=\(domain)")
+            current.respond(
+                Decision(
+                    verdict: .allow,
+                    reason: "Browsing lease granted: \(domain) (session, auto-revokes on site drift)",
+                    additionalContext: ctx))
+
         case .suppressRuleForSession(let ruleId, let context, let updatedCommand, let fieldUpdates):
             ctx = context
             updated = fieldUpdates ?? buildUpdatedInput(updatedCommand)
@@ -418,6 +431,7 @@ final class ApprovalCoordinator: ObservableObject {
         case .alwaysDenyPattern: return "alwaysDenyPattern"
         case .alwaysAllowPattern: return "alwaysAllowPattern"
         case .alwaysPromptPattern: return "alwaysPromptPattern"
+        case .allowSiteForSession: return "allowSiteForSession"
         }
     }
 

--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -179,6 +179,17 @@ final class ApprovalCoordinator: ObservableObject {
             let rule = SessionRule(toolName: payload.toolName, pattern: pattern)
             DispatchQueue.main.async { session.sessionRules.append(rule) }
         }
+        // Browsing-lease button: only for chrome navigate approvals with a
+        // parseable URL — the phone twin of the panel's "Allow Site".
+        let leaseDomain: String? = (pending.nonSuppressible || payload.toolName != BrowsingLease.navigateTool)
+            ? nil
+            : BrowsingLease.normalizedHost(fromURL: payload.toolInput["url"]?.stringValue ?? "")
+        let allowSite: (() -> Void)? = leaseDomain.map { domain in
+            {
+                session.grantBrowsingLease(domain: domain)
+                gavelLog("[lease] granted pid=\(session.pid) domain=\(domain) via=phone")
+            }
+        }
         resolvable.addCleanup { [weak self] source, _ in
             guard source == .telegram else { return }
             DispatchQueue.main.async { self?.dismissPending(id: pendingId, pid: session.pid) }
@@ -187,7 +198,7 @@ final class ApprovalCoordinator: ObservableObject {
             ? RemoteApprovalBridge.withheldBody(payload: payload, session: session)
             : RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: pending.triggerReason)
         let isCommit = withheld == nil && payload.toolName == "Bash" && (payload.command?.contains("commit") ?? false)
-        bridge.notify(resolvable: resolvable, text: text, pid: session.pid, toolName: payload.toolName, withheld: withheld != nil, allowSession: allowSession, offerCommentClean: isCommit)
+        bridge.notify(resolvable: resolvable, text: text, pid: session.pid, toolName: payload.toolName, withheld: withheld != nil, allowSession: allowSession, offerCommentClean: isCommit, leaseDomain: leaseDomain, allowSite: allowSite)
     }
 
     /// Remove a pending approval resolved remotely from its session panel.

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -631,6 +631,35 @@ struct ApprovalPanelView: View {
                     .keyboardShortcut("r", modifiers: [.command])
                     .help(approval.triggeringRulePattern.map { "Suppress rule for session: \($0)" } ?? "Suppress firing rule for session")
                 }
+
+            }
+
+            // Site lease: offered only on chrome navigate approvals with a
+            // parseable URL. Own row — the rules row above already holds up
+            // to seven buttons and would clip this one in the fixed-width
+            // panel. Scoped tighter than Session Allow: page interaction +
+            // same-site navigation on this domain, auto-revoked on site
+            // drift / TTL; javascript & uploads still prompt.
+            if !approval.nonSuppressible,
+               approval.payload.toolName == BrowsingLease.navigateTool,
+               let leaseDomain = BrowsingLease.normalizedHost(
+                   fromURL: approval.payload.toolInput["url"]?.stringValue ?? "") {
+                HStack {
+                    Spacer()
+                    Button(action: {
+                        coordinator.handleAction(.allowSiteForSession(
+                            domain: leaseDomain,
+                            context: noteState.noteForAllowContext
+                        ), on: sessionPanel)
+                        coordinator.sessionManager?.noteInteraction()
+                    }) {
+                        Label("Allow Site: \(leaseDomain)", systemImage: "globe")
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.teal)
+                    .keyboardShortcut("g", modifiers: [.command])
+                    .help("Session lease for \(leaseDomain): auto-allow page interaction (computer, form_input) and same-site navigation. Auto-revokes if the page leaves \(leaseDomain), after \(Int(BrowsingLease.defaultTTL / 60)) min, or via the SITE badge in the Monitor. javascript_tool and file uploads still prompt.")
+                }
             }
 
             // One-time actions

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -243,6 +243,20 @@ final class HookRouter {
                         sendResponse(Decision(verdict: .allow, reason: "Session rule: \(rule.pattern)"), payload: payload, session: session, respond: respond)
                         return
                     }
+
+                    // Browsing lease: site-scoped session allow for chrome
+                    // page-interaction tools + same-site navigation. Drift
+                    // revocation lives in handlePostToolUse.
+                    if let lease = session.browsingLease,
+                       let reason = lease.allows(
+                           toolName: payload.toolName,
+                           url: payload.toolInput["url"]?.stringValue
+                       ) {
+                        session.stats.incrementAllow()
+                        emitFeed(.decision(badge: .allow, reason: reason, pid: session.pid, at: timestamp))
+                        sendResponse(Decision(verdict: .allow, reason: reason), payload: payload, session: session, respond: respond)
+                        return
+                    }
                 }
 
                 // MCP-style block: jump straight to interactive dialog
@@ -337,18 +351,54 @@ final class HookRouter {
     ) {
         var output = ""
         if let response = payload.toolResponse {
-            if let str = response.stringValue {
-                output = str
-            } else if let dict = response.dictValue {
-                let stdout = dict["stdout"]?.stringValue ?? ""
-                let stderr = dict["stderr"]?.stringValue ?? ""
-                output = [stdout, stderr].filter { !$0.isEmpty }.joined(separator: "\n")
+            output = Self.extractResponseText(response)
+        }
+
+        // Browsing-lease drift check: the extension appends a Tab Context
+        // block (with the executed tab's live URL) to every chrome tool
+        // result, so an in-page navigation is visible in the response of the
+        // click that caused it. Any off-domain URL — or an unparseable
+        // response, fail closed — revokes the lease before the next call.
+        if BrowsingLease.driftCheckedTools.contains(payload.toolName),
+           let lease = session.browsingLease {
+            if !lease.isActive {
+                session.revokeBrowsingLease()
+                gavelLog("[lease] expired pid=\(session.pid) domain=\(lease.domain)")
+            } else if let why = BrowsingLease.driftReason(inResponse: output, domain: lease.domain) {
+                session.revokeBrowsingLease()
+                let reason = "Browsing lease revoked (\(lease.domain)): \(why)"
+                gavelLog("[lease] \(reason) pid=\(session.pid)")
+                emitFeed(.system(reason, pid: session.pid, at: timestamp))
             }
         }
 
         if !output.isEmpty {
             emitFeed(.toolResult(output: output, pid: session.pid, at: timestamp))
         }
+    }
+
+    /// Flatten a tool_response into displayable text. Handles the Bash shape
+    /// ({stdout, stderr}), plain strings, and MCP content arrays
+    /// ({content: [{type: "text", text: ...}]} or a bare array of items).
+    static func extractResponseText(_ response: AnyCodable) -> String {
+        if let str = response.stringValue { return str }
+        if let dict = response.dictValue {
+            let stdout = dict["stdout"]?.stringValue ?? ""
+            let stderr = dict["stderr"]?.stringValue ?? ""
+            if !stdout.isEmpty || !stderr.isEmpty {
+                return [stdout, stderr].filter { !$0.isEmpty }.joined(separator: "\n")
+            }
+            if let content = dict["content"]?.arrayValue {
+                return content.compactMap { $0.dictValue?["text"]?.stringValue }
+                    .joined(separator: "\n")
+            }
+            return ""
+        }
+        if let arr = response.arrayValue {
+            return arr.compactMap { $0.dictValue?["text"]?.stringValue }
+                .joined(separator: "\n")
+        }
+        return ""
     }
 
     // MARK: - Helpers

--- a/Sources/Gavel/Models/BrowsingLease.swift
+++ b/Sources/Gavel/Models/BrowsingLease.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// Site-scoped session lease for claude-in-chrome automation.
+///
+/// Granted from a navigate approval ("Allow Site"); auto-allows the
+/// high-frequency page-interaction tools on that site so a driven page
+/// doesn't cost one prompt per click. Revoked the moment a driven tab
+/// reports a URL off the leased domain — the drift is visible in the SAME
+/// tool response that caused it, so exposure is bounded to one
+/// already-approved action — or on TTL expiry, manual revoke, or
+/// `revokeAutoApprove`.
+struct BrowsingLease {
+    let domain: String  // normalized host, e.g. "example.com"
+    let grantedAt: Date
+    let ttl: TimeInterval
+
+    static let defaultTTL: TimeInterval = 30 * 60
+
+    static let chromeToolPrefix = "mcp__claude-in-chrome__"
+    static let navigateTool = chromeToolPrefix + "navigate"
+
+    /// Tools a lease may auto-allow. Deliberately excludes the exfil-grade
+    /// tools (javascript_tool, file_upload, upload_image, shortcuts_execute)
+    /// and tab lifecycle — those keep their normal prompt tier regardless of
+    /// any lease.
+    static let leaseSafeTools: Set<String> = [
+        chromeToolPrefix + "computer",
+        chromeToolPrefix + "form_input",
+    ]
+
+    /// Tools whose responses must re-confirm the leased domain (all carry the
+    /// extension's "Tab Context" block with an "Executed on tabId" line).
+    static let driftCheckedTools: Set<String> = leaseSafeTools.union([navigateTool])
+
+    var expiresAt: Date { grantedAt.addingTimeInterval(ttl) }
+    var isActive: Bool { Date() < expiresAt }
+
+    init(domain: String, grantedAt: Date = Date(), ttl: TimeInterval = BrowsingLease.defaultTTL) {
+        self.domain = domain
+        self.grantedAt = grantedAt
+        self.ttl = ttl
+    }
+
+    /// Normalize a URL (with or without scheme — navigate accepts both) to a
+    /// comparable host. "www." is stripped so example.com and www.example.com
+    /// are one site; everything else is exact-host, so sub.example.com is a
+    /// DIFFERENT site than example.com (stricter beats eTLD+1 cleverness).
+    static func normalizedHost(fromURL urlString: String) -> String? {
+        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let withScheme = trimmed.contains("://") ? trimmed : "https://" + trimmed
+        guard let host = URL(string: withScheme)?.host?.lowercased(), !host.isEmpty else {
+            return nil
+        }
+        return host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
+    }
+
+    func covers(urlString: String) -> Bool {
+        Self.normalizedHost(fromURL: urlString) == domain
+    }
+
+    /// Whether this lease allows the tool call. Returns a human-readable
+    /// reason on allow; nil falls through to the normal prompt tiers.
+    func allows(toolName: String, url: String?) -> String? {
+        guard isActive else { return nil }
+        if Self.leaseSafeTools.contains(toolName) {
+            return "Browsing lease: \(domain)"
+        }
+        if toolName == Self.navigateTool, let url, covers(urlString: url) {
+            return "Browsing lease: \(domain) (same-site navigate)"
+        }
+        return nil
+    }
+
+    // MARK: - Drift detection
+
+    /// Inspect a chrome tool response for domain drift. Returns a revocation
+    /// reason if the executed tab is off-domain, or if the response carries
+    /// no parseable executed-tab URL (fail closed — a lease only survives
+    /// while responses keep proving the domain).
+    static func driftReason(inResponse text: String, domain: String) -> String? {
+        guard let executedURL = executedTabURL(inResponse: text) else {
+            return "response missing executed-tab URL (fail closed)"
+        }
+        if let host = normalizedHost(fromURL: executedURL), host == domain {
+            return nil
+        }
+        let drifted = normalizedHost(fromURL: executedURL) ?? executedURL
+        return "tab drifted to \(drifted)"
+    }
+
+    /// Parse the executed tab's URL out of the "Tab Context" block the chrome
+    /// extension appends to every tool result:
+    ///
+    ///     Tab Context:
+    ///     - Executed on tabId: 2140008915
+    ///     - Available tabs:
+    ///       • tabId 2140008915: "Example Domain" (https://example.com/)
+    ///
+    /// The URL is the last parenthesized span on the executed tab's line, so
+    /// titles containing parentheses don't break the parse.
+    static func executedTabURL(inResponse text: String) -> String? {
+        guard let idMatch = firstRegexMatch(#"Executed on tabId:\s*(\d+)"#, in: text) else {
+            return nil
+        }
+        for line in text.split(separator: "\n") where line.contains("tabId \(idMatch):") {
+            // Skip the "Executed on tabId: N" line itself (no URL on it).
+            guard let open = line.lastIndex(of: "("),
+                  let close = line.lastIndex(of: ")"),
+                  open < close
+            else { continue }
+            let url = String(line[line.index(after: open)..<close])
+            if !url.isEmpty { return url }
+        }
+        return nil
+    }
+
+    private static func firstRegexMatch(_ pattern: String, in text: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+              match.numberOfRanges > 1,
+              let range = Range(match.range(at: 1), in: text)
+        else { return nil }
+        return String(text[range])
+    }
+}

--- a/Sources/Gavel/Models/HookEvent.swift
+++ b/Sources/Gavel/Models/HookEvent.swift
@@ -254,6 +254,7 @@ struct AnyCodable: Codable {
     var intValue: Int? { value as? Int }
     var boolValue: Bool? { value as? Bool }
     var dictValue: [String: AnyCodable]? { value as? [String: AnyCodable] }
+    var arrayValue: [AnyCodable]? { value as? [AnyCodable] }
 
     init(_ value: Any) {
         self.value = value

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -79,6 +79,41 @@ final class Session: ObservableObject, Identifiable {
         return (_remoteEnabled, _remoteUntil)
     }
 
+    // Browsing lease — site-scoped session allow for claude-in-chrome tools.
+    // Lock-guarded like remote approval: granted on main (panel action) but
+    // read on the socket queue for every chrome PreToolUse, and revoked from
+    // the PostToolUse path, which must be visible to the very next PreToolUse.
+    private var _browsingLease: BrowsingLease?
+    private let browsingLeaseLock = NSLock()
+
+    /// Main-thread mirror for Monitor display only — never gate on this.
+    @Published var browsingLeaseDomainUI: String?
+
+    var browsingLease: BrowsingLease? {
+        browsingLeaseLock.lock()
+        defer { browsingLeaseLock.unlock() }
+        return _browsingLease
+    }
+
+    func grantBrowsingLease(domain: String, ttl: TimeInterval = BrowsingLease.defaultTTL) {
+        browsingLeaseLock.lock()
+        _browsingLease = BrowsingLease(domain: domain, ttl: ttl)
+        browsingLeaseLock.unlock()
+        DispatchQueue.main.async { self.browsingLeaseDomainUI = domain }
+    }
+
+    @discardableResult
+    func revokeBrowsingLease() -> BrowsingLease? {
+        browsingLeaseLock.lock()
+        let lease = _browsingLease
+        _browsingLease = nil
+        browsingLeaseLock.unlock()
+        if lease != nil {
+            DispatchQueue.main.async { self.browsingLeaseDomainUI = nil }
+        }
+        return lease
+    }
+
     // Worker-mutable state. NOT @Published on purpose — both are touched on
     // every PreToolUse hook from background threads, and `@Published`
     // mutations from non-main contend with SwiftUI's main-thread publish
@@ -134,6 +169,7 @@ final class Session: ObservableObject, Identifiable {
         autoApproveUntil = nil
         sessionRules.removeAll()
         suppressedRuleIds.removeAll()
+        revokeBrowsingLease()
     }
 
     /// Check if a tool call matches any session allow rule.

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -1476,6 +1476,11 @@ struct SessionRulesView: View {
                     if session.isPaused {
                         badge("PAUSED", color: .orange)
                     }
+                    if let leaseDomain = session.browsingLeaseDomainUI {
+                        badge("SITE \(leaseDomain)", color: .teal)
+                            .onTapGesture { session.revokeBrowsingLease() }
+                            .help("Browsing lease: chrome page interaction auto-allowed on \(leaseDomain). Click to revoke.")
+                    }
                 }
             }
 

--- a/Sources/Gavel/Remote/RemoteApprovalBridge.swift
+++ b/Sources/Gavel/Remote/RemoteApprovalBridge.swift
@@ -13,13 +13,18 @@ final class RemoteApprovalBridge {
         let toolName: String
         let resolvable: ResolvableApproval
         let allowSession: (() -> Void)?
+        let allowSite: (() -> Void)?
         var messageId: Int?
-        init(nonce: String, pid: Int, toolName: String, resolvable: ResolvableApproval, allowSession: (() -> Void)?) {
+        init(
+            nonce: String, pid: Int, toolName: String, resolvable: ResolvableApproval,
+            allowSession: (() -> Void)?, allowSite: (() -> Void)? = nil
+        ) {
             self.nonce = nonce
             self.pid = pid
             self.toolName = toolName
             self.resolvable = resolvable
             self.allowSession = allowSession
+            self.allowSite = allowSite
         }
     }
 
@@ -77,7 +82,10 @@ final class RemoteApprovalBridge {
     // MARK: - Outbound
 
     /// Send a pending approval to the phone and register it for inbound resolution.
-    func notify(resolvable: ResolvableApproval, text: String, pid: Int = 0, toolName: String = "", withheld: Bool = false, allowSession: (() -> Void)?, offerCommentClean: Bool = false) {
+    /// `leaseDomain`/`allowSite` (both required together) add a browsing-lease
+    /// button for chrome navigate approvals — the phone twin of the panel's
+    /// "Allow Site" (see BrowsingLease).
+    func notify(resolvable: ResolvableApproval, text: String, pid: Int = 0, toolName: String = "", withheld: Bool = false, allowSession: (() -> Void)?, offerCommentClean: Bool = false, leaseDomain: String? = nil, allowSite: (() -> Void)? = nil) {
         lock.lock(); let chat = chatId; lock.unlock()
         guard let chat else { return }
 
@@ -88,7 +96,9 @@ final class RemoteApprovalBridge {
         }
 
         let nonce = Self.makeNonce()
-        let corr = Correlation(nonce: nonce, pid: pid, toolName: toolName, resolvable: resolvable, allowSession: allowSession)
+        let corr = Correlation(
+            nonce: nonce, pid: pid, toolName: toolName, resolvable: resolvable,
+            allowSession: allowSession, allowSite: allowSite)
         lock.lock(); byNonce[nonce] = corr; pendingOrder.append(nonce); lock.unlock()
 
         resolvable.addCleanup { [weak self] source, _ in
@@ -109,6 +119,9 @@ final class RemoteApprovalBridge {
         // Allow-once-only approvals (nil allowSession) omit the session button entirely.
         if allowSession != nil {
             keyboard.append([TelegramButton(text: "✅ Allow for session", callbackData: "s:\(nonce)")])
+        }
+        if allowSite != nil, let leaseDomain {
+            keyboard.append([TelegramButton(text: "🌐 Allow site: \(leaseDomain)", callbackData: "g:\(nonce)")])
         }
         keyboard.append([TelegramButton(text: "✅ Allow w/ note", callbackData: "ar:\(nonce)"),
                          TelegramButton(text: "🛑 Deny w/ reason", callbackData: "dr:\(nonce)")])
@@ -256,6 +269,7 @@ final class RemoteApprovalBridge {
         forget(nonce)
 
         if action == "s" { corr.allowSession?() }
+        if action == "g" { corr.allowSite?() }
         let decision = Self.decision(for: action)
         let won = corr.resolvable.resolve(decision, from: .telegram)
         remoteLog?("resolved pid=\(corr.pid) nonce=\(nonce) action=\(action) won=\(won)")
@@ -302,6 +316,7 @@ final class RemoteApprovalBridge {
         case "d": return Decision(verdict: .block, reason: "Denied from phone")
         case "c": return Decision(verdict: .block, reason: "Denied from phone — clean up the house-rule comment violations in this change, then re-propose the commit.")
         case "s": return Decision(verdict: .allow, reason: "Approved for session from phone")
+        case "g": return Decision(verdict: .allow, reason: "Browsing lease granted from phone")
         default: return Decision(verdict: .allow, reason: "Approved from phone")
         }
     }
@@ -328,6 +343,7 @@ final class RemoteApprovalBridge {
         switch action {
         case "d": return "🛑 Denied from phone"
         case "c": return "🧹 Denied — clean comments & re-propose"
+        case "g": return "🌐 Site leased from phone"
         default: return "✅ Approved from phone"
         }
     }

--- a/Sources/GavelHook/main.swift
+++ b/Sources/GavelHook/main.swift
@@ -71,6 +71,40 @@ let requestsRemoteApproval = ["1", "true", "yes"].contains(
 let spawnedSessionName = (ProcessInfo.processInfo.environment["GAVEL_SESSION_NAME"] ?? "")
     .trimmingCharacters(in: .whitespacesAndNewlines)
 
+// PostToolUse tool_response can be huge (screenshot base64, long Bash output).
+// The daemon's socket read treats a short read as end-of-message, so an
+// oversized envelope arrives truncated and the WHOLE event is silently
+// dropped — which breaks the feed and, worse, browsing-lease drift detection
+// (the screenshot response is exactly where a site drift becomes visible).
+// Sanitize client-side: drop non-text MCP content items (images) and keep
+// each string's TAIL (the chrome extension appends its Tab Context block at
+// the end, and Bash errors also tend to be last).
+let sanitizeCap = 8 * 1024
+
+func sanitizeString(_ s: String) -> String {
+    guard s.utf8.count > sanitizeCap else { return s }
+    let tail = String(s.suffix(sanitizeCap / 2))
+    return "[gavel-hook: truncated \(s.utf8.count) bytes]…\(tail)"
+}
+
+func sanitizeResponseValue(_ value: Any) -> Any {
+    if let s = value as? String { return sanitizeString(s) }
+    if let arr = value as? [Any] {
+        // MCP content array: keep text items, drop image/binary items.
+        return arr.compactMap { item -> Any? in
+            if let dict = item as? [String: Any], let type = dict["type"] as? String,
+                type != "text" {
+                return nil
+            }
+            return sanitizeResponseValue(item)
+        }
+    }
+    if let dict = value as? [String: Any] {
+        return dict.mapValues { sanitizeResponseValue($0) }
+    }
+    return value
+}
+
 // Merge stdin JSON as payload (add "type" discriminator for daemon decoding)
 if var payload = stdinJson {
     payload["type"] = hookType
@@ -79,6 +113,9 @@ if var payload = stdinJson {
     }
     if hookType == "SessionStart", !spawnedSessionName.isEmpty {
         payload["session_name"] = spawnedSessionName
+    }
+    if hookType == "PostToolUse", let response = payload["tool_response"] {
+        payload["tool_response"] = sanitizeResponseValue(response)
     }
     envelope["payload"] = payload
 }

--- a/Tests/GavelTests/BrowsingLeaseTests.swift
+++ b/Tests/GavelTests/BrowsingLeaseTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+
+@testable import Gavel
+
+final class BrowsingLeaseTests: XCTestCase {
+
+    // Verbatim shape of a real claude-in-chrome response (captured 2026-07-06).
+    private let computerResponse = """
+        Successfully captured screenshot (1568x748, jpeg) - ID: ss_6893plqd3
+
+        Tab Context:
+        - Executed on tabId: 2140008915
+        - Available tabs:
+          • tabId 2140008915: "Example Domain" (https://example.com/)
+        """
+
+    private let driftedResponse = """
+        Clicked at (400, 300)
+
+        Tab Context:
+        - Executed on tabId: 2140008915
+        - Available tabs:
+          • tabId 2140008915: "Evil" (https://evil.example.net/phish)
+          • tabId 99: "Old tab" (https://example.com/)
+        """
+
+    // MARK: - Host normalization
+
+    func testNormalizedHostStripsWwwAndLowercases() {
+        XCTAssertEqual(BrowsingLease.normalizedHost(fromURL: "https://WWW.Example.COM/path?q=1"), "example.com")
+        XCTAssertEqual(BrowsingLease.normalizedHost(fromURL: "https://example.com"), "example.com")
+    }
+
+    func testNormalizedHostAcceptsSchemelessURL() {
+        // navigate accepts scheme-less input and defaults to https
+        XCTAssertEqual(BrowsingLease.normalizedHost(fromURL: "example.com/login"), "example.com")
+    }
+
+    func testNormalizedHostSubdomainIsDistinct() {
+        XCTAssertEqual(BrowsingLease.normalizedHost(fromURL: "https://sub.example.com"), "sub.example.com")
+    }
+
+    func testNormalizedHostRejectsGarbage() {
+        XCTAssertNil(BrowsingLease.normalizedHost(fromURL: ""))
+        XCTAssertNil(BrowsingLease.normalizedHost(fromURL: "   "))
+    }
+
+    // MARK: - Lease gating
+
+    func testLeaseAllowsComputerAndFormInput() {
+        let lease = BrowsingLease(domain: "example.com")
+        XCTAssertNotNil(lease.allows(toolName: "mcp__claude-in-chrome__computer", url: nil))
+        XCTAssertNotNil(lease.allows(toolName: "mcp__claude-in-chrome__form_input", url: nil))
+    }
+
+    func testLeaseNeverAllowsExfilGradeTools() {
+        let lease = BrowsingLease(domain: "example.com")
+        for tool in ["javascript_tool", "file_upload", "upload_image", "shortcuts_execute", "tabs_create_mcp", "tabs_close_mcp"] {
+            XCTAssertNil(
+                lease.allows(toolName: "mcp__claude-in-chrome__\(tool)", url: nil),
+                "\(tool) must keep its normal prompt tier under a lease")
+        }
+    }
+
+    func testLeaseAllowsSameSiteNavigateOnly() {
+        let lease = BrowsingLease(domain: "example.com")
+        XCTAssertNotNil(lease.allows(toolName: BrowsingLease.navigateTool, url: "https://example.com/page2"))
+        XCTAssertNotNil(lease.allows(toolName: BrowsingLease.navigateTool, url: "www.example.com/page3"))
+        XCTAssertNil(lease.allows(toolName: BrowsingLease.navigateTool, url: "https://other.com"))
+        XCTAssertNil(lease.allows(toolName: BrowsingLease.navigateTool, url: nil))
+    }
+
+    func testExpiredLeaseAllowsNothing() {
+        let lease = BrowsingLease(domain: "example.com", grantedAt: Date(timeIntervalSinceNow: -3600), ttl: 60)
+        XCTAssertFalse(lease.isActive)
+        XCTAssertNil(lease.allows(toolName: "mcp__claude-in-chrome__computer", url: nil))
+    }
+
+    func testLeaseIgnoresNonChromeTools() {
+        let lease = BrowsingLease(domain: "example.com")
+        XCTAssertNil(lease.allows(toolName: "Bash", url: nil))
+        XCTAssertNil(lease.allows(toolName: "Write", url: nil))
+    }
+
+    // MARK: - Drift detection
+
+    func testExecutedTabURLParsesRealResponse() {
+        XCTAssertEqual(BrowsingLease.executedTabURL(inResponse: computerResponse), "https://example.com/")
+    }
+
+    func testExecutedTabURLPicksExecutedTabNotOthers() {
+        XCTAssertEqual(BrowsingLease.executedTabURL(inResponse: driftedResponse), "https://evil.example.net/phish")
+    }
+
+    func testNoDriftOnLeasedDomain() {
+        XCTAssertNil(BrowsingLease.driftReason(inResponse: computerResponse, domain: "example.com"))
+    }
+
+    func testDriftRevokesOnForeignDomain() {
+        let reason = BrowsingLease.driftReason(inResponse: driftedResponse, domain: "example.com")
+        XCTAssertNotNil(reason)
+        XCTAssertTrue(reason!.contains("evil.example.net"))
+    }
+
+    func testDriftFailsClosedOnUnparseableResponse() {
+        XCTAssertNotNil(BrowsingLease.driftReason(inResponse: "no tab context here", domain: "example.com"))
+        XCTAssertNotNil(BrowsingLease.driftReason(inResponse: "", domain: "example.com"))
+    }
+
+    func testTitleWithParenthesesDoesNotBreakURLParse() {
+        let response = """
+            Tab Context:
+            - Executed on tabId: 7
+            - Available tabs:
+              • tabId 7: "Docs (v2) — reference (beta)" (https://example.com/docs)
+            """
+        XCTAssertEqual(BrowsingLease.executedTabURL(inResponse: response), "https://example.com/docs")
+    }
+
+    // MARK: - Session lifecycle
+
+    func testGrantAndRevokeOnSession() {
+        let session = Session(pid: 4242)
+        XCTAssertNil(session.browsingLease)
+        session.grantBrowsingLease(domain: "example.com")
+        XCTAssertEqual(session.browsingLease?.domain, "example.com")
+        XCTAssertTrue(session.browsingLease!.isActive)
+        let revoked = session.revokeBrowsingLease()
+        XCTAssertEqual(revoked?.domain, "example.com")
+        XCTAssertNil(session.browsingLease)
+    }
+
+    func testRevokeAutoApproveClearsLease() {
+        let session = Session(pid: 4243)
+        session.grantBrowsingLease(domain: "example.com")
+        session.revokeAutoApprove()
+        XCTAssertNil(session.browsingLease)
+    }
+
+    // MARK: - Response text extraction (MCP content arrays)
+
+    func testExtractResponseTextFromMCPContentDict() {
+        let response = AnyCodable([
+            "content": AnyCodable([
+                AnyCodable(["type": AnyCodable("text"), "text": AnyCodable("hello")]),
+                AnyCodable(["type": AnyCodable("text"), "text": AnyCodable("Tab Context: ...")]),
+            ])
+        ])
+        XCTAssertEqual(HookRouter.extractResponseText(response), "hello\nTab Context: ...")
+    }
+
+    func testExtractResponseTextFromBashDict() {
+        let response = AnyCodable([
+            "stdout": AnyCodable("out"),
+            "stderr": AnyCodable("err"),
+        ])
+        XCTAssertEqual(HookRouter.extractResponseText(response), "out\nerr")
+    }
+
+    func testExtractResponseTextFromPlainString() {
+        XCTAssertEqual(HookRouter.extractResponseText(AnyCodable("plain")), "plain")
+    }
+
+    func testExtractResponseTextFromBareArray() {
+        let response = AnyCodable([
+            AnyCodable(["type": AnyCodable("text"), "text": AnyCodable("item")])
+        ])
+        XCTAssertEqual(HookRouter.extractResponseText(response), "item")
+    }
+}

--- a/Tests/GavelTests/RemoteApprovalBridgeTests.swift
+++ b/Tests/GavelTests/RemoteApprovalBridgeTests.swift
@@ -35,6 +35,37 @@ final class RemoteApprovalBridgeTests: XCTestCase {
         XCTAssertTrue(fake.edits.contains { $0.text.contains("from phone") })
     }
 
+    func testAllowSiteButtonGrantsLeaseAndResolvesAllow() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        var resolved: Decision?
+        var leaseGranted = false
+        let approval = ResolvableApproval { resolved = $0 }
+
+        bridge.notify(
+            resolvable: approval, text: "navigate?", allowSession: nil,
+            leaseDomain: "example.com", allowSite: { leaseGranted = true })
+        XCTAssertTrue(
+            fake.lastCallbackData.contains { $0.hasPrefix("g:") },
+            "keyboard should carry the Allow-site button")
+
+        let n = nonce(from: fake.lastCallbackData)
+        bridge.handle(callbackUpdate(action: "g", nonce: n, fromId: owner, chatId: owner, messageId: fake.lastSentMessageId))
+
+        XCTAssertTrue(leaseGranted)
+        XCTAssertEqual(resolved?.verdict, .allow)
+        XCTAssertEqual(resolved?.reason, "Browsing lease granted from phone")
+        XCTAssertTrue(fake.edits.contains { $0.text.contains("Site leased from phone") })
+    }
+
+    func testNoAllowSiteButtonWithoutLeaseDomain() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+
+        bridge.notify(resolvable: ResolvableApproval { _ in }, text: "approve?", allowSession: nil)
+        XCTAssertFalse(fake.lastCallbackData.contains { $0.hasPrefix("g:") })
+    }
+
     func testUnauthorizedChatIgnored() {
         let fake = FakeTelegramTransport()
         let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)

--- a/justfile
+++ b/justfile
@@ -46,13 +46,13 @@ dev-install: build
     # The identity NAME is resolved from the local keychain at runtime so the
     # repo carries no personal info; the private key never leaves the keychain.
     #
-    # Daemon-side caveat: even with Developer ID, LaunchAgent kills the daemon
-    # for "Invalid Page" because the brew bottle is also notarized — `spctl -a`
-    # confirms `source=Unnotarized Developer ID` rejects this binary. Notarizing
-    # locally is impractical (multi-min round-trip to Apple per build). For
-    # daemon-side dev, use `just dev-daemon` instead — foreground spawn from an
-    # interactive shell is permissive about codesigning. dev-install is most
-    # useful for hook-side testing where the parent chain is more lenient.
+    # Daemon-side caveat, corrected 2026-07-06: the "Invalid Page" SIGKILL under
+    # LaunchAgent is caused by overwriting the Cellar binary IN PLACE — the
+    # kernel caches the code signature per vnode, so new content on the same
+    # inode fails validation. Replacing on a fresh inode (rm, then cp — see the
+    # swap loop) runs fine under launchd with a plain Developer ID signature.
+    # `just dev-daemon` remains the fastest loop for daemon-side iteration;
+    # dev-install is the persistent option once a change is worth dogfooding.
     set -euo pipefail
     ver=$(brew list --versions gavel | awk '{print $2}')
     cellar="/opt/homebrew/Cellar/gavel/${ver}/bin"
@@ -75,17 +75,24 @@ dev-install: build
     fi
 
     for bin in gavel gavel-hook; do
-        [[ -f "$cellar/$bin" ]] || { echo "missing $cellar/$bin"; exit 1; }
         # Preserve the FIRST backup as the brew-pristine snapshot — re-running
         # dev-install would otherwise capture the currently-installed dev binary,
-        # erasing the restore path. `cp -p` also preserves source mode (555),
-        # which makes an overwrite-cp permission-denied on subsequent runs.
+        # erasing the restore path.
         bak="$backup/${bin}.${ver}.bak"
-        if [[ ! -f "$bak" ]]; then
-            cp -p "$cellar/$bin" "$bak"
+        if [[ -f "$cellar/$bin" ]]; then
+            [[ -f "$bak" ]] || cp -p "$cellar/$bin" "$bak"
+        elif [[ ! -f "$bak" ]]; then
+            # No installed binary AND no pristine backup — nothing to restore
+            # to later, so refuse rather than strand the user.
+            echo "missing $cellar/$bin and no backup at $bak — run 'brew reinstall gavel' first"
+            exit 1
         fi
         codesign --force --sign "$identity" --options runtime ".build/release/$bin"
-        chmod u+w "$cellar/$bin"
+        # Replace on a FRESH inode: the kernel caches code signatures per
+        # vnode, so cp'ing over the existing file leaves a stale signature
+        # association and launchd SIGKILLs the daemon with "Invalid Page"
+        # (crash-looped 2026-07-06 until replaced rm-then-cp).
+        rm -f "$cellar/$bin"
         cp ".build/release/$bin" "$cellar/$bin"
         chmod 555 "$cellar/$bin"
     done


### PR DESCRIPTION
## What

A **browsing lease**: on a `claude-in-chrome` navigate approval, a new teal **Allow Site: \<domain\>** button grants a session-scoped lease for that domain. Under an active lease:

- `computer` and `form_input` auto-allow (the high-frequency page-interaction tools)
- `navigate` auto-allows **same-site only**; a cross-domain navigate prompts (and can re-lease)
- `javascript_tool`, `file_upload`, `upload_image`, `shortcuts_execute`, and tab lifecycle keep their normal prompt tier -- exfil-grade tools are never lease-safe

## Revocation (the load-bearing part)

The chrome extension appends a **Tab Context** block with live tab URLs to every tool result. `handlePostToolUse` parses the executed tab's URL from lease-checked tool responses and revokes the lease the moment it reports off-domain -- fail closed if the URL can't be parsed. In-page cross-site navigation is therefore visible in the response of the very click that caused it; the residual exposure is bounded to the action(s) already approved before the tab reports the new URL (empirically: the drifting click plus at most one more when navigation outraces response capture). Also revoked: 30-min TTL, `revokeAutoApprove`, and click-to-revoke on the Monitor's new `SITE <domain>` badge.

## PostToolUse payload sanitization (bug fix riding along)

The daemon's socket read treats a short read as end-of-message, so oversized PostToolUse envelopes (screenshot base64, long Bash output) arrived truncated and were **silently dropped** -- today that loses feed events, and it would have blinded drift detection exactly when a screenshot reveals the drift. `gavel-hook` now sanitizes `tool_response` client-side: drops non-text MCP content items, keeps string tails (Tab Context is trailing). Proper length-prefixed socket framing is a follow-up.

## Testing

- 21 new unit tests (`BrowsingLeaseTests`): host normalization, lease gating incl. exfil-tool exclusions, drift parsing against a verbatim captured response, fail-closed paths, session lifecycle, response-text extraction
- Full suite: 679 tests, 0 new failures (the 2 `ProcessTreeTests` live-discovery failures pre-exist on main, environment-dependent)
- **Live E2E** via dev-daemon swap: lease granted from the panel → promptless screenshot → cross-site click (example.com → iana.org) → `[lease] revoked … tab drifted to iana.org` on the response that revealed it → next call prompted again

## Not in this PR

- Phone (Telegram) approvals don't offer Allow Site yet -- Mac panel only
- Length-prefixed socket framing to remove the short-read truncation class entirely
- `browser_batch` is not lease-safe (and note: it's also absent from the user-tier chrome prompt rule -- pre-existing)