### PR TITLE
feat(approval): tell the agent when the diff was reviewed before approval

### DIFF
--- a/Sources/Gavel/Approval/ResolvableApproval.swift
+++ b/Sources/Gavel/Approval/ResolvableApproval.swift
@@ -8,11 +8,15 @@ final class ResolvableApproval {
 
     private let lock = NSLock()
     private var resolved = false
-    private let sink: (Decision) -> Void
+    /// Hands the winning Decision back to the blocked approval worker — the
+    /// closure `requestApproval` passes in to capture the result and signal
+    /// its semaphore.
+    private let deliverDecision: (Decision) -> Void
     private var onResolved: [(Source, Decision) -> Void] = []
+    private var transforms: [(Decision, Source) -> Decision] = []
 
-    init(sink: @escaping (Decision) -> Void) {
-        self.sink = sink
+    init(deliverDecision: @escaping (Decision) -> Void) {
+        self.deliverDecision = deliverDecision
     }
 
     var isResolved: Bool {
@@ -27,8 +31,18 @@ final class ResolvableApproval {
         onResolved.append(hook)
     }
 
-    /// Returns true iff this call won the race. The sink and every cleanup hook
-    /// fire exactly once, on the winning caller's thread.
+    /// Register a transform applied to the winning Decision before it is
+    /// delivered — this is how state known only to one responder (e.g. the
+    /// review page was opened) can decorate a resolution won by a different
+    /// responder. Skipped if already resolved.
+    func addDecisionTransform(_ transform: @escaping (Decision, Source) -> Decision) {
+        lock.lock(); defer { lock.unlock() }
+        guard !resolved else { return }
+        transforms.append(transform)
+    }
+
+    /// Returns true iff this call won the race. The decision is delivered and
+    /// every cleanup hook fires exactly once, on the winning caller's thread.
     @discardableResult
     func resolve(_ decision: Decision, from source: Source) -> Bool {
         lock.lock()
@@ -38,11 +52,14 @@ final class ResolvableApproval {
         }
         resolved = true
         let hooks = onResolved
+        let pendingTransforms = transforms
         onResolved = []
+        transforms = []
         lock.unlock()
 
-        sink(decision)
-        for hook in hooks { hook(source, decision) }
+        let final = pendingTransforms.reduce(decision) { $1($0, source) }
+        deliverDecision(final)
+        for hook in hooks { hook(source, final) }
         return true
     }
 }

--- a/Sources/Gavel/Models/Decision.swift
+++ b/Sources/Gavel/Models/Decision.swift
@@ -40,6 +40,21 @@ struct Decision: Codable {
         self.nonSuppressible = nonSuppressible
     }
 
+    /// Copy of this decision with `line` appended to additionalContext
+    /// (newline-joined; becomes the whole context when none was set).
+    func appendingContext(_ line: String) -> Decision {
+        let merged: String
+        if let ctx = additionalContext, !ctx.isEmpty {
+            merged = ctx + "\n" + line
+        } else {
+            merged = line
+        }
+        return Decision(
+            verdict: verdict, reason: reason, additionalContext: merged,
+            updatedInput: updatedInput, askUser: askUser,
+            triggeringRuleId: triggeringRuleId, nonSuppressible: nonSuppressible)
+    }
+
     /// Internal protocol JSON sent to the gavel-hook shim via socket.
     var hookResponse: String {
         switch verdict {

--- a/Sources/Gavel/Review/DiffReviewServer.swift
+++ b/Sources/Gavel/Review/DiffReviewServer.swift
@@ -35,6 +35,11 @@ final class DiffReviewServer {
         /// Set (under the server lock) once any source resolves the approval.
         var resolvedBy: ResolvableApproval.Source?
         var resolvedAt: Date?
+        /// Set (under the server lock) on the first GET of the still-pending
+        /// review page — the evidence that a human actually opened the diff.
+        /// GETs after resolution serve the "already resolved" page and never
+        /// set this, so it can't be back-filled once the race is over.
+        var viewedAt: Date?
 
         init(nonce: String, content: ReviewContent, resolvable: ResolvableApproval) {
             self.nonce = nonce
@@ -136,6 +141,22 @@ final class DiffReviewServer {
             session.resolvedAt = Date()
             self.lock.unlock()
         }
+        // Reviewed-and-approved vs approved-on-trust: when the review page
+        // was opened before the approval resolved, tell the agent — whichever
+        // responder (Mac panel / Telegram / web) wins the race.
+        resolvable.addDecisionTransform { [weak self] decision, _ in
+            guard let self, decision.verdict == .allow else { return decision }
+            self.lock.lock()
+            let viewed = session.viewedAt != nil
+            self.lock.unlock()
+            guard viewed else { return decision }
+            gavelLog("[review] reviewed-signal attached nonce=\(nonce.prefix(8))…")
+            // Standalone form when there's no note; appended line otherwise.
+            let hasNote = !(decision.additionalContext?.isEmpty ?? true)
+            return decision.appendingContext(hasNote
+                ? "User reviewed the diff before approving."
+                : "User approved this via Gavel — user reviewed the diff before approving")
+        }
         return nonce
     }
 
@@ -209,12 +230,15 @@ final class DiffReviewServer {
             }
             lock.lock()
             let resolvedBy = session.resolvedBy
+            let firstView = resolvedBy == nil && session.viewedAt == nil
+            if firstView { session.viewedAt = Date() }
             lock.unlock()
-            if let resolvedBy {
-                send(connection, status: 200, body: DiffHTML.resolvedPage(by: label(resolvedBy)), contentType: "text/html; charset=utf-8")
-            } else {
-                send(connection, status: 200, body: DiffHTML.page(content: session.content), contentType: "text/html; charset=utf-8")
+            if firstView {
+                gavelLog("[review] page viewed nonce=\(session.nonce.prefix(8))…")
             }
+            let page = resolvedBy.map { DiffHTML.resolvedPage(by: label($0)) }
+                ?? DiffHTML.page(content: session.content)
+            send(connection, status: 200, body: page, contentType: "text/html; charset=utf-8")
             return
         }
 

--- a/Tests/GavelTests/DiffReviewServerTests.swift
+++ b/Tests/GavelTests/DiffReviewServerTests.swift
@@ -195,6 +195,78 @@ final class DiffReviewServerTests: XCTestCase {
         XCTAssertTrue(page.body.contains("Mac panel"))
     }
 
+    // MARK: - Reviewed signal
+
+    func testViewedPageThenMacAllowCarriesReviewedSignal() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(content: makeContent(), resolvable: resolvable)
+
+        _ = try request("/review/\(nonce)")
+        resolvable.resolve(Decision(verdict: .allow, reason: "User approved"), from: .mac)
+
+        let d = try XCTUnwrap(decision)
+        XCTAssertEqual(
+            d.additionalContext,
+            "User approved this via Gavel — user reviewed the diff before approving")
+    }
+
+    func testMacAllowWithoutViewHasNoReviewedSignal() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        _ = server.register(content: makeContent(), resolvable: resolvable)
+
+        resolvable.resolve(Decision(verdict: .allow, reason: "User approved"), from: .mac)
+
+        let d = try XCTUnwrap(decision)
+        XCTAssertNil(d.additionalContext, "approved-on-trust must not claim a review")
+    }
+
+    func testReviewedSignalAppendsToExistingNote() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(content: makeContent(), resolvable: resolvable)
+
+        _ = try request("/review/\(nonce)")
+        resolvable.resolve(
+            Decision(
+                verdict: .allow, reason: "User approved",
+                additionalContext: "User approved this via Gavel — commit gate"),
+            from: .telegram)
+
+        let ctx = try XCTUnwrap(decision?.additionalContext)
+        XCTAssertTrue(ctx.hasPrefix("User approved this via Gavel — commit gate"))
+        XCTAssertTrue(ctx.hasSuffix("User reviewed the diff before approving."))
+    }
+
+    func testWebApproveAfterViewCarriesReviewedSignal() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(content: makeContent(), resolvable: resolvable)
+
+        _ = try request("/review/\(nonce)")
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"approve"}"#)
+        XCTAssertEqual(res.status, 200)
+
+        let d = try XCTUnwrap(decision)
+        XCTAssertEqual(d.verdict, .allow)
+        XCTAssertEqual(
+            d.additionalContext,
+            "User approved this via Gavel — user reviewed the diff before approving")
+    }
+
+    func testViewedPageThenDenyGetsNoSignal() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(content: makeContent(), resolvable: resolvable)
+
+        _ = try request("/review/\(nonce)")
+        resolvable.resolve(Decision(verdict: .block, reason: "User denied"), from: .mac)
+
+        let d = try XCTUnwrap(decision)
+        XCTAssertNil(d.additionalContext)
+    }
+
     // MARK: - Credential withholding
 
     func testHunkWithKnownSecretIsWithheld() throws {

--- a/Tests/GavelTests/ResolvableApprovalTests.swift
+++ b/Tests/GavelTests/ResolvableApprovalTests.swift
@@ -34,6 +34,32 @@ final class ResolvableApprovalTests: XCTestCase {
         XCTAssertTrue(approval.isResolved)
     }
 
+    func testDecisionTransformDecoratesWinningDecision() {
+        var sunk: [Decision] = []
+        let approval = ResolvableApproval { sunk.append($0) }
+        var cleanupDecisions: [Decision] = []
+        approval.addDecisionTransform { decision, _ in
+            decision.appendingContext("reviewed")
+        }
+        approval.addCleanup { _, decision in cleanupDecisions.append(decision) }
+
+        approval.resolve(Decision(verdict: .allow, reason: "panel"), from: .mac)
+
+        XCTAssertEqual(sunk.first?.additionalContext, "reviewed")
+        XCTAssertEqual(cleanupDecisions.first?.additionalContext, "reviewed",
+                       "cleanup hooks must see the transformed decision")
+    }
+
+    func testDecisionTransformAfterResolutionIsIgnored() {
+        var sunk: [Decision] = []
+        let approval = ResolvableApproval { sunk.append($0) }
+        approval.resolve(Decision(verdict: .allow, reason: nil), from: .mac)
+        approval.addDecisionTransform { decision, _ in
+            decision.appendingContext("too late")
+        }
+        XCTAssertNil(sunk.first?.additionalContext)
+    }
+
     func testConcurrentResolveYieldsExactlyOneWinner() {
         let approval = ResolvableApproval { _ in }
         let winners = NSMutableArray()


### PR DESCRIPTION
## What

When Gavel's diff-review page was opened before a commit approval resolved, the allow's `additionalContext` now carries a reviewed-signal so the agent can distinguish *reviewed-and-approved* from *approved-on-trust*:

> User approved this via Gavel — user reviewed the diff before approving

(Appended as `User reviewed the diff before approving.` when a note or web-review comments already occupy the context.)

## Why

The diff review was invisible to the agent — it only saw the git command succeed, and would mischaracterize human-reviewed changes as shipped unreviewed.

## How

- `ReviewSession.viewedAt` is set on the first GET of a still-pending review page. Post-resolution GETs serve the resolved page and never set it, so a review can't be marked viewed after the fact.
- New `ResolvableApproval.addDecisionTransform` decorates the winning Decision before delivery, whichever responder wins the race — Mac panel, Telegram Allow button, or the review page's own approve. Registered by `DiffReviewServer.register` alongside the existing cleanup hook.
- Deny verdicts and unviewed reviews are untouched: a false "reviewed" claim is worse than none. The page is tailnet-only and button URLs aren't prefetched by Telegram clients, so a GET means a human opened it.
- Review feedback folded in: `ResolvableApproval.sink` renamed to `deliverDecision`; branchy GET route and transform flattened.

## Testing

- 7 new unit tests (transform semantics on `ResolvableApproval`; viewed/unviewed × mac/telegram/web/deny on `DiffReviewServer`). Full suite: 735 tests, 1 pre-existing environment-dependent failure (`testLiveClaudeSessionDiscoveryAgainstPsWitness`, fails identically on clean main).
- Live E2E via dev-daemon swap: real commit approvals from a phone-enabled session. Signal delivered into the agent session for review-page approve (with and without notes) and for Telegram-button allow after viewing (log: `page viewed` 7–46s after link creation, human-scale). Approvals without a page view carried no signal.