### PR TITLE
feat(approval): embedded diff review server with web resolver

### DIFF
--- a/Sources/Gavel/Approval/ResolvableApproval.swift
+++ b/Sources/Gavel/Approval/ResolvableApproval.swift
@@ -4,7 +4,7 @@ import Foundation
 /// (the on-Mac panel and the Telegram bridge). Exactly one `resolve` wins.
 final class ResolvableApproval {
 
-    enum Source { case mac, telegram, timeout, autoApprove }
+    enum Source { case mac, telegram, timeout, autoApprove, web }
 
     private let lock = NSLock()
     private var resolved = false

--- a/Sources/Gavel/Review/DiffCapture.swift
+++ b/Sources/Gavel/Review/DiffCapture.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Snapshot of the changes a pending `git commit` would record, captured at
+/// approval time so the reviewed bytes stay authoritative even if the tree
+/// changes while the approval pends.
+struct CapturedDiff {
+    let diffText: String
+    let commitMessage: String?
+    /// True when the commit used -a/--all, so the diff is HEAD-relative
+    /// (staged-only `--cached` would render empty or incomplete).
+    let includesUnstaged: Bool
+    let truncated: Bool
+}
+
+enum DiffCapture {
+
+    static func capture(cwd: String, command: String) -> CapturedDiff? {
+        let allFlag = commitUsesAllFlag(command)
+        let diffArgs = allFlag
+            ? ["diff", "HEAD", "--no-color", "--no-ext-diff"]
+            : ["diff", "--cached", "--no-color", "--no-ext-diff"]
+        guard let raw = runGit(diffArgs, cwd: cwd) else { return nil }
+
+        var text = raw
+        var truncated = false
+        if text.utf8.count > GavelConstants.reviewDiffMaxBytes {
+            // Cut at a line boundary so the parser never sees a torn hunk line.
+            let prefix = String(decoding: Array(text.utf8.prefix(GavelConstants.reviewDiffMaxBytes)), as: UTF8.self)
+            text = prefix.components(separatedBy: "\n").dropLast().joined(separator: "\n")
+            truncated = true
+        }
+        return CapturedDiff(
+            diffText: text,
+            commitMessage: commitMessage(from: command),
+            includesUnstaged: allFlag,
+            truncated: truncated
+        )
+    }
+
+    /// Detects -a/--all on the commit invocation. Quoted spans are stripped
+    /// first so words inside the -m message can't read as flags.
+    static func commitUsesAllFlag(_ command: String) -> Bool {
+        let stripped = strippingQuotedSpans(command)
+        for token in stripped.split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" }) {
+            if token == "--all" { return true }
+            if token.hasPrefix("-"), !token.hasPrefix("--"), token.dropFirst().contains("a") {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Best-effort extraction of the first -m message for the page header.
+    static func commitMessage(from command: String) -> String? {
+        for pattern in [#"-m[ \t]+"([^"]*)""#, #"-m[ \t]+'([^']*)'"#, #"-m[ \t]+([^\s"']+)"#] {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            let range = NSRange(command.startIndex..., in: command)
+            if let match = regex.firstMatch(in: command, range: range),
+               let r = Range(match.range(at: 1), in: command) {
+                let msg = String(command[r])
+                if !msg.isEmpty { return msg }
+            }
+        }
+        return nil
+    }
+
+    static func strippingQuotedSpans(_ text: String) -> String {
+        var result = ""
+        var quote: Character? = nil
+        for ch in text {
+            if let q = quote {
+                if ch == q { quote = nil }
+                continue
+            }
+            if ch == "\"" || ch == "'" {
+                quote = ch
+                continue
+            }
+            result.append(ch)
+        }
+        return result
+    }
+
+    /// Runs git synchronously in `cwd` and returns stdout, or nil on failure.
+    /// Absolute binary + augmented PATH: the LaunchAgent inherits a minimal
+    /// PATH and git may exec helpers from /usr/local or homebrew.
+    static func runGit(_ args: [String], cwd: String) -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        task.arguments = ["-C", cwd, "--no-pager"] + args
+
+        var environment = ProcessInfo.processInfo.environment
+        let toolPaths = "/usr/local/bin:/opt/homebrew/bin"
+        environment["PATH"] = toolPaths + ":" + (environment["PATH"] ?? "/usr/bin:/bin")
+        task.environment = environment
+
+        let stdout = Pipe()
+        task.standardOutput = stdout
+        task.standardError = FileHandle.nullDevice
+
+        // Drain on a background thread while waiting — a diff larger than the
+        // pipe buffer would otherwise deadlock waitUntilExit.
+        var data = Data()
+        let drained = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            data = stdout.fileHandleForReading.readDataToEndOfFile()
+            drained.signal()
+        }
+
+        do {
+            try task.run()
+        } catch {
+            gavelLog("[review] git spawn failed: \(error.localizedDescription)")
+            return nil
+        }
+        task.waitUntilExit()
+        drained.wait()
+
+        guard task.terminationStatus == 0 else {
+            gavelLog("[review] git \(args.first ?? "?") exited \(task.terminationStatus) cwd=\(cwd)")
+            return nil
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Sources/Gavel/Review/DiffHTML.swift
+++ b/Sources/Gavel/Review/DiffHTML.swift
@@ -1,0 +1,265 @@
+import Foundation
+
+/// Everything the review page needs, assembled at approval time.
+struct ReviewContent {
+    let repoName: String
+    let commitMessage: String?
+    let files: [DiffFile]
+    let includesUnstaged: Bool
+    let truncated: Bool
+}
+
+/// Server-side renderer for the mobile review page. Fully self-contained:
+/// inline CSS/JS, no external fetches (the page is served over the tailnet
+/// and must work without any CDN).
+enum DiffHTML {
+
+    static func page(content: ReviewContent) -> String {
+        let adds = content.files.reduce(0) { $0 + $1.additions }
+        let dels = content.files.reduce(0) { $0 + $1.deletions }
+
+        var banners = ""
+        if content.includesUnstaged {
+            banners += banner("Commit uses -a: includes unstaged changes to tracked files.")
+        }
+        if content.truncated {
+            banners += banner("Diff truncated at \(GavelConstants.reviewDiffMaxBytes / (1024 * 1024)) MB — review the tail at the desk.")
+        }
+
+        let body: String
+        if content.files.isEmpty {
+            body = "<p class=\"empty\">No changes captured — nothing staged?</p>"
+        } else {
+            body = content.files.map { fileSection($0) }.joined()
+        }
+
+        let title = esc("Review — \(content.repoName)")
+        let commitLine = content.commitMessage.map {
+            "<p class=\"msg\">\(esc($0))</p>"
+        } ?? ""
+
+        return """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>\(title)</title>
+        <style>\(css)</style>
+        </head>
+        <body>
+        <header>
+        <h1>\(esc(content.repoName))</h1>
+        \(commitLine)
+        <p class="stats">\(content.files.count) file\(content.files.count == 1 ? "" : "s") · <span class="add">+\(adds)</span> <span class="del">−\(dels)</span></p>
+        </header>
+        \(banners)
+        <main>\(body)</main>
+        <footer id="bar">
+        <textarea id="note" placeholder="Overall note (optional)"></textarea>
+        <div class="btns">
+        <button class="reject" onclick="submitVerdict('request_changes')">Request changes</button>
+        <button class="approve" onclick="submitVerdict('approve')">Approve</button>
+        </div>
+        </footer>
+        <script>\(js)</script>
+        </body>
+        </html>
+        """
+    }
+
+    static func resolvedPage(by source: String) -> String {
+        """
+        <!DOCTYPE html>
+        <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Review resolved</title><style>\(css)</style></head>
+        <body><header><h1>Already resolved</h1>
+        <p class="msg">This approval was resolved via \(esc(source)).</p></header></body></html>
+        """
+    }
+
+    // MARK: - Sections
+
+    private static func fileSection(_ file: DiffFile) -> String {
+        var label = esc(file.displayPath)
+        if file.isRename { label = "\(esc(file.oldPath)) → \(esc(file.newPath))" }
+        var tag = ""
+        if file.isNew { tag = "<span class=\"tag new\">new</span>" }
+        if file.isDeleted { tag = "<span class=\"tag del\">deleted</span>" }
+        if file.isBinary { tag += "<span class=\"tag bin\">binary</span>" }
+
+        let inner: String
+        if file.isBinary {
+            inner = "<div class=\"withheld\">Binary file — not rendered.</div>"
+        } else if file.hunks.isEmpty {
+            inner = "<div class=\"withheld\">No content changes (mode/rename only).</div>"
+        } else {
+            inner = file.hunks.map { hunkSection($0, file: file) }.joined()
+        }
+
+        return """
+        <details open class="file">
+        <summary>\(label) \(tag) <span class="fstats"><span class="add">+\(file.additions)</span> <span class="del">−\(file.deletions)</span></span></summary>
+        \(inner)
+        </details>
+        """
+    }
+
+    private static func hunkSection(_ hunk: DiffHunk, file: DiffFile) -> String {
+        // Credential gate for content leaving the machine: same philosophy as
+        // CredentialGate withholding commands from Telegram. Known-secret
+        // patterns only — the entropy heuristic would flag every lockfile hash.
+        if let label = SecretRedactor.firstMatchLabel(in: hunk.rawText) {
+            return """
+            <div class="hunk">
+            <div class="hheader">\(esc(hunk.header))</div>
+            <div class="withheld">Hunk withheld — possible \(esc(label)). Review at the desk.</div>
+            </div>
+            """
+        }
+
+        let rows = hunk.lines.map { line -> String in
+            let cls: String
+            switch line.kind {
+            case .addition: cls = "add"
+            case .deletion: cls = "del"
+            case .context: cls = "ctx"
+            case .meta: cls = "meta"
+            }
+            let num = line.newNumber ?? line.oldNumber
+            let numText = num.map(String.init) ?? ""
+            return "<div class=\"ln \(cls)\"><span class=\"no\">\(numText)</span><span class=\"code\">\(esc(line.raw))</span></div>"
+        }.joined()
+
+        return """
+        <div class="hunk">
+        <div class="hheader">\(esc(hunk.header))</div>
+        <div class="lines">\(rows)</div>
+        <button class="cbtn" onclick="toggleComment(this)">💬 Comment</button>
+        <textarea class="hc hidden" data-file="\(escAttr(file.displayPath))" data-line="\(hunk.newStart)" placeholder="Comment on this hunk"></textarea>
+        </div>
+        """
+    }
+
+    private static func banner(_ text: String) -> String {
+        "<div class=\"banner\">\(esc(text))</div>"
+    }
+
+    // MARK: - Escaping
+
+    static func esc(_ text: String) -> String {
+        text.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+    }
+
+    static func escAttr(_ text: String) -> String {
+        esc(text)
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+
+    // MARK: - Assets
+
+    private static let css = """
+    :root { color-scheme: light dark; }
+    * { box-sizing: border-box; margin: 0; }
+    body { font-family: -apple-system, system-ui, sans-serif; font-size: 15px;
+           background: #f5f5f7; color: #1d1d1f; padding-bottom: 170px; }
+    header { padding: 14px 16px 8px; }
+    h1 { font-size: 17px; }
+    .msg { font-style: italic; opacity: .8; margin-top: 4px; }
+    .stats, .fstats { font-size: 13px; opacity: .75; margin-top: 4px; }
+    .add { color: #1a7f37; } .del { color: #cf222e; }
+    .banner { background: #fff8c5; border: 1px solid #d4a72c66; margin: 6px 12px;
+              padding: 8px 12px; border-radius: 8px; font-size: 13px; }
+    .file { background: #fff; margin: 8px 8px; border-radius: 10px; overflow: hidden;
+            border: 1px solid #0000001a; }
+    summary { padding: 10px 12px; font-weight: 600; font-size: 13px;
+              font-family: ui-monospace, monospace; word-break: break-all; cursor: pointer; }
+    .tag { font-size: 11px; padding: 1px 6px; border-radius: 6px; margin-left: 4px;
+           background: #ddf4ff; color: #0969da; font-family: -apple-system, system-ui; }
+    .tag.del { background: #ffebe9; color: #cf222e; }
+    .hunk { border-top: 1px solid #0000000d; }
+    .hheader { font-family: ui-monospace, monospace; font-size: 11px; opacity: .6;
+               padding: 6px 12px; background: #f0f4f8; }
+    .lines { overflow-x: auto; font-family: ui-monospace, monospace; font-size: 12px;
+             line-height: 1.5; }
+    .ln { display: flex; white-space: pre; }
+    .ln .no { flex: 0 0 38px; text-align: right; padding-right: 8px; opacity: .4;
+              user-select: none; font-size: 10px; line-height: 1.8; }
+    .ln .code { padding-right: 12px; }
+    .ln.add { background: #dafbe1; } .ln.add .code { color: #116329; }
+    .ln.del { background: #ffebe9; } .ln.del .code { color: #82071e; }
+    .ln.meta { opacity: .5; font-style: italic; }
+    .withheld { padding: 12px; font-size: 13px; background: #fff1e5; color: #953800; }
+    .cbtn { margin: 8px 12px; font-size: 12px; padding: 4px 10px; border-radius: 8px;
+            border: 1px solid #0002; background: transparent; }
+    textarea { width: calc(100% - 24px); margin: 0 12px 10px; padding: 8px;
+               border-radius: 8px; border: 1px solid #0003; font-size: 15px;
+               font-family: inherit; min-height: 60px; background: inherit; color: inherit; }
+    .hidden { display: none; }
+    .empty { padding: 24px; text-align: center; opacity: .7; }
+    footer { position: fixed; bottom: 0; left: 0; right: 0; background: #fffffff2;
+             backdrop-filter: blur(10px); border-top: 1px solid #0002; padding: 10px 0
+             calc(10px + env(safe-area-inset-bottom)); }
+    footer textarea { min-height: 44px; margin-bottom: 8px; }
+    .btns { display: flex; gap: 10px; padding: 0 12px; }
+    .btns button { flex: 1; padding: 12px; border-radius: 10px; border: none;
+                   font-size: 16px; font-weight: 600; }
+    .approve { background: #1a7f37; color: #fff; }
+    .reject { background: #cf222e; color: #fff; }
+    button:disabled { opacity: .5; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #161618; color: #f5f5f7; }
+      .file { background: #1e1e20; border-color: #ffffff1a; }
+      .hheader { background: #26262a; }
+      .banner { background: #3a3117; border-color: #d4a72c44; }
+      .ln.add { background: #12261e; } .ln.add .code { color: #3fb950; }
+      .ln.del { background: #2d1215; } .ln.del .code { color: #f85149; }
+      .withheld { background: #341a00; color: #e3b341; }
+      footer { background: #161618f2; border-color: #fff2; }
+      .cbtn { border-color: #fff3; color: #f5f5f7; }
+      textarea { border-color: #fff3; }
+    }
+    """
+
+    private static let js = """
+    function toggleComment(btn) {
+      const ta = btn.nextElementSibling;
+      ta.classList.toggle('hidden');
+      if (!ta.classList.contains('hidden')) ta.focus();
+    }
+    function submitVerdict(verdict) {
+      const comments = [];
+      document.querySelectorAll('textarea.hc').forEach(function (t) {
+        if (t.value.trim()) {
+          comments.push({ file: t.dataset.file, line: parseInt(t.dataset.line, 10), text: t.value.trim() });
+        }
+      });
+      const note = document.getElementById('note').value.trim();
+      document.querySelectorAll('.btns button').forEach(function (b) { b.disabled = true; });
+      fetch(location.pathname + '/verdict', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ verdict: verdict, note: note || null, comments: comments })
+      }).then(function (r) {
+        if (r.ok) {
+          finish(verdict === 'approve' ? '✅ Approved — commit proceeding.'
+                                       : '📝 Changes requested — comments sent to Claude.');
+        } else if (r.status === 409) {
+          finish('Already resolved elsewhere (Mac panel or Telegram).');
+        } else {
+          fail('Submit failed: HTTP ' + r.status);
+        }
+      }).catch(function (e) { fail('Submit failed: ' + e); });
+    }
+    function finish(msg) {
+      document.body.innerHTML = '<header><h1>' + msg + '</h1><p class="msg">You can close this tab.</p></header>';
+    }
+    function fail(msg) {
+      document.querySelectorAll('.btns button').forEach(function (b) { b.disabled = false; });
+      alert(msg);
+    }
+    """
+}

--- a/Sources/Gavel/Review/DiffParser.swift
+++ b/Sources/Gavel/Review/DiffParser.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+/// One file's worth of a unified diff.
+struct DiffFile {
+    var oldPath: String = ""
+    var newPath: String = ""
+    var isNew = false
+    var isDeleted = false
+    var isRename = false
+    var isBinary = false
+    var hunks: [DiffHunk] = []
+
+    var displayPath: String {
+        if newPath.isEmpty || newPath == "/dev/null" { return oldPath }
+        return newPath
+    }
+
+    var additions: Int { hunks.reduce(0) { $0 + $1.lines.filter { $0.kind == .addition }.count } }
+    var deletions: Int { hunks.reduce(0) { $0 + $1.lines.filter { $0.kind == .deletion }.count } }
+}
+
+struct DiffHunk {
+    let header: String
+    /// First new-file line of the hunk — the anchor for review comments.
+    let newStart: Int
+    var lines: [DiffLine] = []
+
+    /// Raw hunk text, scanned for credentials before the hunk is served.
+    var rawText: String {
+        ([header] + lines.map { $0.raw }).joined(separator: "\n")
+    }
+}
+
+struct DiffLine {
+    enum Kind { case context, addition, deletion, meta }
+    let kind: Kind
+    /// Full line including the +/-/space prefix.
+    let raw: String
+    let oldNumber: Int?
+    let newNumber: Int?
+}
+
+/// Parses `git diff` unified output into `DiffFile`s. Best-effort: unrecognized
+/// metadata lines are skipped, paths with spaces resolve via the ---/+++ lines.
+enum DiffParser {
+
+    static func parse(_ text: String) -> [DiffFile] {
+        var files: [DiffFile] = []
+        var file: DiffFile?
+        var hunk: DiffHunk?
+        var oldNo = 0
+        var newNo = 0
+
+        func flushHunk() {
+            if let h = hunk, let _ = file { file!.hunks.append(h) }
+            hunk = nil
+        }
+        func flushFile() {
+            flushHunk()
+            if let f = file { files.append(f) }
+            file = nil
+        }
+
+        var rawLines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        if rawLines.last == "" { rawLines.removeLast() }
+
+        for s in rawLines {
+
+            if s.hasPrefix("diff --git ") {
+                flushFile()
+                var f = DiffFile()
+                // "diff --git a/x b/y" — ambiguous when paths contain spaces;
+                // the ---/+++ lines below overwrite with authoritative values.
+                if let range = s.range(of: " b/", options: .backwards) {
+                    f.newPath = String(s[range.upperBound...])
+                    let head = String(s[s.index(s.startIndex, offsetBy: 11)..<range.lowerBound])
+                    f.oldPath = head.hasPrefix("a/") ? String(head.dropFirst(2)) : head
+                }
+                file = f
+                continue
+            }
+
+            guard file != nil else { continue }
+
+            if hunk == nil {
+                if s.hasPrefix("new file mode") { file!.isNew = true; continue }
+                if s.hasPrefix("deleted file mode") { file!.isDeleted = true; continue }
+                if s.hasPrefix("rename from ") {
+                    file!.isRename = true
+                    file!.oldPath = String(s.dropFirst("rename from ".count))
+                    continue
+                }
+                if s.hasPrefix("rename to ") {
+                    file!.newPath = String(s.dropFirst("rename to ".count))
+                    continue
+                }
+                if s.hasPrefix("Binary files ") || s.hasPrefix("GIT binary patch") {
+                    file!.isBinary = true
+                    continue
+                }
+                if s.hasPrefix("--- ") {
+                    let p = String(s.dropFirst(4))
+                    file!.oldPath = p.hasPrefix("a/") ? String(p.dropFirst(2)) : p
+                    continue
+                }
+                if s.hasPrefix("+++ ") {
+                    let p = String(s.dropFirst(4))
+                    file!.newPath = p.hasPrefix("b/") ? String(p.dropFirst(2)) : p
+                    continue
+                }
+            }
+
+            if s.hasPrefix("@@") {
+                flushHunk()
+                let (o, n) = Self.hunkStarts(s)
+                oldNo = o
+                newNo = n
+                hunk = DiffHunk(header: s, newStart: n)
+                continue
+            }
+
+            guard hunk != nil else { continue }
+
+            if s.hasPrefix("+") {
+                hunk!.lines.append(DiffLine(kind: .addition, raw: s, oldNumber: nil, newNumber: newNo))
+                newNo += 1
+            } else if s.hasPrefix("-") {
+                hunk!.lines.append(DiffLine(kind: .deletion, raw: s, oldNumber: oldNo, newNumber: nil))
+                oldNo += 1
+            } else if s.hasPrefix("\\") {
+                hunk!.lines.append(DiffLine(kind: .meta, raw: s, oldNumber: nil, newNumber: nil))
+            } else {
+                hunk!.lines.append(DiffLine(kind: .context, raw: s, oldNumber: oldNo, newNumber: newNo))
+                oldNo += 1
+                newNo += 1
+            }
+        }
+        flushFile()
+        return files
+    }
+
+    /// Extracts (oldStart, newStart) from "@@ -12,5 +14,6 @@ context".
+    static func hunkStarts(_ header: String) -> (Int, Int) {
+        var old = 0
+        var new = 0
+        for token in header.split(separator: " ") {
+            if token.hasPrefix("-") {
+                old = Int(token.dropFirst().split(separator: ",").first ?? "0") ?? 0
+            } else if token.hasPrefix("+") {
+                new = Int(token.dropFirst().split(separator: ",").first ?? "0") ?? 0
+            }
+        }
+        return (old, new)
+    }
+}

--- a/Sources/Gavel/Review/DiffReviewServer.swift
+++ b/Sources/Gavel/Review/DiffReviewServer.swift
@@ -1,0 +1,354 @@
+import Foundation
+import Network
+
+/// A verdict POSTed from the review page.
+struct ReviewVerdictSubmission: Codable {
+    let verdict: String
+    let note: String?
+    let comments: [ReviewComment]?
+}
+
+struct ReviewComment: Codable {
+    let file: String
+    let line: Int?
+    let text: String
+}
+
+/// Loopback HTTP server that serves pending commit reviews and accepts their
+/// verdicts as a `.web` resolver racing the Mac panel and Telegram.
+///
+/// Security model: the listener only ever binds 127.0.0.1 — tailnet
+/// reachability comes exclusively via `tailscale serve` (WireGuard-
+/// authenticated peers), never `tailscale funnel`. The per-review nonce is
+/// the sole capability: unknown nonces get a uniform 404, resolved reviews
+/// stop serving diff content, and a verdict can only ever win the resolution
+/// race once (ResolvableApproval guarantees exactly-one-Decision).
+final class DiffReviewServer {
+
+    static let shared = DiffReviewServer()
+
+    final class ReviewSession {
+        let nonce: String
+        let content: ReviewContent
+        let resolvable: ResolvableApproval
+        let createdAt = Date()
+        /// Set (under the server lock) once any source resolves the approval.
+        var resolvedBy: ResolvableApproval.Source?
+        var resolvedAt: Date?
+
+        init(nonce: String, content: ReviewContent, resolvable: ResolvableApproval) {
+            self.nonce = nonce
+            self.content = content
+            self.resolvable = resolvable
+        }
+    }
+
+    private let queue = DispatchQueue(label: "gavel.review-server")
+    private let lock = NSLock()
+    private var sessions: [String: ReviewSession] = [:]
+    private var listener: NWListener?
+    /// Actual bound port — differs from the requested one when tests pass 0.
+    private(set) var boundPort: UInt16?
+
+    // MARK: - Lifecycle
+
+    /// Starts the listener if not already running. Blocks until the socket is
+    /// ready so callers can trust `boundPort`. Idempotent.
+    func start(port: UInt16 = GavelConstants.reviewServerPort) throws {
+        lock.lock()
+        if listener != nil {
+            lock.unlock()
+            return
+        }
+        lock.unlock()
+
+        let params = NWParameters.tcp
+        params.allowLocalEndpointReuse = true
+        params.requiredLocalEndpoint = NWEndpoint.hostPort(
+            host: .ipv4(.loopback), port: NWEndpoint.Port(rawValue: port)!)
+
+        let nw = try NWListener(using: params)
+        let ready = DispatchSemaphore(value: 0)
+        var startError: Error?
+
+        nw.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .ready:
+                self?.boundPort = nw.port?.rawValue
+                ready.signal()
+            case .failed(let error):
+                startError = error
+                ready.signal()
+            default:
+                break
+            }
+        }
+        nw.newConnectionHandler = { [weak self] connection in
+            self?.accept(connection)
+        }
+        nw.start(queue: queue)
+
+        guard ready.wait(timeout: .now() + 5) == .success, startError == nil else {
+            nw.cancel()
+            throw startError ?? NSError(
+                domain: "gavel.review", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "review server start timed out"])
+        }
+
+        lock.lock()
+        listener = nw
+        lock.unlock()
+        gavelLog("[review] server listening on 127.0.0.1:\(boundPort ?? 0)")
+    }
+
+    func stop() {
+        lock.lock()
+        listener?.cancel()
+        listener = nil
+        sessions.removeAll()
+        lock.unlock()
+    }
+
+    // MARK: - Registration
+
+    /// Registers a review for a pending approval and returns its nonce.
+    /// The review dies with the approval: any resolution (mac / telegram /
+    /// timeout / web) flips it to the "already resolved" page.
+    func register(content: ReviewContent, resolvable: ResolvableApproval) -> String {
+        pruneStale()
+
+        var bytes = [UInt8](repeating: 0, count: 16)
+        for i in bytes.indices { bytes[i] = UInt8.random(in: .min ... .max) }
+        let nonce = Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+
+        let session = ReviewSession(nonce: nonce, content: content, resolvable: resolvable)
+        lock.lock()
+        sessions[nonce] = session
+        lock.unlock()
+
+        resolvable.addCleanup { [weak self] source, _ in
+            guard let self else { return }
+            self.lock.lock()
+            session.resolvedBy = source
+            session.resolvedAt = Date()
+            self.lock.unlock()
+        }
+        return nonce
+    }
+
+    private func session(for nonce: String) -> ReviewSession? {
+        lock.lock()
+        defer { lock.unlock() }
+        return sessions[nonce]
+    }
+
+    /// Drops resolved reviews past the TTL and unresolved ones past the
+    /// approval timeout (their worker already failed closed).
+    private func pruneStale() {
+        let now = Date()
+        lock.lock()
+        sessions = sessions.filter { _, s in
+            if let resolvedAt = s.resolvedAt {
+                return now.timeIntervalSince(resolvedAt) < GavelConstants.reviewResolvedTTL
+            }
+            return now.timeIntervalSince(s.createdAt) < GavelConstants.approvalTimeoutSeconds
+        }
+        lock.unlock()
+    }
+
+    // MARK: - HTTP
+
+    private func accept(_ connection: NWConnection) {
+        connection.start(queue: queue)
+        // Hard connection deadline: a client that stalls mid-request can't
+        // hold the (serial) server queue's buffers forever.
+        queue.asyncAfter(deadline: .now() + 15) {
+            connection.cancel()
+        }
+        receive(connection, buffered: Data())
+    }
+
+    private func receive(_ connection: NWConnection, buffered: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) {
+            [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            var buffer = buffered
+            if let data { buffer.append(data) }
+
+            if error != nil {
+                connection.cancel()
+                return
+            }
+            if buffer.count > GavelConstants.reviewMaxBodyBytes + 8 * 1024 {
+                self.send(connection, status: 413, body: "payload too large")
+                return
+            }
+            if let request = HTTPRequest.parse(buffer) {
+                self.route(request, on: connection)
+                return
+            }
+            if isComplete {
+                connection.cancel()
+                return
+            }
+            self.receive(connection, buffered: buffer)
+        }
+    }
+
+    private func route(_ request: HTTPRequest, on connection: NWConnection) {
+        let parts = request.path.split(separator: "/").map(String.init)
+
+        // GET /review/<nonce>
+        if request.method == "GET", parts.count == 2, parts[0] == "review" {
+            guard let session = session(for: parts[1]) else {
+                send(connection, status: 404, body: "not found")
+                return
+            }
+            lock.lock()
+            let resolvedBy = session.resolvedBy
+            lock.unlock()
+            if let resolvedBy {
+                send(connection, status: 200, body: DiffHTML.resolvedPage(by: label(resolvedBy)), contentType: "text/html; charset=utf-8")
+            } else {
+                send(connection, status: 200, body: DiffHTML.page(content: session.content), contentType: "text/html; charset=utf-8")
+            }
+            return
+        }
+
+        // POST /review/<nonce>/verdict
+        if request.method == "POST", parts.count == 3, parts[0] == "review", parts[2] == "verdict" {
+            guard let session = session(for: parts[1]) else {
+                send(connection, status: 404, body: "not found")
+                return
+            }
+            guard request.body.count <= GavelConstants.reviewMaxBodyBytes else {
+                send(connection, status: 413, body: "payload too large")
+                return
+            }
+            guard let submission = try? JSONDecoder().decode(ReviewVerdictSubmission.self, from: request.body),
+                  let decision = Self.decision(for: submission) else {
+                send(connection, status: 400, body: "bad request")
+                return
+            }
+            lock.lock()
+            let alreadyResolved = session.resolvedBy != nil
+            lock.unlock()
+            if alreadyResolved || !session.resolvable.resolve(decision, from: .web) {
+                send(connection, status: 409, body: "{\"status\":\"already_resolved\"}", contentType: "application/json")
+                return
+            }
+            gavelLog("[review] web verdict=\(submission.verdict) comments=\(submission.comments?.count ?? 0) nonce=\(session.nonce.prefix(8))…")
+            send(connection, status: 200, body: "{\"status\":\"ok\"}", contentType: "application/json")
+            return
+        }
+
+        send(connection, status: 404, body: "not found")
+    }
+
+    private func send(_ connection: NWConnection, status: Int, body: String, contentType: String = "text/plain; charset=utf-8") {
+        let reason: String
+        switch status {
+        case 200: reason = "OK"
+        case 400: reason = "Bad Request"
+        case 404: reason = "Not Found"
+        case 409: reason = "Conflict"
+        case 413: reason = "Payload Too Large"
+        default: reason = "Error"
+        }
+        let payload = Data(body.utf8)
+        let head = """
+        HTTP/1.1 \(status) \(reason)\r
+        Content-Type: \(contentType)\r
+        Content-Length: \(payload.count)\r
+        Cache-Control: no-store\r
+        X-Content-Type-Options: nosniff\r
+        Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'\r
+        Connection: close\r
+        \r
+
+        """
+        var response = Data(head.utf8)
+        response.append(payload)
+        connection.send(content: response, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+
+    // MARK: - Verdict mapping
+
+    /// Maps a web submission onto the existing Decision vocabulary:
+    /// approve → allow (+ non-blocking notes), request_changes → block with
+    /// the structured comments as the deny reason Claude acts on.
+    static func decision(for submission: ReviewVerdictSubmission) -> Decision? {
+        let comments = submission.comments ?? []
+        var lines = comments.map { c in
+            "\(c.file):\(c.line ?? 0) — \(c.text)"
+        }
+        if let note = submission.note, !note.isEmpty {
+            lines.append("Overall: \(note)")
+        }
+
+        switch submission.verdict {
+        case "approve":
+            let context = lines.isEmpty
+                ? nil
+                : "Code review notes (non-blocking):\n" + lines.joined(separator: "\n")
+            return Decision(
+                verdict: .allow, reason: "User approved via web review",
+                additionalContext: context)
+        case "request_changes":
+            var reason = "Code review — changes requested"
+            reason += comments.isEmpty ? ":" : " (\(comments.count) comment\(comments.count == 1 ? "" : "s")):"
+            reason += "\n" + (lines.isEmpty ? "See the review page — no comment text was attached." : lines.joined(separator: "\n"))
+            return Decision(verdict: .block, reason: reason)
+        default:
+            return nil
+        }
+    }
+
+    private func label(_ source: ResolvableApproval.Source) -> String {
+        switch source {
+        case .mac: return "the Mac panel"
+        case .telegram: return "Telegram"
+        case .timeout: return "timeout"
+        case .autoApprove: return "auto-approve"
+        case .web: return "this review page"
+        }
+    }
+}
+
+/// Minimal HTTP/1.1 request parser — just enough for the two review routes.
+/// Returns nil until the full head and Content-Length body have arrived.
+struct HTTPRequest {
+    let method: String
+    let path: String
+    let body: Data
+
+    static func parse(_ data: Data) -> HTTPRequest? {
+        guard let headEnd = data.range(of: Data("\r\n\r\n".utf8)) else { return nil }
+        guard let head = String(data: data[..<headEnd.lowerBound], encoding: .utf8) else { return nil }
+
+        let lines = head.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else { return nil }
+        let parts = requestLine.split(separator: " ")
+        guard parts.count >= 2 else { return nil }
+        let method = String(parts[0])
+        // Strip any query string; the routes don't use one.
+        let path = String(parts[1]).components(separatedBy: "?")[0]
+
+        var contentLength = 0
+        for line in lines.dropFirst() {
+            let kv = line.split(separator: ":", maxSplits: 1)
+            if kv.count == 2, kv[0].trimmingCharacters(in: .whitespaces).lowercased() == "content-length" {
+                contentLength = Int(kv[1].trimmingCharacters(in: .whitespaces)) ?? 0
+            }
+        }
+
+        let body = data[headEnd.upperBound...]
+        guard body.count >= contentLength else { return nil }
+        return HTTPRequest(method: method, path: path, body: Data(body.prefix(contentLength)))
+    }
+}

--- a/Sources/Gavel/System/Constants.swift
+++ b/Sources/Gavel/System/Constants.swift
@@ -64,4 +64,19 @@ enum GavelConstants {
     /// Minimum length of an alphanumeric run treated as credential-shaped by the
     /// credential gate's entropy heuristic.
     static let credentialEntropyRunLength = 20
+
+    /// Loopback port for the diff review server. Only ever bound to 127.0.0.1;
+    /// tailnet reachability comes exclusively via `tailscale serve`.
+    static let reviewServerPort: UInt16 = 48765
+
+    /// Cap on a review verdict POST body.
+    static let reviewMaxBodyBytes = 64 * 1024
+
+    /// Cap on captured diff text. Bigger diffs are truncated with a banner —
+    /// a phone review of a multi-megabyte diff isn't a real review anyway.
+    static let reviewDiffMaxBytes = 2 * 1024 * 1024
+
+    /// How long a resolved review stays retrievable (shows "resolved by …"
+    /// instead of 404) before it's garbage-collected.
+    static let reviewResolvedTTL: TimeInterval = 3600
 }

--- a/Tests/GavelTests/DiffCaptureTests.swift
+++ b/Tests/GavelTests/DiffCaptureTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+
+@testable import Gavel
+
+final class DiffCaptureTests: XCTestCase {
+
+    // MARK: - Flag detection
+
+    func testAllFlagVariants() {
+        XCTAssertTrue(DiffCapture.commitUsesAllFlag("git commit -am 'x'"))
+        XCTAssertTrue(DiffCapture.commitUsesAllFlag("git commit -a -m 'x'"))
+        XCTAssertTrue(DiffCapture.commitUsesAllFlag("git commit --all -m 'x'"))
+        XCTAssertTrue(DiffCapture.commitUsesAllFlag("git commit -qam 'x'"))
+        XCTAssertFalse(DiffCapture.commitUsesAllFlag("git commit -m 'x'"))
+        XCTAssertFalse(DiffCapture.commitUsesAllFlag("git commit --amend -m 'x'"))
+    }
+
+    func testAllFlagNotFooledByMessageContent() {
+        XCTAssertFalse(DiffCapture.commitUsesAllFlag(#"git commit -m "docs: explain the -a flag""#))
+        XCTAssertFalse(DiffCapture.commitUsesAllFlag("git commit -m 'add -a support later'"))
+    }
+
+    // MARK: - Message extraction
+
+    func testCommitMessageExtraction() {
+        XCTAssertEqual(DiffCapture.commitMessage(from: #"git commit -m "feat: add thing""#), "feat: add thing")
+        XCTAssertEqual(DiffCapture.commitMessage(from: "git commit -m 'fix bug'"), "fix bug")
+        XCTAssertEqual(DiffCapture.commitMessage(from: "git commit -m oneword"), "oneword")
+        XCTAssertNil(DiffCapture.commitMessage(from: "git commit"))
+    }
+
+    // MARK: - Live capture against a scratch repo
+
+    private func makeRepo() throws -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gavel-diffcapture-\(UUID().uuidString)").path
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(atPath: dir) }
+        XCTAssertNotNil(DiffCapture.runGit(["init", "-q"], cwd: dir))
+        return dir
+    }
+
+    private func write(_ text: String, to name: String, in dir: String) throws {
+        try text.write(toFile: (dir as NSString).appendingPathComponent(name), atomically: true, encoding: .utf8)
+    }
+
+    func testCapturesStagedDiff() throws {
+        let repo = try makeRepo()
+        try write("hello\n", to: "f.txt", in: repo)
+        XCTAssertNotNil(DiffCapture.runGit(["add", "f.txt"], cwd: repo))
+
+        let captured = DiffCapture.capture(cwd: repo, command: "git commit -m 'test'")
+        XCTAssertNotNil(captured)
+        XCTAssertFalse(captured!.includesUnstaged)
+        XCTAssertFalse(captured!.truncated)
+        XCTAssertTrue(captured!.diffText.contains("+hello"))
+        XCTAssertEqual(captured!.commitMessage, "test")
+
+        let files = DiffParser.parse(captured!.diffText)
+        XCTAssertEqual(files.count, 1)
+        XCTAssertEqual(files[0].displayPath, "f.txt")
+        XCTAssertTrue(files[0].isNew)
+    }
+
+    func testDashAFallsBackToHeadDiff() throws {
+        let repo = try makeRepo()
+        try write("v1\n", to: "f.txt", in: repo)
+        XCTAssertNotNil(DiffCapture.runGit(["add", "f.txt"], cwd: repo))
+        XCTAssertNotNil(DiffCapture.runGit(
+            ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "init"], cwd: repo))
+        try write("v2\n", to: "f.txt", in: repo)
+
+        // Plain commit: nothing staged, so the cached diff is empty…
+        let staged = DiffCapture.capture(cwd: repo, command: "git commit -m 'x'")
+        XCTAssertEqual(DiffParser.parse(staged!.diffText).count, 0)
+
+        // …but -am stages tracked changes at commit time, so review HEAD-relative.
+        let all = DiffCapture.capture(cwd: repo, command: "git commit -am 'x'")
+        XCTAssertTrue(all!.includesUnstaged)
+        XCTAssertTrue(all!.diffText.contains("+v2"))
+    }
+
+    func testNonRepoReturnsNil() {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gavel-notarepo-\(UUID().uuidString)").path
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(atPath: dir) }
+        XCTAssertNil(DiffCapture.capture(cwd: dir, command: "git commit -m x"))
+    }
+}

--- a/Tests/GavelTests/DiffParserTests.swift
+++ b/Tests/GavelTests/DiffParserTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+
+@testable import Gavel
+
+final class DiffParserTests: XCTestCase {
+
+    private let multiFileFixture = """
+    diff --git a/Sources/A.swift b/Sources/A.swift
+    index 1111111..2222222 100644
+    --- a/Sources/A.swift
+    +++ b/Sources/A.swift
+    @@ -10,7 +10,8 @@ struct A {
+     context1
+    -old line
+    +new line
+    +added line
+     context2
+    @@ -40,3 +41,3 @@
+     c
+    -x
+    +y
+     d
+    diff --git a/B.txt b/B.txt
+    new file mode 100644
+    index 0000000..3333333
+    --- /dev/null
+    +++ b/B.txt
+    @@ -0,0 +1,2 @@
+    +hello
+    +world
+    """
+
+    func testMultiFileMultiHunk() {
+        let files = DiffParser.parse(multiFileFixture)
+        XCTAssertEqual(files.count, 2)
+
+        let a = files[0]
+        XCTAssertEqual(a.displayPath, "Sources/A.swift")
+        XCTAssertEqual(a.hunks.count, 2)
+        XCTAssertEqual(a.hunks[0].newStart, 10)
+        XCTAssertEqual(a.hunks[1].newStart, 41)
+        XCTAssertEqual(a.additions, 3)
+        XCTAssertEqual(a.deletions, 2)
+        XCTAssertFalse(a.isNew)
+
+        let b = files[1]
+        XCTAssertEqual(b.displayPath, "B.txt")
+        XCTAssertTrue(b.isNew)
+        XCTAssertEqual(b.additions, 2)
+        XCTAssertEqual(b.deletions, 0)
+    }
+
+    func testLineNumbering() {
+        let files = DiffParser.parse(multiFileFixture)
+        let lines = files[0].hunks[0].lines
+        XCTAssertEqual(lines[0].kind, .context)
+        XCTAssertEqual(lines[0].newNumber, 10)
+        XCTAssertEqual(lines[1].kind, .deletion)
+        XCTAssertEqual(lines[1].oldNumber, 11)
+        XCTAssertNil(lines[1].newNumber)
+        XCTAssertEqual(lines[2].kind, .addition)
+        XCTAssertEqual(lines[2].newNumber, 11)
+        XCTAssertEqual(lines[3].newNumber, 12)
+        XCTAssertEqual(lines[4].kind, .context)
+        XCTAssertEqual(lines[4].oldNumber, 12)
+        XCTAssertEqual(lines[4].newNumber, 13)
+    }
+
+    func testRename() {
+        let fixture = """
+        diff --git a/old.txt b/new.txt
+        similarity index 90%
+        rename from old.txt
+        rename to new.txt
+        index 1111111..2222222 100644
+        --- a/old.txt
+        +++ b/new.txt
+        @@ -1,2 +1,2 @@
+        -a
+        +b
+         c
+        """
+        let files = DiffParser.parse(fixture)
+        XCTAssertEqual(files.count, 1)
+        XCTAssertTrue(files[0].isRename)
+        XCTAssertEqual(files[0].oldPath, "old.txt")
+        XCTAssertEqual(files[0].newPath, "new.txt")
+        XCTAssertEqual(files[0].hunks.count, 1)
+    }
+
+    func testBinaryNewFile() {
+        let fixture = """
+        diff --git a/img.png b/img.png
+        new file mode 100644
+        index 0000000..1111111
+        Binary files /dev/null and b/img.png differ
+        """
+        let files = DiffParser.parse(fixture)
+        XCTAssertEqual(files.count, 1)
+        XCTAssertTrue(files[0].isBinary)
+        XCTAssertTrue(files[0].isNew)
+        XCTAssertTrue(files[0].hunks.isEmpty)
+    }
+
+    func testDeletedFile() {
+        let fixture = """
+        diff --git a/gone.txt b/gone.txt
+        deleted file mode 100644
+        index 1111111..0000000
+        --- a/gone.txt
+        +++ /dev/null
+        @@ -1,1 +0,0 @@
+        -bye
+        """
+        let files = DiffParser.parse(fixture)
+        XCTAssertEqual(files.count, 1)
+        XCTAssertTrue(files[0].isDeleted)
+        XCTAssertEqual(files[0].displayPath, "gone.txt")
+        XCTAssertEqual(files[0].deletions, 1)
+    }
+
+    func testNoNewlineMarker() {
+        let fixture = """
+        diff --git a/x.txt b/x.txt
+        index 1111111..2222222 100644
+        --- a/x.txt
+        +++ b/x.txt
+        @@ -1,1 +1,1 @@
+        -a
+        +b
+        \\ No newline at end of file
+        """
+        let files = DiffParser.parse(fixture)
+        XCTAssertEqual(files[0].hunks[0].lines.last?.kind, .meta)
+    }
+
+    func testEmptyInput() {
+        XCTAssertTrue(DiffParser.parse("").isEmpty)
+    }
+}

--- a/Tests/GavelTests/DiffReviewServerTests.swift
+++ b/Tests/GavelTests/DiffReviewServerTests.swift
@@ -1,0 +1,231 @@
+import XCTest
+
+@testable import Gavel
+
+final class DiffReviewServerTests: XCTestCase {
+
+    private var server: DiffReviewServer!
+    private var port: UInt16!
+
+    override func setUpWithError() throws {
+        server = DiffReviewServer()
+        try server.start(port: 0)
+        port = try XCTUnwrap(server.boundPort)
+    }
+
+    override func tearDown() {
+        server.stop()
+        server = nil
+    }
+
+    // MARK: - Helpers
+
+    private func makeContent(diff: String = defaultDiff) -> ReviewContent {
+        ReviewContent(
+            repoName: "scratch-repo",
+            commitMessage: "feat: test",
+            files: DiffParser.parse(diff),
+            includesUnstaged: false,
+            truncated: false)
+    }
+
+    private static let defaultDiff = """
+    diff --git a/Sources/A.swift b/Sources/A.swift
+    index 1111111..2222222 100644
+    --- a/Sources/A.swift
+    +++ b/Sources/A.swift
+    @@ -10,3 +10,4 @@ struct A {
+     context
+    -old
+    +new
+    +extra
+    """
+
+    private struct HTTPResult {
+        let status: Int
+        let body: String
+    }
+
+    private func request(_ path: String, method: String = "GET", body: String? = nil) throws -> HTTPResult {
+        var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port!)\(path)")!)
+        req.httpMethod = method
+        if let body {
+            req.httpBody = Data(body.utf8)
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        var result: HTTPResult?
+        let done = DispatchSemaphore(value: 0)
+        URLSession.shared.dataTask(with: req) { data, response, _ in
+            if let http = response as? HTTPURLResponse {
+                result = HTTPResult(
+                    status: http.statusCode,
+                    body: String(decoding: data ?? Data(), as: UTF8.self))
+            }
+            done.signal()
+        }.resume()
+        guard done.wait(timeout: .now() + 10) == .success else {
+            throw XCTSkip("HTTP request timed out")
+        }
+        return try XCTUnwrap(result)
+    }
+
+    // MARK: - GET
+
+    func testGetRendersDiff() throws {
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(content: makeContent(), resolvable: resolvable)
+
+        let res = try request("/review/\(nonce)")
+        XCTAssertEqual(res.status, 200)
+        XCTAssertTrue(res.body.contains("Sources/A.swift"))
+        XCTAssertTrue(res.body.contains("+new"))
+        XCTAssertTrue(res.body.contains("scratch-repo"))
+    }
+
+    func testUnknownNonceIs404() throws {
+        let res = try request("/review/does-not-exist")
+        XCTAssertEqual(res.status, 404)
+        XCTAssertFalse(res.body.contains("Sources"))
+    }
+
+    func testUnknownRouteIs404() throws {
+        let res = try request("/anything/else")
+        XCTAssertEqual(res.status, 404)
+    }
+
+    // MARK: - POST verdict
+
+    func testRequestChangesBlocksWithComments() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(content: makeContent(), resolvable: resolvable)
+
+        let body = """
+        {"verdict":"request_changes","note":"tighten this up",
+         "comments":[{"file":"Sources/A.swift","line":10,"text":"rename this"},
+                     {"file":"Sources/A.swift","line":12,"text":"guard nil first"}]}
+        """
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: body)
+        XCTAssertEqual(res.status, 200)
+
+        let d = try XCTUnwrap(decision)
+        XCTAssertEqual(d.verdict, .block)
+        let reason = try XCTUnwrap(d.reason)
+        XCTAssertTrue(reason.contains("changes requested (2 comments)"))
+        XCTAssertTrue(reason.contains("Sources/A.swift:10 — rename this"))
+        XCTAssertTrue(reason.contains("Sources/A.swift:12 — guard nil first"))
+        XCTAssertTrue(reason.contains("Overall: tighten this up"))
+    }
+
+    func testApproveWithNoteAllowsWithContext() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(content: makeContent(), resolvable: resolvable)
+
+        let body = #"{"verdict":"approve","note":"nice","comments":[]}"#
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: body)
+        XCTAssertEqual(res.status, 200)
+
+        let d = try XCTUnwrap(decision)
+        XCTAssertEqual(d.verdict, .allow)
+        XCTAssertEqual(d.additionalContext?.contains("Overall: nice"), true)
+    }
+
+    func testApproveWithoutCommentsHasNoContext() {
+        let d = DiffReviewServer.decision(
+            for: ReviewVerdictSubmission(verdict: "approve", note: nil, comments: []))
+        XCTAssertEqual(d?.verdict, .allow)
+        XCTAssertNil(d?.additionalContext)
+    }
+
+    func testUnknownVerdictRejected() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(content: makeContent(), resolvable: resolvable)
+
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"maybe"}"#)
+        XCTAssertEqual(res.status, 400)
+        XCTAssertNil(decision)
+        XCTAssertFalse(resolvable.isResolved)
+    }
+
+    func testMalformedBodyRejected() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(content: makeContent(), resolvable: resolvable)
+
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: "not json {{{")
+        XCTAssertEqual(res.status, 400)
+        XCTAssertNil(decision)
+    }
+
+    // MARK: - Resolution lifecycle
+
+    func testSecondSubmitIs409AndGetShowsResolved() throws {
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(content: makeContent(), resolvable: resolvable)
+
+        let first = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"approve"}"#)
+        XCTAssertEqual(first.status, 200)
+
+        let second = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"approve"}"#)
+        XCTAssertEqual(second.status, 409)
+
+        let page = try request("/review/\(nonce)")
+        XCTAssertEqual(page.status, 200)
+        XCTAssertTrue(page.body.contains("Already resolved"))
+        XCTAssertFalse(page.body.contains("+new"), "resolved page must not leak diff content")
+    }
+
+    func testWebLosesRaceToMacPanel() throws {
+        var decisions: [Decision] = []
+        let resolvable = ResolvableApproval { decisions.append($0) }
+        let nonce = server.register(content: makeContent(), resolvable: resolvable)
+
+        // Mac panel wins first…
+        XCTAssertTrue(resolvable.resolve(Decision(verdict: .allow, reason: "panel"), from: .mac))
+
+        // …web submit afterwards is a conflict, and no second Decision fires.
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"request_changes"}"#)
+        XCTAssertEqual(res.status, 409)
+        XCTAssertEqual(decisions.count, 1)
+        XCTAssertEqual(decisions[0].reason, "panel")
+
+        let page = try request("/review/\(nonce)")
+        XCTAssertTrue(page.body.contains("Mac panel"))
+    }
+
+    // MARK: - Credential withholding
+
+    func testHunkWithKnownSecretIsWithheld() throws {
+        let secretDiff = """
+        diff --git a/config.env b/config.env
+        index 1111111..2222222 100644
+        --- a/config.env
+        +++ b/config.env
+        @@ -1,1 +1,2 @@
+         KEY=old
+        +AWS_KEY=AKIAIOSFODNN7EXAMPLE
+        """
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(content: makeContent(diff: secretDiff), resolvable: resolvable)
+
+        let res = try request("/review/\(nonce)")
+        XCTAssertEqual(res.status, 200)
+        XCTAssertFalse(res.body.contains("AKIAIOSFODNN7EXAMPLE"), "secret must never be served")
+        XCTAssertTrue(res.body.contains("withheld"))
+        XCTAssertTrue(res.body.contains("AWS access key"))
+    }
+
+    // MARK: - Oversize body
+
+    func testOversizedBodyRejected() throws {
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(content: makeContent(), resolvable: resolvable)
+
+        let huge = #"{"verdict":"approve","note":""# + String(repeating: "x", count: GavelConstants.reviewMaxBodyBytes + 1024) + #""}"#
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: huge)
+        XCTAssertEqual(res.status, 413)
+        XCTAssertFalse(resolvable.isResolved)
+    }
+}


### PR DESCRIPTION
Part 1 of the phone pre-commit review feature (plan: web diff review as an approval resolver). This PR lands the engine, fully self-contained and unused by the daemon until PR 2 wires it into the coordinator and Telegram.

## What

- **DiffReviewServer** — loopback-only NWListener HTTP server. `GET /review/{nonce}` serves a self-contained mobile review page; `POST /review/{nonce}/verdict` resolves the pending approval as a new `.web` source on `ResolvableApproval`, racing the Mac panel and Telegram with the existing exactly-once guarantee.
- **Verdict mapping** — approve → `.allow` (comments ride along as `additionalContext`, the allow-with-note path); request changes → `.block` with structured `file:line — comment` lines as the deny reason, so Claude applies the feedback and re-commits.
- **DiffCapture** — snapshots the diff at approval time via `git diff --cached`, falling back to `git diff HEAD` when the commit uses `-a`/`-am`/`--all` (which would otherwise render an empty staged diff). Quoted spans are stripped before flag detection so `-m "docs: the -a flag"` can't fool it.
- **Credential withholding** — hunks matching `SecretRedactor` patterns are withheld with a banner before the page is served (same philosophy as `CredentialGate` withholding commands from Telegram).
- **DiffParser / DiffHTML** — unified-diff parser and server-side renderer; inline CSS/JS only, dark-mode aware, no external fetches.

## Security model

- Listener binds 127.0.0.1 only. Tailnet reachability (PR 2) comes exclusively via `tailscale serve` — never funnel.
- Per-review 128-bit nonce is the sole capability; unknown nonces get uniform 404s; resolved reviews stop serving diff content; verdict POSTs are size-capped.
- Resolution through any source (mac / telegram / timeout / web) kills the review via the existing cleanup hooks.

## Tests

25 new tests: parser fixtures (multi-hunk, rename, binary, new/deleted, no-newline), `-a` detection + message extraction, live scratch-repo capture for both staged and `-am` paths, and full HTTP round-trips against a real listener — render, 404s, verdict resolution, 409 on lost race vs the Mac panel, malformed/oversized body rejection, and secret withholding.

`swift test` green except `ProcessTreeTests.testLiveClaudeSessionDiscoveryAgainstPsWitness`, which fails identically on main (live-environment test, unrelated).

Part 2 will follow: coordinator/Telegram wiring + `tailscale serve` bootstrap.