### PR TITLE
feat(notifications): review link in Telegram commit approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,28 @@ Slept and exited sessions remain as tombstones with **History**, **Resume** (cop
 
 ![Bulk operations bar](docs/images/session-bulk-bar.png)
 
+## Phone Pre-Commit Review
+
+For sessions with the **Phone** toggle on, a `git commit` approval adds a
+**🔍 Review diff** button to the Telegram message. It opens a mobile review
+page of the pending commit's diff — served by the daemon on loopback and
+exposed only to your tailnet via `tailscale serve` (never funnel; requires
+Tailscale running on the Mac and your phone on the tailnet).
+
+Review change by change, attach per-hunk comments, then:
+
+- **Approve** — the commit proceeds; comments ride along as a non-blocking
+  note to Claude
+- **Request changes** — the commit is blocked and your comments become the
+  deny reason as `file:line — comment` lines; Claude applies the feedback
+  and the next commit attempt gets a fresh review link
+
+The page races the Mac panel and the Telegram buttons — whichever answers
+first wins, exactly once. Hunks containing recognizable credentials are
+withheld from the page. The diff is snapshotted at approval time; commits
+using `-a`/`-am` are captured HEAD-relative so unstaged tracked changes
+show correctly.
+
 ## Session Context
 
 Gavel injects `~/.claude/gavel/session-context.md` into every Claude Code session at startup. This seeds Claude with engineering principles, code quality standards, and verification practices.

--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -198,7 +198,36 @@ final class ApprovalCoordinator: ObservableObject {
             ? RemoteApprovalBridge.withheldBody(payload: payload, session: session)
             : RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: pending.triggerReason)
         let isCommit = withheld == nil && payload.toolName == "Bash" && (payload.command?.contains("commit") ?? false)
-        bridge.notify(resolvable: resolvable, text: text, pid: session.pid, toolName: payload.toolName, withheld: withheld != nil, allowSession: allowSession, offerCommentClean: isCommit, leaseDomain: leaseDomain, allowSite: allowSite)
+        let reviewURL = isCommit ? makeReviewLink(payload: payload, session: session, resolvable: resolvable) : nil
+        bridge.notify(resolvable: resolvable, text: text, pid: session.pid, toolName: payload.toolName, withheld: withheld != nil, allowSession: allowSession, offerCommentClean: isCommit, leaseDomain: leaseDomain, allowSite: allowSite, reviewURL: reviewURL)
+    }
+
+    /// Snapshot the pending commit's diff, register it with the review
+    /// server, and return the tailnet review URL. Every failure is soft —
+    /// a nil just means the Telegram message goes out without a link.
+    private func makeReviewLink(payload: PreToolUsePayload, session: Session, resolvable: ResolvableApproval) -> String? {
+        guard let cwd = payload.cwd ?? session.cwd, let command = payload.command else { return nil }
+        guard let captured = DiffCapture.capture(cwd: cwd, command: command),
+              !captured.diffText.isEmpty else {
+            // Empty diff (e.g. --amend reword) — a review page would show nothing.
+            return nil
+        }
+        do {
+            try DiffReviewServer.shared.start()
+        } catch {
+            gavelLog("[review] server start failed: \(error.localizedDescription)")
+            return nil
+        }
+        guard let base = TailscaleServe.reviewBaseURL() else { return nil }
+        let content = ReviewContent(
+            repoName: URL(fileURLWithPath: cwd).lastPathComponent,
+            commitMessage: captured.commitMessage,
+            files: DiffParser.parse(captured.diffText),
+            includesUnstaged: captured.includesUnstaged,
+            truncated: captured.truncated)
+        let nonce = DiffReviewServer.shared.register(content: content, resolvable: resolvable)
+        gavelLog("[review] link created pid=\(session.pid) files=\(content.files.count) nonce=\(nonce.prefix(8))…")
+        return "\(base)/review/\(nonce)"
     }
 
     /// Remove a pending approval resolved remotely from its session panel.

--- a/Sources/Gavel/Remote/RemoteApprovalBridge.swift
+++ b/Sources/Gavel/Remote/RemoteApprovalBridge.swift
@@ -85,7 +85,7 @@ final class RemoteApprovalBridge {
     /// `leaseDomain`/`allowSite` (both required together) add a browsing-lease
     /// button for chrome navigate approvals — the phone twin of the panel's
     /// "Allow Site" (see BrowsingLease).
-    func notify(resolvable: ResolvableApproval, text: String, pid: Int = 0, toolName: String = "", withheld: Bool = false, allowSession: (() -> Void)?, offerCommentClean: Bool = false, leaseDomain: String? = nil, allowSite: (() -> Void)? = nil) {
+    func notify(resolvable: ResolvableApproval, text: String, pid: Int = 0, toolName: String = "", withheld: Bool = false, allowSession: (() -> Void)?, offerCommentClean: Bool = false, leaseDomain: String? = nil, allowSite: (() -> Void)? = nil, reviewURL: String? = nil) {
         lock.lock(); let chat = chatId; lock.unlock()
         guard let chat else { return }
 
@@ -112,10 +112,15 @@ final class RemoteApprovalBridge {
             }
         }
 
-        var keyboard: [[TelegramButton]] = [
+        var keyboard: [[TelegramButton]] = []
+        // Review link leads the keyboard: on a commit approval the intended
+        // flow is review first, then verdict (on the page or via the buttons).
+        if let reviewURL {
+            keyboard.append([TelegramButton(text: "🔍 Review diff", url: reviewURL)])
+        }
+        keyboard.append(
             [TelegramButton(text: "✅ Allow once", callbackData: "a:\(nonce)"),
-             TelegramButton(text: "🛑 Deny", callbackData: "d:\(nonce)")],
-        ]
+             TelegramButton(text: "🛑 Deny", callbackData: "d:\(nonce)")])
         // Allow-once-only approvals (nil allowSession) omit the session button entirely.
         if allowSession != nil {
             keyboard.append([TelegramButton(text: "✅ Allow for session", callbackData: "s:\(nonce)")])

--- a/Sources/Gavel/Remote/TelegramTransport.swift
+++ b/Sources/Gavel/Remote/TelegramTransport.swift
@@ -1,8 +1,24 @@
 import Foundation
 
+/// An inline keyboard button — exactly one of callbackData/url per the
+/// Telegram Bot API (callback buttons resolve approvals, url buttons open
+/// the tailnet review page).
 struct TelegramButton {
     let text: String
-    let callbackData: String
+    let callbackData: String?
+    let url: String?
+
+    init(text: String, callbackData: String) {
+        self.text = text
+        self.callbackData = callbackData
+        self.url = nil
+    }
+
+    init(text: String, url: String) {
+        self.text = text
+        self.callbackData = nil
+        self.url = url
+    }
 }
 
 struct TelegramCallback {

--- a/Sources/Gavel/Remote/URLSessionTelegramTransport.swift
+++ b/Sources/Gavel/Remote/URLSessionTelegramTransport.swift
@@ -104,7 +104,14 @@ final class URLSessionTelegramTransport: TelegramTransport {
     }
 
     private func encode(_ keyboard: [[TelegramButton]]) -> [[[String: String]]] {
-        keyboard.map { row in row.map { ["text": $0.text, "callback_data": $0.callbackData] } }
+        keyboard.map { row in
+            row.map { button in
+                if let url = button.url {
+                    return ["text": button.text, "url": url]
+                }
+                return ["text": button.text, "callback_data": button.callbackData ?? ""]
+            }
+        }
     }
 
     private func call(_ method: String, params: [String: Any], completion: @escaping (Result<[String: Any], Error>) -> Void) {

--- a/Sources/Gavel/Review/TailscaleServe.swift
+++ b/Sources/Gavel/Review/TailscaleServe.swift
@@ -10,12 +10,27 @@ import Foundation
 /// No caching: status + registration re-run per review so a `tailscale
 /// serve reset` or daemon flap between commits can't leave stale links.
 /// Both calls are ~50ms against the local tailscaled.
+///
+/// A Mac can run TWO independent backends at once (the Tailscale.app system
+/// extension and a homebrew tailscaled), each with its own node identity and
+/// CLI. Backend choice is therefore by state, not binary path: probe every
+/// candidate CLI, keep the Running ones, and prefer the backend that can see
+/// an online iOS peer — that's the one the phone can actually reach.
 enum TailscaleServe {
 
-    /// Test seam — production runs the tailscale CLI, tests stub responses.
+    /// One probed backend: the CLI that reached it, its MagicDNS name, and
+    /// whether an iOS device is currently online on its tailnet.
+    struct Backend {
+        let binary: String
+        let host: String
+        let hasOnlineIOSPeer: Bool
+    }
+
+    /// Test seam — production runs a tailscale CLI, tests stub responses.
     /// Returns (exitStatus, stdout) or nil when the binary can't be run.
-    static var runner: (_ args: [String]) -> (status: Int32, stdout: String)? = { args in
-        guard let binary = binaryPath() else { return nil }
+    /// stderr is discarded deliberately: the CLI prints version-skew
+    /// warnings there that would corrupt JSON parsing if merged.
+    static var runner: (_ binary: String, _ args: [String]) -> (status: Int32, stdout: String)? = { binary, args in
         let task = Process()
         task.executableURL = URL(fileURLWithPath: binary)
         task.arguments = args
@@ -38,37 +53,42 @@ enum TailscaleServe {
         return (task.terminationStatus, String(decoding: data, as: UTF8.self))
     }
 
-    static func binaryPath() -> String? {
-        let candidates = [
+    static func candidateBinaries() -> [String] {
+        [
             "/opt/homebrew/bin/tailscale",
             "/usr/local/bin/tailscale",
             "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
-        ]
-        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+        ].filter { FileManager.default.isExecutableFile(atPath: $0) }
     }
 
     /// Base URL for review links (e.g. "https://host.tailnet.ts.net:8443"),
-    /// or nil when tailscale is missing/stopped — callers fail soft by
-    /// omitting the link; the approval itself is never affected.
+    /// or nil when no backend is running — callers fail soft by omitting
+    /// the link; the approval itself is never affected.
     static func reviewBaseURL() -> String? {
-        guard let status = runner(["status", "--json"]), status.status == 0,
-              let host = hostname(fromStatusJSON: Data(status.stdout.utf8)) else {
-            gavelLog("[review] tailscale unavailable — no review link")
+        let running = candidateBinaries().compactMap { binary -> Backend? in
+            guard let result = runner(binary, ["status", "--json"]), result.status == 0 else { return nil }
+            return backend(binary: binary, statusJSON: Data(result.stdout.utf8))
+        }
+        guard let chosen = running.first(where: { $0.hasOnlineIOSPeer }) ?? running.first else {
+            gavelLog("[review] no running tailscale backend — no review link")
             return nil
+        }
+        if running.count > 1 {
+            gavelLog("[review] \(running.count) tailscale backends running — chose \(chosen.host) (\(chosen.binary), iOS peer online=\(chosen.hasOnlineIOSPeer))")
         }
         let target = "http://127.0.0.1:\(GavelConstants.reviewServerPort)"
-        guard let serve = runner(["serve", "--bg", "--https=\(GavelConstants.reviewTailnetHTTPSPort)", target]),
+        guard let serve = runner(chosen.binary, ["serve", "--bg", "--https=\(GavelConstants.reviewTailnetHTTPSPort)", target]),
               serve.status == 0 else {
-            gavelLog("[review] tailscale serve registration failed")
+            gavelLog("[review] tailscale serve registration failed via \(chosen.binary)")
             return nil
         }
-        return "https://\(host):\(GavelConstants.reviewTailnetHTTPSPort)"
+        return "https://\(chosen.host):\(GavelConstants.reviewTailnetHTTPSPort)"
     }
 
-    /// Extracts the node's MagicDNS name from `tailscale status --json`.
-    /// Nil unless the backend is actually running — a stopped tailscaled
-    /// still reports a DNSName but can't route.
-    static func hostname(fromStatusJSON data: Data) -> String? {
+    /// Parses `tailscale status --json` into a Backend. Nil unless the
+    /// backend is actually Running — a stopped tailscaled still reports a
+    /// DNSName but can't route.
+    static func backend(binary: String, statusJSON data: Data) -> Backend? {
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               root["BackendState"] as? String == "Running",
               let selfNode = root["Self"] as? [String: Any],
@@ -76,6 +96,11 @@ enum TailscaleServe {
             return nil
         }
         if dns.hasSuffix(".") { dns.removeLast() }
-        return dns
+
+        let peers = root["Peer"] as? [String: [String: Any]] ?? [:]
+        let hasPhone = peers.values.contains { peer in
+            peer["OS"] as? String == "iOS" && peer["Online"] as? Bool == true
+        }
+        return Backend(binary: binary, host: dns, hasOnlineIOSPeer: hasPhone)
     }
 }

--- a/Sources/Gavel/Review/TailscaleServe.swift
+++ b/Sources/Gavel/Review/TailscaleServe.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Exposes the loopback review server to the tailnet via `tailscale serve`
+/// and builds the public review URL.
+///
+/// Serve only, NEVER funnel: reachability is limited to WireGuard-
+/// authenticated tailnet peers. A dedicated HTTPS port keeps the mapping
+/// from clobbering any serve config the user runs on 443.
+///
+/// No caching: status + registration re-run per review so a `tailscale
+/// serve reset` or daemon flap between commits can't leave stale links.
+/// Both calls are ~50ms against the local tailscaled.
+enum TailscaleServe {
+
+    /// Test seam — production runs the tailscale CLI, tests stub responses.
+    /// Returns (exitStatus, stdout) or nil when the binary can't be run.
+    static var runner: (_ args: [String]) -> (status: Int32, stdout: String)? = { args in
+        guard let binary = binaryPath() else { return nil }
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: binary)
+        task.arguments = args
+        let stdout = Pipe()
+        task.standardOutput = stdout
+        task.standardError = FileHandle.nullDevice
+        var data = Data()
+        let drained = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            data = stdout.fileHandleForReading.readDataToEndOfFile()
+            drained.signal()
+        }
+        do {
+            try task.run()
+        } catch {
+            return nil
+        }
+        task.waitUntilExit()
+        drained.wait()
+        return (task.terminationStatus, String(decoding: data, as: UTF8.self))
+    }
+
+    static func binaryPath() -> String? {
+        let candidates = [
+            "/opt/homebrew/bin/tailscale",
+            "/usr/local/bin/tailscale",
+            "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+        ]
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    /// Base URL for review links (e.g. "https://host.tailnet.ts.net:8443"),
+    /// or nil when tailscale is missing/stopped — callers fail soft by
+    /// omitting the link; the approval itself is never affected.
+    static func reviewBaseURL() -> String? {
+        guard let status = runner(["status", "--json"]), status.status == 0,
+              let host = hostname(fromStatusJSON: Data(status.stdout.utf8)) else {
+            gavelLog("[review] tailscale unavailable — no review link")
+            return nil
+        }
+        let target = "http://127.0.0.1:\(GavelConstants.reviewServerPort)"
+        guard let serve = runner(["serve", "--bg", "--https=\(GavelConstants.reviewTailnetHTTPSPort)", target]),
+              serve.status == 0 else {
+            gavelLog("[review] tailscale serve registration failed")
+            return nil
+        }
+        return "https://\(host):\(GavelConstants.reviewTailnetHTTPSPort)"
+    }
+
+    /// Extracts the node's MagicDNS name from `tailscale status --json`.
+    /// Nil unless the backend is actually running — a stopped tailscaled
+    /// still reports a DNSName but can't route.
+    static func hostname(fromStatusJSON data: Data) -> String? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              root["BackendState"] as? String == "Running",
+              let selfNode = root["Self"] as? [String: Any],
+              var dns = selfNode["DNSName"] as? String, !dns.isEmpty else {
+            return nil
+        }
+        if dns.hasSuffix(".") { dns.removeLast() }
+        return dns
+    }
+}

--- a/Sources/Gavel/Review/TailscaleServe.swift
+++ b/Sources/Gavel/Review/TailscaleServe.swift
@@ -9,27 +9,37 @@ import Foundation
 ///
 /// No caching: status + registration re-run per review so a `tailscale
 /// serve reset` or daemon flap between commits can't leave stale links.
-/// Both calls are ~50ms against the local tailscaled.
 ///
-/// A Mac can run TWO independent backends at once (the Tailscale.app system
-/// extension and a homebrew tailscaled), each with its own node identity and
-/// CLI. Backend choice is therefore by state, not binary path: probe every
-/// candidate CLI, keep the Running ones, and prefer the backend that can see
-/// an online iOS peer — that's the one the phone can actually reach.
+/// A Mac can run SEVERAL independent backends at once: the Tailscale.app
+/// system extension plus any number of homebrew tailscaleds with custom
+/// `--socket` paths (e.g. tailscaled-personal.sock for a second tailnet).
+/// A CLI run without --socket silently falls back to the GUI extension's
+/// IPC, so binary discovery alone probes the wrong daemon. Discovery is
+/// therefore by ENDPOINT (binary × socket): probe every /var/run
+/// tailscaled socket plus the default GUI discovery, keep the Running
+/// ones, and prefer the backend that can see an online iOS peer — that's
+/// the tailnet the phone can actually reach.
 enum TailscaleServe {
 
-    /// One probed backend: the CLI that reached it, its MagicDNS name, and
-    /// whether an iOS device is currently online on its tailnet.
+    /// One probed, Running backend and the endpoint that reached it.
     struct Backend {
         let binary: String
+        /// Unix socket the CLI must target, nil for default GUI discovery.
+        let socketPath: String?
         let host: String
         let hasOnlineIOSPeer: Bool
     }
 
+    /// Hard deadline per CLI invocation. `tailscale serve` BLOCKS
+    /// interactively when Serve isn't enabled on the tailnet (prints an
+    /// enable URL and waits) — without a deadline that would hang the
+    /// approval flow's worker thread.
+    static let commandTimeout: TimeInterval = 10
+
     /// Test seam — production runs a tailscale CLI, tests stub responses.
-    /// Returns (exitStatus, stdout) or nil when the binary can't be run.
-    /// stderr is discarded deliberately: the CLI prints version-skew
-    /// warnings there that would corrupt JSON parsing if merged.
+    /// Returns (exitStatus, stdout); nil when the binary can't be run or
+    /// the deadline expired. stderr is discarded deliberately: the CLI
+    /// prints version-skew warnings there that would corrupt JSON parsing.
     static var runner: (_ binary: String, _ args: [String]) -> (status: Int32, stdout: String)? = { binary, args in
         let task = Process()
         task.executableURL = URL(fileURLWithPath: binary)
@@ -48,9 +58,32 @@ enum TailscaleServe {
         } catch {
             return nil
         }
-        task.waitUntilExit()
+        let exited = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            task.waitUntilExit()
+            exited.signal()
+        }
+        if exited.wait(timeout: .now() + commandTimeout) == .timedOut {
+            task.terminate()
+            _ = exited.wait(timeout: .now() + 2)
+            _ = drained.wait(timeout: .now() + 2)
+            gavelLog("[review] tailscale \(args.first ?? "?") timed out after \(Int(commandTimeout))s — killed")
+            // Partial stdout still matters: the blocked serve prints the
+            // tailnet enable URL before waiting.
+            return (124, String(decoding: data, as: UTF8.self))
+        }
         drained.wait()
         return (task.terminationStatus, String(decoding: data, as: UTF8.self))
+    }
+
+    /// Test seam for socket discovery.
+    static var socketPaths: () -> [String] = {
+        let dir = "/var/run"
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: dir)) ?? []
+        return names
+            .filter { $0.hasPrefix("tailscaled") && $0.hasSuffix(".sock") }
+            .sorted()
+            .map { dir + "/" + $0 }
     }
 
     static func candidateBinaries() -> [String] {
@@ -65,30 +98,88 @@ enum TailscaleServe {
     /// or nil when no backend is running — callers fail soft by omitting
     /// the link; the approval itself is never affected.
     static func reviewBaseURL() -> String? {
-        let running = candidateBinaries().compactMap { binary -> Backend? in
-            guard let result = runner(binary, ["status", "--json"]), result.status == 0 else { return nil }
-            return backend(binary: binary, statusJSON: Data(result.stdout.utf8))
+        let binaries = candidateBinaries()
+        guard let cli = binaries.first else {
+            gavelLog("[review] no tailscale CLI installed — no review link")
+            return nil
         }
+
+        // Socket endpoints first: explicitly-configured daemons beat the
+        // GUI-discovery fallback when both are Running and phoneless.
+        var endpoints: [(binary: String, socketPath: String?)] =
+            socketPaths().map { (cli, $0) }
+        endpoints += binaries.map { ($0, nil) }
+
+        var running: [Backend] = []
+        for endpoint in endpoints {
+            let args = socketArgs(endpoint.socketPath) + ["status", "--json"]
+            guard let result = runner(endpoint.binary, args), result.status == 0,
+                  let backend = backend(
+                      binary: endpoint.binary, socketPath: endpoint.socketPath,
+                      statusJSON: Data(result.stdout.utf8)) else { continue }
+            // Default-discovery probes from different binaries can reach the
+            // same daemon — one entry per node is enough.
+            if !running.contains(where: { $0.host == backend.host }) {
+                running.append(backend)
+            }
+        }
+
         guard let chosen = running.first(where: { $0.hasOnlineIOSPeer }) ?? running.first else {
             gavelLog("[review] no running tailscale backend — no review link")
             return nil
         }
         if running.count > 1 {
-            gavelLog("[review] \(running.count) tailscale backends running — chose \(chosen.host) (\(chosen.binary), iOS peer online=\(chosen.hasOnlineIOSPeer))")
+            gavelLog("[review] \(running.count) tailscale backends running — chose \(chosen.host) (socket=\(chosen.socketPath ?? "default"), iOS peer online=\(chosen.hasOnlineIOSPeer))")
         }
+
         let target = "http://127.0.0.1:\(GavelConstants.reviewServerPort)"
-        guard let serve = runner(chosen.binary, ["serve", "--bg", "--https=\(GavelConstants.reviewTailnetHTTPSPort)", target]),
-              serve.status == 0 else {
-            gavelLog("[review] tailscale serve registration failed via \(chosen.binary)")
+        let serveArgs = socketArgs(chosen.socketPath)
+            + ["serve", "--bg", "--https=\(GavelConstants.reviewTailnetHTTPSPort)", target]
+        let serve = runner(chosen.binary, serveArgs)
+        guard let serve, serve.status == 0 else {
+            handleServeFailure(output: serve?.stdout ?? "")
             return nil
         }
         return "https://\(chosen.host):\(GavelConstants.reviewTailnetHTTPSPort)"
     }
 
+    private static func socketArgs(_ socketPath: String?) -> [String] {
+        socketPath.map { ["--socket=\($0)"] } ?? []
+    }
+
+    /// Tracks the one-time "enable Serve on your tailnet" notification so a
+    /// disabled tailnet doesn't ping the user on every commit.
+    private static var notifiedServeDisabled = false
+    private static let notifyLock = NSLock()
+
+    static func handleServeFailure(output: String) {
+        gavelLog("[review] tailscale serve registration failed")
+        guard let url = enableURL(fromServeOutput: output) else { return }
+        notifyLock.lock()
+        let alreadyNotified = notifiedServeDisabled
+        notifiedServeDisabled = true
+        notifyLock.unlock()
+        guard !alreadyNotified else { return }
+        GavelNotifications.notify(
+            title: "Gavel — enable Tailscale Serve",
+            body: "Phone diff review needs Serve enabled on your tailnet (one-time):\n\(url)"
+        )
+    }
+
+    /// Extracts the admin-console enable link from the CLI's "Serve is not
+    /// enabled on your tailnet" output.
+    static func enableURL(fromServeOutput output: String) -> String? {
+        guard output.contains("Serve is not enabled") else { return nil }
+        return output
+            .components(separatedBy: .whitespacesAndNewlines)
+            .first { $0.hasPrefix("https://login.tailscale.com/f/serve") }
+            ?? "https://login.tailscale.com"
+    }
+
     /// Parses `tailscale status --json` into a Backend. Nil unless the
     /// backend is actually Running — a stopped tailscaled still reports a
     /// DNSName but can't route.
-    static func backend(binary: String, statusJSON data: Data) -> Backend? {
+    static func backend(binary: String, socketPath: String?, statusJSON data: Data) -> Backend? {
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               root["BackendState"] as? String == "Running",
               let selfNode = root["Self"] as? [String: Any],
@@ -101,6 +192,6 @@ enum TailscaleServe {
         let hasPhone = peers.values.contains { peer in
             peer["OS"] as? String == "iOS" && peer["Online"] as? Bool == true
         }
-        return Backend(binary: binary, host: dns, hasOnlineIOSPeer: hasPhone)
+        return Backend(binary: binary, socketPath: socketPath, host: dns, hasOnlineIOSPeer: hasPhone)
     }
 }

--- a/Sources/Gavel/System/Constants.swift
+++ b/Sources/Gavel/System/Constants.swift
@@ -69,6 +69,10 @@ enum GavelConstants {
     /// tailnet reachability comes exclusively via `tailscale serve`.
     static let reviewServerPort: UInt16 = 48765
 
+    /// Tailnet-side HTTPS port for review links. Dedicated port so the serve
+    /// mapping never clobbers anything the user serves on 443.
+    static let reviewTailnetHTTPSPort: UInt16 = 8443
+
     /// Cap on a review verdict POST body.
     static let reviewMaxBodyBytes = 64 * 1024
 

--- a/Tests/GavelTests/FakeTelegramTransport.swift
+++ b/Tests/GavelTests/FakeTelegramTransport.swift
@@ -39,7 +39,7 @@ final class FakeTelegramTransport: TelegramTransport {
     var parkedUpdatesCompletion: ((Result<[TelegramUpdate], Error>) -> Void)?
 
     var lastCallbackData: [String] {
-        (sentMessages.last?.keyboard ?? []).flatMap { $0 }.map { $0.callbackData }
+        (sentMessages.last?.keyboard ?? []).flatMap { $0 }.compactMap { $0.callbackData }
     }
 
     var lastSentMessageId: Int { nextMessageId - 1 }

--- a/Tests/GavelTests/ReviewLinkButtonTests.swift
+++ b/Tests/GavelTests/ReviewLinkButtonTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+@testable import Gavel
+
+final class ReviewLinkButtonTests: XCTestCase {
+
+    private let owner: Int64 = 42
+
+    func testReviewURLLeadsKeyboardAsURLButton() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        let approval = ResolvableApproval { _ in }
+
+        bridge.notify(
+            resolvable: approval, text: "commit?", allowSession: nil,
+            offerCommentClean: true,
+            reviewURL: "https://mac.tail1234.ts.net:8443/review/abc123")
+
+        let keyboard = try! XCTUnwrap(fake.sentMessages.last?.keyboard)
+        let first = try! XCTUnwrap(keyboard.first?.first)
+        XCTAssertEqual(first.text, "🔍 Review diff")
+        XCTAssertEqual(first.url, "https://mac.tail1234.ts.net:8443/review/abc123")
+        XCTAssertNil(first.callbackData)
+
+        // Verdict buttons still present and callback-typed.
+        XCTAssertTrue(fake.lastCallbackData.contains { $0.hasPrefix("a:") })
+        XCTAssertTrue(fake.lastCallbackData.contains { $0.hasPrefix("d:") })
+        XCTAssertTrue(fake.lastCallbackData.contains { $0.hasPrefix("c:") })
+    }
+
+    func testNoReviewURLMeansNoURLButtons() {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        let approval = ResolvableApproval { _ in }
+
+        bridge.notify(resolvable: approval, text: "cmd?", allowSession: nil)
+
+        let keyboard = fake.sentMessages.last?.keyboard ?? []
+        XCTAssertTrue(keyboard.flatMap { $0 }.allSatisfy { $0.url == nil })
+    }
+}

--- a/Tests/GavelTests/TailscaleServeTests.swift
+++ b/Tests/GavelTests/TailscaleServeTests.swift
@@ -5,13 +5,17 @@ import XCTest
 final class TailscaleServeTests: XCTestCase {
 
     private var savedRunner: ((_ binary: String, _ args: [String]) -> (status: Int32, stdout: String)?)!
+    private var savedSockets: (() -> [String])!
 
-    override func setUp() {
+    override func setUpWithError() throws {
+        try XCTSkipIf(TailscaleServe.candidateBinaries().isEmpty, "no tailscale CLI installed")
         savedRunner = TailscaleServe.runner
+        savedSockets = TailscaleServe.socketPaths
     }
 
     override func tearDown() {
-        TailscaleServe.runner = savedRunner
+        if savedRunner != nil { TailscaleServe.runner = savedRunner }
+        if savedSockets != nil { TailscaleServe.socketPaths = savedSockets }
     }
 
     private func statusJSON(state: String, dns: String?, iosPeerOnline: Bool? = nil) -> String {
@@ -22,138 +26,181 @@ final class TailscaleServeTests: XCTestCase {
         return #"{"BackendState": "\#(state)", \#(selfBlock) \#(peerBlock) "Version": "1.98"}"#
     }
 
+    private func socketArg(in args: [String]) -> String? {
+        args.first { $0.hasPrefix("--socket=") }
+    }
+
     // MARK: - Status parsing
 
-    func testBackendStripsTrailingDot() {
+    func testBackendStripsTrailingDotAndKeepsSocket() {
         let backend = TailscaleServe.backend(
-            binary: "/bin/ts",
+            binary: "/bin/ts", socketPath: "/var/run/tailscaled-x.sock",
             statusJSON: Data(statusJSON(state: "Running", dns: "mac.tail1234.ts.net.").utf8))
         XCTAssertEqual(backend?.host, "mac.tail1234.ts.net")
+        XCTAssertEqual(backend?.socketPath, "/var/run/tailscaled-x.sock")
         XCTAssertEqual(backend?.hasOnlineIOSPeer, false)
     }
 
     func testStoppedBackendYieldsNil() {
         XCTAssertNil(TailscaleServe.backend(
-            binary: "/bin/ts",
+            binary: "/bin/ts", socketPath: nil,
             statusJSON: Data(statusJSON(state: "Stopped", dns: "mac.tail1234.ts.net.").utf8)))
     }
 
     func testMissingSelfOrGarbageYieldsNil() {
         XCTAssertNil(TailscaleServe.backend(
-            binary: "/bin/ts", statusJSON: Data(statusJSON(state: "Running", dns: nil).utf8)))
-        XCTAssertNil(TailscaleServe.backend(binary: "/bin/ts", statusJSON: Data("not json".utf8)))
+            binary: "/bin/ts", socketPath: nil,
+            statusJSON: Data(statusJSON(state: "Running", dns: nil).utf8)))
+        XCTAssertNil(TailscaleServe.backend(
+            binary: "/bin/ts", socketPath: nil, statusJSON: Data("not json".utf8)))
     }
 
     func testDetectsOnlineIOSPeer() {
         let online = TailscaleServe.backend(
-            binary: "/bin/ts",
+            binary: "/bin/ts", socketPath: nil,
             statusJSON: Data(statusJSON(state: "Running", dns: "a.ts.net.", iosPeerOnline: true).utf8))
         XCTAssertEqual(online?.hasOnlineIOSPeer, true)
 
         let offline = TailscaleServe.backend(
-            binary: "/bin/ts",
+            binary: "/bin/ts", socketPath: nil,
             statusJSON: Data(statusJSON(state: "Running", dns: "a.ts.net.", iosPeerOnline: false).utf8))
         XCTAssertEqual(offline?.hasOnlineIOSPeer, false)
     }
 
-    // MARK: - Backend choice + serve registration
+    // MARK: - Endpoint discovery + backend choice
 
-    /// Stub a fleet of backends: binary path → status JSON (or nil for "can't run").
-    /// Serve calls succeed and are recorded.
-    private func stubBackends(_ fleet: [String: String?], serveCalls: NSMutableArray) {
-        TailscaleServe.runner = { binary, args in
-            if args.first == "status" {
-                guard let json = fleet[binary] ?? nil else { return nil }
-                return (0, json)
+    /// The dogfood topology: GUI extension Stopped, custom-socket daemon
+    /// Running with the phone online. The socket endpoint must win, and
+    /// serve must be registered through the same socket.
+    func testCustomSocketDaemonChosenOverStoppedExtension() {
+        TailscaleServe.socketPaths = { ["/var/run/tailscaled-personal.sock"] }
+        var serveCalls: [[String]] = []
+        TailscaleServe.runner = { _, args in
+            if args.contains("--json") {
+                if self.socketArg(in: args) != nil {
+                    return (0, self.statusJSON(state: "Running", dns: "personal.tail2.ts.net.", iosPeerOnline: true))
+                }
+                return (0, self.statusJSON(state: "Stopped", dns: "work.tail1.ts.net."))
             }
-            serveCalls.add([binary] + args)
+            serveCalls.append(args)
             return (0, "")
         }
-    }
-
-    func testSingleRunningBackendIsUsed() {
-        let serveCalls = NSMutableArray()
-        // Only probe binaries that exist on this machine — candidateBinaries()
-        // filters by executability, so stub every candidate uniformly.
-        var fleet: [String: String?] = [:]
-        for (index, binary) in TailscaleServe.candidateBinaries().enumerated() {
-            fleet[binary] = index == 0
-                ? statusJSON(state: "Running", dns: "solo.tail1.ts.net.")
-                : statusJSON(state: "Stopped", dns: "other.tail2.ts.net.")
-        }
-        try? XCTSkipIf(fleet.isEmpty, "no tailscale binaries installed")
-        stubBackends(fleet, serveCalls: serveCalls)
 
         let base = TailscaleServe.reviewBaseURL()
-        XCTAssertEqual(base, "https://solo.tail1.ts.net:\(GavelConstants.reviewTailnetHTTPSPort)")
+        XCTAssertEqual(base, "https://personal.tail2.ts.net:\(GavelConstants.reviewTailnetHTTPSPort)")
         XCTAssertEqual(serveCalls.count, 1)
-        let call = serveCalls[0] as! [String]
-        XCTAssertEqual(Array(call.dropFirst()), [
+        XCTAssertEqual(socketArg(in: serveCalls[0]), "--socket=/var/run/tailscaled-personal.sock")
+        XCTAssertEqual(Array(serveCalls[0].dropFirst()), [
             "serve", "--bg",
             "--https=\(GavelConstants.reviewTailnetHTTPSPort)",
             "http://127.0.0.1:\(GavelConstants.reviewServerPort)",
         ])
     }
 
-    func testTwoRunningBackendsPrefersOnlineIOSPeer() throws {
-        let candidates = TailscaleServe.candidateBinaries()
-        try XCTSkipIf(candidates.count < 2, "needs two installed tailscale binaries")
-
-        let serveCalls = NSMutableArray()
-        var fleet: [String: String?] = [:]
-        // First candidate running but phoneless; second running WITH the phone.
-        fleet[candidates[0]] = statusJSON(state: "Running", dns: "work.tail1.ts.net.", iosPeerOnline: false)
-        fleet[candidates[1]] = statusJSON(state: "Running", dns: "personal.tail2.ts.net.", iosPeerOnline: true)
-        for extra in candidates.dropFirst(2) { fleet[extra] = nil }
-        stubBackends(fleet, serveCalls: serveCalls)
+    func testBothRunningPrefersBackendWithOnlineIOSPeer() {
+        TailscaleServe.socketPaths = { ["/var/run/tailscaled-personal.sock"] }
+        var serveCalls: [[String]] = []
+        TailscaleServe.runner = { _, args in
+            if args.contains("--json") {
+                if self.socketArg(in: args) != nil {
+                    return (0, self.statusJSON(state: "Running", dns: "personal.tail2.ts.net.", iosPeerOnline: false))
+                }
+                return (0, self.statusJSON(state: "Running", dns: "work.tail1.ts.net.", iosPeerOnline: true))
+            }
+            serveCalls.append(args)
+            return (0, "")
+        }
 
         let base = TailscaleServe.reviewBaseURL()
-        XCTAssertEqual(base, "https://personal.tail2.ts.net:\(GavelConstants.reviewTailnetHTTPSPort)")
-        // Serve must be registered through the SAME backend the URL points at.
-        XCTAssertEqual((serveCalls[0] as! [String]).first, candidates[1])
+        XCTAssertEqual(base, "https://work.tail1.ts.net:\(GavelConstants.reviewTailnetHTTPSPort)")
+        XCTAssertNil(socketArg(in: serveCalls[0]), "serve must go through the same (default) endpoint as the chosen backend")
     }
 
-    func testTwoRunningBackendsNoPhoneFallsBackToFirst() throws {
-        let candidates = TailscaleServe.candidateBinaries()
-        try XCTSkipIf(candidates.count < 2, "needs two installed tailscale binaries")
-
-        let serveCalls = NSMutableArray()
-        var fleet: [String: String?] = [:]
-        fleet[candidates[0]] = statusJSON(state: "Running", dns: "first.tail1.ts.net.", iosPeerOnline: false)
-        fleet[candidates[1]] = statusJSON(state: "Running", dns: "second.tail2.ts.net.", iosPeerOnline: false)
-        for extra in candidates.dropFirst(2) { fleet[extra] = nil }
-        stubBackends(fleet, serveCalls: serveCalls)
-
+    func testBothRunningNoPhoneFallsBackToSocketEndpoint() {
+        TailscaleServe.socketPaths = { ["/var/run/tailscaled-personal.sock"] }
+        TailscaleServe.runner = { _, args in
+            if args.contains("--json") {
+                if self.socketArg(in: args) != nil {
+                    return (0, self.statusJSON(state: "Running", dns: "personal.tail2.ts.net.", iosPeerOnline: false))
+                }
+                return (0, self.statusJSON(state: "Running", dns: "work.tail1.ts.net.", iosPeerOnline: false))
+            }
+            return (0, "")
+        }
+        // Socket endpoints are probed first, so with no phone anywhere the
+        // explicitly-configured daemon wins.
         XCTAssertEqual(
             TailscaleServe.reviewBaseURL(),
-            "https://first.tail1.ts.net:\(GavelConstants.reviewTailnetHTTPSPort)")
+            "https://personal.tail2.ts.net:\(GavelConstants.reviewTailnetHTTPSPort)")
+    }
+
+    func testSameNodeReachedTwiceIsDeduped() {
+        TailscaleServe.socketPaths = { [] }
+        var serveCalls = 0
+        // Every default-discovery probe (one per installed binary) reports
+        // the same node — must collapse to one backend, one serve call.
+        TailscaleServe.runner = { _, args in
+            if args.contains("--json") {
+                return (0, self.statusJSON(state: "Running", dns: "solo.tail1.ts.net.", iosPeerOnline: true))
+            }
+            serveCalls += 1
+            return (0, "")
+        }
+        XCTAssertEqual(
+            TailscaleServe.reviewBaseURL(),
+            "https://solo.tail1.ts.net:\(GavelConstants.reviewTailnetHTTPSPort)")
+        XCTAssertEqual(serveCalls, 1)
     }
 
     func testAllStoppedFailsSoft() {
-        let serveCalls = NSMutableArray()
-        var fleet: [String: String?] = [:]
-        for binary in TailscaleServe.candidateBinaries() {
-            fleet[binary] = statusJSON(state: "Stopped", dns: "x.ts.net.")
+        TailscaleServe.socketPaths = { ["/var/run/tailscaled-personal.sock"] }
+        var serveCalls = 0
+        TailscaleServe.runner = { _, args in
+            if args.contains("--json") {
+                return (0, self.statusJSON(state: "Stopped", dns: "x.ts.net."))
+            }
+            serveCalls += 1
+            return (0, "")
         }
-        stubBackends(fleet, serveCalls: serveCalls)
-
         XCTAssertNil(TailscaleServe.reviewBaseURL())
-        XCTAssertEqual(serveCalls.count, 0)
+        XCTAssertEqual(serveCalls, 0)
     }
 
-    func testServeRegistrationFailureFailsSoft() throws {
-        try XCTSkipIf(TailscaleServe.candidateBinaries().isEmpty, "no tailscale binaries installed")
+    func testServeFailureIncludingTimeoutFailsSoft() {
+        TailscaleServe.socketPaths = { [] }
         TailscaleServe.runner = { _, args in
-            if args.first == "status" {
+            if args.contains("--json") {
                 return (0, self.statusJSON(state: "Running", dns: "x.ts.net."))
             }
-            return (1, "")
+            // 124 is the runner's timeout status — the blocked "Serve is not
+            // enabled" interactive wait surfaces this way.
+            return (124, "Serve is not enabled on your tailnet.")
         }
         XCTAssertNil(TailscaleServe.reviewBaseURL())
     }
 
     func testNoRunnableBinariesFailsSoft() {
+        TailscaleServe.socketPaths = { [] }
         TailscaleServe.runner = { _, _ in nil }
         XCTAssertNil(TailscaleServe.reviewBaseURL())
+    }
+
+    // MARK: - Serve-disabled enable URL
+
+    func testEnableURLExtraction() {
+        let output = """
+
+        Serve is not enabled on your tailnet.
+        To enable, visit:
+
+        \thttps://login.tailscale.com/f/serve?node=nABC123CNTRL
+        """
+        XCTAssertEqual(
+            TailscaleServe.enableURL(fromServeOutput: output),
+            "https://login.tailscale.com/f/serve?node=nABC123CNTRL")
+        XCTAssertNil(TailscaleServe.enableURL(fromServeOutput: "some other failure"))
+        XCTAssertEqual(
+            TailscaleServe.enableURL(fromServeOutput: "Serve is not enabled on your tailnet."),
+            "https://login.tailscale.com")
     }
 }

--- a/Tests/GavelTests/TailscaleServeTests.swift
+++ b/Tests/GavelTests/TailscaleServeTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class TailscaleServeTests: XCTestCase {
 
-    private var savedRunner: ((_ args: [String]) -> (status: Int32, stdout: String)?)!
+    private var savedRunner: ((_ binary: String, _ args: [String]) -> (status: Int32, stdout: String)?)!
 
     override func setUp() {
         savedRunner = TailscaleServe.runner
@@ -14,61 +14,136 @@ final class TailscaleServeTests: XCTestCase {
         TailscaleServe.runner = savedRunner
     }
 
-    private func statusJSON(state: String, dns: String?) -> String {
+    private func statusJSON(state: String, dns: String?, iosPeerOnline: Bool? = nil) -> String {
         let selfBlock = dns.map { #""Self": {"DNSName": "\#($0)"},"# } ?? ""
-        return #"{"BackendState": "\#(state)", \#(selfBlock) "Version": "1.98"}"#
+        let peerBlock = iosPeerOnline.map {
+            #""Peer": {"nodekey:abc": {"OS": "iOS", "Online": \#($0)}, "nodekey:def": {"OS": "linux", "Online": true}},"#
+        } ?? ""
+        return #"{"BackendState": "\#(state)", \#(selfBlock) \#(peerBlock) "Version": "1.98"}"#
     }
 
     // MARK: - Status parsing
 
-    func testHostnameStripsTrailingDot() {
-        let host = TailscaleServe.hostname(
-            fromStatusJSON: Data(statusJSON(state: "Running", dns: "mac.tail1234.ts.net.").utf8))
-        XCTAssertEqual(host, "mac.tail1234.ts.net")
+    func testBackendStripsTrailingDot() {
+        let backend = TailscaleServe.backend(
+            binary: "/bin/ts",
+            statusJSON: Data(statusJSON(state: "Running", dns: "mac.tail1234.ts.net.").utf8))
+        XCTAssertEqual(backend?.host, "mac.tail1234.ts.net")
+        XCTAssertEqual(backend?.hasOnlineIOSPeer, false)
     }
 
-    func testStoppedBackendYieldsNoHostname() {
-        let host = TailscaleServe.hostname(
-            fromStatusJSON: Data(statusJSON(state: "Stopped", dns: "mac.tail1234.ts.net.").utf8))
-        XCTAssertNil(host)
+    func testStoppedBackendYieldsNil() {
+        XCTAssertNil(TailscaleServe.backend(
+            binary: "/bin/ts",
+            statusJSON: Data(statusJSON(state: "Stopped", dns: "mac.tail1234.ts.net.").utf8)))
     }
 
-    func testMissingSelfYieldsNoHostname() {
-        XCTAssertNil(TailscaleServe.hostname(
-            fromStatusJSON: Data(statusJSON(state: "Running", dns: nil).utf8)))
-        XCTAssertNil(TailscaleServe.hostname(fromStatusJSON: Data("not json".utf8)))
+    func testMissingSelfOrGarbageYieldsNil() {
+        XCTAssertNil(TailscaleServe.backend(
+            binary: "/bin/ts", statusJSON: Data(statusJSON(state: "Running", dns: nil).utf8)))
+        XCTAssertNil(TailscaleServe.backend(binary: "/bin/ts", statusJSON: Data("not json".utf8)))
     }
 
-    // MARK: - URL construction + serve registration
+    func testDetectsOnlineIOSPeer() {
+        let online = TailscaleServe.backend(
+            binary: "/bin/ts",
+            statusJSON: Data(statusJSON(state: "Running", dns: "a.ts.net.", iosPeerOnline: true).utf8))
+        XCTAssertEqual(online?.hasOnlineIOSPeer, true)
 
-    func testReviewBaseURLRegistersServeAndBuildsURL() {
-        var calls: [[String]] = []
-        let status = statusJSON(state: "Running", dns: "mac.tail1234.ts.net.")
-        TailscaleServe.runner = { args in
-            calls.append(args)
-            return args.first == "status" ? (0, status) : (0, "")
+        let offline = TailscaleServe.backend(
+            binary: "/bin/ts",
+            statusJSON: Data(statusJSON(state: "Running", dns: "a.ts.net.", iosPeerOnline: false).utf8))
+        XCTAssertEqual(offline?.hasOnlineIOSPeer, false)
+    }
+
+    // MARK: - Backend choice + serve registration
+
+    /// Stub a fleet of backends: binary path → status JSON (or nil for "can't run").
+    /// Serve calls succeed and are recorded.
+    private func stubBackends(_ fleet: [String: String?], serveCalls: NSMutableArray) {
+        TailscaleServe.runner = { binary, args in
+            if args.first == "status" {
+                guard let json = fleet[binary] ?? nil else { return nil }
+                return (0, json)
+            }
+            serveCalls.add([binary] + args)
+            return (0, "")
         }
+    }
+
+    func testSingleRunningBackendIsUsed() {
+        let serveCalls = NSMutableArray()
+        // Only probe binaries that exist on this machine — candidateBinaries()
+        // filters by executability, so stub every candidate uniformly.
+        var fleet: [String: String?] = [:]
+        for (index, binary) in TailscaleServe.candidateBinaries().enumerated() {
+            fleet[binary] = index == 0
+                ? statusJSON(state: "Running", dns: "solo.tail1.ts.net.")
+                : statusJSON(state: "Stopped", dns: "other.tail2.ts.net.")
+        }
+        try? XCTSkipIf(fleet.isEmpty, "no tailscale binaries installed")
+        stubBackends(fleet, serveCalls: serveCalls)
 
         let base = TailscaleServe.reviewBaseURL()
-        XCTAssertEqual(base, "https://mac.tail1234.ts.net:\(GavelConstants.reviewTailnetHTTPSPort)")
-        XCTAssertEqual(calls.count, 2)
-        XCTAssertEqual(calls[0], ["status", "--json"])
-        XCTAssertEqual(calls[1], [
+        XCTAssertEqual(base, "https://solo.tail1.ts.net:\(GavelConstants.reviewTailnetHTTPSPort)")
+        XCTAssertEqual(serveCalls.count, 1)
+        let call = serveCalls[0] as! [String]
+        XCTAssertEqual(Array(call.dropFirst()), [
             "serve", "--bg",
             "--https=\(GavelConstants.reviewTailnetHTTPSPort)",
             "http://127.0.0.1:\(GavelConstants.reviewServerPort)",
         ])
     }
 
-    func testStoppedTailscaleFailsSoft() {
-        TailscaleServe.runner = { args in
-            (0, args.first == "status" ? self.statusJSON(state: "Stopped", dns: "x.ts.net.") : "")
-        }
-        XCTAssertNil(TailscaleServe.reviewBaseURL())
+    func testTwoRunningBackendsPrefersOnlineIOSPeer() throws {
+        let candidates = TailscaleServe.candidateBinaries()
+        try XCTSkipIf(candidates.count < 2, "needs two installed tailscale binaries")
+
+        let serveCalls = NSMutableArray()
+        var fleet: [String: String?] = [:]
+        // First candidate running but phoneless; second running WITH the phone.
+        fleet[candidates[0]] = statusJSON(state: "Running", dns: "work.tail1.ts.net.", iosPeerOnline: false)
+        fleet[candidates[1]] = statusJSON(state: "Running", dns: "personal.tail2.ts.net.", iosPeerOnline: true)
+        for extra in candidates.dropFirst(2) { fleet[extra] = nil }
+        stubBackends(fleet, serveCalls: serveCalls)
+
+        let base = TailscaleServe.reviewBaseURL()
+        XCTAssertEqual(base, "https://personal.tail2.ts.net:\(GavelConstants.reviewTailnetHTTPSPort)")
+        // Serve must be registered through the SAME backend the URL points at.
+        XCTAssertEqual((serveCalls[0] as! [String]).first, candidates[1])
     }
 
-    func testServeRegistrationFailureFailsSoft() {
-        TailscaleServe.runner = { args in
+    func testTwoRunningBackendsNoPhoneFallsBackToFirst() throws {
+        let candidates = TailscaleServe.candidateBinaries()
+        try XCTSkipIf(candidates.count < 2, "needs two installed tailscale binaries")
+
+        let serveCalls = NSMutableArray()
+        var fleet: [String: String?] = [:]
+        fleet[candidates[0]] = statusJSON(state: "Running", dns: "first.tail1.ts.net.", iosPeerOnline: false)
+        fleet[candidates[1]] = statusJSON(state: "Running", dns: "second.tail2.ts.net.", iosPeerOnline: false)
+        for extra in candidates.dropFirst(2) { fleet[extra] = nil }
+        stubBackends(fleet, serveCalls: serveCalls)
+
+        XCTAssertEqual(
+            TailscaleServe.reviewBaseURL(),
+            "https://first.tail1.ts.net:\(GavelConstants.reviewTailnetHTTPSPort)")
+    }
+
+    func testAllStoppedFailsSoft() {
+        let serveCalls = NSMutableArray()
+        var fleet: [String: String?] = [:]
+        for binary in TailscaleServe.candidateBinaries() {
+            fleet[binary] = statusJSON(state: "Stopped", dns: "x.ts.net.")
+        }
+        stubBackends(fleet, serveCalls: serveCalls)
+
+        XCTAssertNil(TailscaleServe.reviewBaseURL())
+        XCTAssertEqual(serveCalls.count, 0)
+    }
+
+    func testServeRegistrationFailureFailsSoft() throws {
+        try XCTSkipIf(TailscaleServe.candidateBinaries().isEmpty, "no tailscale binaries installed")
+        TailscaleServe.runner = { _, args in
             if args.first == "status" {
                 return (0, self.statusJSON(state: "Running", dns: "x.ts.net."))
             }
@@ -77,8 +152,8 @@ final class TailscaleServeTests: XCTestCase {
         XCTAssertNil(TailscaleServe.reviewBaseURL())
     }
 
-    func testMissingBinaryFailsSoft() {
-        TailscaleServe.runner = { _ in nil }
+    func testNoRunnableBinariesFailsSoft() {
+        TailscaleServe.runner = { _, _ in nil }
         XCTAssertNil(TailscaleServe.reviewBaseURL())
     }
 }

--- a/Tests/GavelTests/TailscaleServeTests.swift
+++ b/Tests/GavelTests/TailscaleServeTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+
+@testable import Gavel
+
+final class TailscaleServeTests: XCTestCase {
+
+    private var savedRunner: ((_ args: [String]) -> (status: Int32, stdout: String)?)!
+
+    override func setUp() {
+        savedRunner = TailscaleServe.runner
+    }
+
+    override func tearDown() {
+        TailscaleServe.runner = savedRunner
+    }
+
+    private func statusJSON(state: String, dns: String?) -> String {
+        let selfBlock = dns.map { #""Self": {"DNSName": "\#($0)"},"# } ?? ""
+        return #"{"BackendState": "\#(state)", \#(selfBlock) "Version": "1.98"}"#
+    }
+
+    // MARK: - Status parsing
+
+    func testHostnameStripsTrailingDot() {
+        let host = TailscaleServe.hostname(
+            fromStatusJSON: Data(statusJSON(state: "Running", dns: "mac.tail1234.ts.net.").utf8))
+        XCTAssertEqual(host, "mac.tail1234.ts.net")
+    }
+
+    func testStoppedBackendYieldsNoHostname() {
+        let host = TailscaleServe.hostname(
+            fromStatusJSON: Data(statusJSON(state: "Stopped", dns: "mac.tail1234.ts.net.").utf8))
+        XCTAssertNil(host)
+    }
+
+    func testMissingSelfYieldsNoHostname() {
+        XCTAssertNil(TailscaleServe.hostname(
+            fromStatusJSON: Data(statusJSON(state: "Running", dns: nil).utf8)))
+        XCTAssertNil(TailscaleServe.hostname(fromStatusJSON: Data("not json".utf8)))
+    }
+
+    // MARK: - URL construction + serve registration
+
+    func testReviewBaseURLRegistersServeAndBuildsURL() {
+        var calls: [[String]] = []
+        let status = statusJSON(state: "Running", dns: "mac.tail1234.ts.net.")
+        TailscaleServe.runner = { args in
+            calls.append(args)
+            return args.first == "status" ? (0, status) : (0, "")
+        }
+
+        let base = TailscaleServe.reviewBaseURL()
+        XCTAssertEqual(base, "https://mac.tail1234.ts.net:\(GavelConstants.reviewTailnetHTTPSPort)")
+        XCTAssertEqual(calls.count, 2)
+        XCTAssertEqual(calls[0], ["status", "--json"])
+        XCTAssertEqual(calls[1], [
+            "serve", "--bg",
+            "--https=\(GavelConstants.reviewTailnetHTTPSPort)",
+            "http://127.0.0.1:\(GavelConstants.reviewServerPort)",
+        ])
+    }
+
+    func testStoppedTailscaleFailsSoft() {
+        TailscaleServe.runner = { args in
+            (0, args.first == "status" ? self.statusJSON(state: "Stopped", dns: "x.ts.net.") : "")
+        }
+        XCTAssertNil(TailscaleServe.reviewBaseURL())
+    }
+
+    func testServeRegistrationFailureFailsSoft() {
+        TailscaleServe.runner = { args in
+            if args.first == "status" {
+                return (0, self.statusJSON(state: "Running", dns: "x.ts.net."))
+            }
+            return (1, "")
+        }
+        XCTAssertNil(TailscaleServe.reviewBaseURL())
+    }
+
+    func testMissingBinaryFailsSoft() {
+        TailscaleServe.runner = { _ in nil }
+        XCTAssertNil(TailscaleServe.reviewBaseURL())
+    }
+}


### PR DESCRIPTION
Part 2 of the phone pre-commit review feature — wires the engine from #193 into the live approval flow. Stacked on #193; retarget to main after it merges.

## What

- **Coordinator wiring** — `maybeSendRemote` reuses the existing `isCommit` seam: on a commit approval in a phone-enabled session it snapshots the diff (`DiffCapture`), registers a review with `DiffReviewServer`, and passes the tailnet URL to the bridge. Runs only when the credential gate hasn't withheld the command (same gating as the clean-comments button).
- **TailscaleServe** — discovers the CLI (homebrew/usr-local/app bundle), reads `status --json` (MagicDNS name, `BackendState == Running`, trailing-dot strip), and registers `tailscale serve --bg --https=8443 http://127.0.0.1:48765`. Dedicated HTTPS port so it never clobbers a user serve config on 443. Registration re-runs per review (idempotent, ~50ms) so a `tailscale serve reset` between commits can't leave stale links. Serve only — never funnel.
- **Telegram URL button** — `TelegramButton` gains a `url` variant (Bot API: exactly one of `callback_data`/`url`). The 🔍 Review diff button leads the keyboard; all existing verdict buttons unchanged.
- **Fail-soft everywhere** — tailscale stopped or missing, empty diff (`--amend` reword), or server start failure just omit the button; the approval itself is never blocked or degraded.
- README: new "Phone Pre-Commit Review" section.

## Tests

9 new tests: status-JSON parsing (running/stopped/missing-Self/garbage), serve registration arg contract + URL construction, all three fail-soft paths, and bridge keyboard assertions (URL button leads, verdict buttons intact, no URL buttons without a link). Full suite green except the pre-existing `ProcessTreeTests` live-environment failure (fails identically on main).

## Live E2E (deferred to dogfood)

Per the plan file: `just dev-daemon`, Phone toggle on, synthesized commit approval, phone on cell network — review → request changes → verify the deny reason lands in the transcript; race and tailscale-down cases. Note: tailscaled is currently *stopped* on the dev Mac, so the fail-soft path is the one that fires until it's started.