### PR TITLE
feat(matcher): per-argument scoping for MCP allow rules

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -19,7 +19,7 @@ final class ApprovalCoordinator: ObservableObject {
             updatedInput: [String: AnyCodable]?)
         case denyPatternForSession(pattern: String, explanation: String?)
         case alwaysDenyPattern(pattern: String, isRegex: Bool, explanation: String?)
-        case alwaysAllowPattern(pattern: String, isRegex: Bool)
+        case alwaysAllowPattern(pattern: String, isRegex: Bool, argConditions: [String: String]?)
         case alwaysPromptPattern(pattern: String, isRegex: Bool)
         case allowSiteForSession(domain: String, context: String?)
 
@@ -363,17 +363,19 @@ final class ApprovalCoordinator: ObservableObject {
             if let e = explText { reason += " — \(e)" }
             current.respond(Decision(verdict: .block, reason: reason))
 
-        case .alwaysAllowPattern(let pattern, let isRegex):
+        case .alwaysAllowPattern(let pattern, let isRegex, let argConditions):
             ctx = nil
             updated = nil
             let sanitized = Self.sanitizeDashes(pattern)
             let rule = PersistentRule(
                 toolName: current.payload.toolName, pattern: sanitized, isRegex: isRegex,
-                verdict: .allow)
+                verdict: .allow, argConditions: argConditions)
             ruleStore?.addRule(rule, origin: "approval-panel:always-allow")
             current.respond(
                 Decision(
-                    verdict: .allow, reason: "Always allow: \(current.payload.toolName): \(pattern)"
+                    // rule.name carries the arg-condition suffix, so a scoped
+                    // allow reads back to the agent as scoped, not blanket.
+                    verdict: .allow, reason: "Always allow: \(rule.name)"
                 ))
 
         case .alwaysPromptPattern(let pattern, let isRegex):

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -68,6 +68,11 @@ struct ApprovalPanelView: View {
     @State private var editedCommand: String = ""
     @State private var editedFields: [String: String] = [:]
     @State private var isRegexMode: Bool = false
+    /// Args ticked to scope an Always Allow to the call's argument values
+    /// (MCP calls only). Patterns are editable regexes, prefilled with the
+    /// escaped current value; unticked args don't constrain the rule.
+    @State private var scopedArgs: Set<String> = []
+    @State private var scopedArgPatterns: [String: String] = [:]
     /// Minimized to a compact bar so the user can read the code/diff behind it.
     @State private var isCollapsed: Bool = false
 
@@ -217,7 +222,28 @@ struct ApprovalPanelView: View {
             let autoOn = a.session.isAutoApproveEnabled || a.session.isAutoApproveActive
             noteState.reset(seededText: seeded, defaultSend: autoOn)
             isRegexMode = false
+            scopedArgs = []
+            scopedArgPatterns = Dictionary(uniqueKeysWithValues: scopableArgs(a).map {
+                ($0.name, NSRegularExpression.escapedPattern(for: $0.value))
+            })
         }
+    }
+
+    /// Scalar args of a pending MCP call, offered as Always Allow scope rows.
+    private func scopableArgs(_ approval: ApprovalCoordinator.PendingApproval) -> [(name: String, value: String)] {
+        guard approval.payload.toolName.hasPrefix("mcp__") else { return [] }
+        return approval.payload.toolInput
+            .compactMap { key, val in PersistentRule.scalarString(val).map { (name: key, value: $0) } }
+            .sorted { $0.name < $1.name }
+    }
+
+    private var selectedArgConditions: [String: String]? {
+        let conditions = scopedArgs.reduce(into: [String: String]()) { acc, arg in
+            if let p = scopedArgPatterns[arg], !p.trimmingCharacters(in: .whitespaces).isEmpty {
+                acc[arg] = p
+            }
+        }
+        return conditions.isEmpty ? nil : conditions
     }
 
     // MARK: - Header
@@ -499,6 +525,48 @@ struct ApprovalPanelView: View {
         .padding(.vertical, 6)
     }
 
+    // MARK: - Arg Scoping (MCP Always Allow)
+
+    @ViewBuilder
+    private func argScopeSection(_ args: [(name: String, value: String)]) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Scope Always Allow to argument values (regex, must fully match — absent arg won't match)")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+            ForEach(args, id: \.name) { arg in
+                HStack(spacing: 6) {
+                    Toggle(isOn: Binding(
+                        get: { scopedArgs.contains(arg.name) },
+                        set: { on in
+                            if on { scopedArgs.insert(arg.name) } else { scopedArgs.remove(arg.name) }
+                        }
+                    )) {
+                        Text(arg.name)
+                            .font(.system(.caption, design: .monospaced))
+                    }
+                    .toggleStyle(.checkbox)
+                    .frame(width: 140, alignment: .leading)
+
+                    Text("=")
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundColor(.secondary)
+
+                    TextField("regex", text: Binding(
+                        get: { scopedArgPatterns[arg.name] ?? "" },
+                        set: { scopedArgPatterns[arg.name] = $0 }
+                    ))
+                    .font(.system(.caption, design: .monospaced))
+                    .textFieldStyle(.roundedBorder)
+                    .disabled(!scopedArgs.contains(arg.name))
+                    .opacity(scopedArgs.contains(arg.name) ? 1 : 0.5)
+                }
+            }
+        }
+        .padding(6)
+        .background(Color.blue.opacity(0.05))
+        .cornerRadius(6)
+    }
+
     // MARK: - Action Bar
 
     @ViewBuilder
@@ -551,6 +619,16 @@ struct ApprovalPanelView: View {
             // Live pattern tester
             patternTester(approval)
 
+            // Arg-scope rows: narrow an Always Allow to specific MCP argument
+            // values (e.g. only this channel + workspace). Hidden for
+            // Allow-once-only approvals, which get no durable allow at all.
+            if !approval.nonSuppressible {
+                let args = scopableArgs(approval)
+                if !args.isEmpty {
+                    argScopeSection(args)
+                }
+            }
+
             // Persistent + session rules row
             HStack(spacing: 6) {
                 Button(action: {
@@ -565,9 +643,9 @@ struct ApprovalPanelView: View {
                 // Durable-allow controls are hidden for Allow-once-only (guardrail-mutation) paths.
                 if !approval.nonSuppressible {
                     Button(action: {
-                        coordinator.handleAction(.alwaysAllowPattern(pattern: sessionPattern, isRegex: isRegexMode), on: sessionPanel)
+                        coordinator.handleAction(.alwaysAllowPattern(pattern: sessionPattern, isRegex: isRegexMode, argConditions: selectedArgConditions), on: sessionPanel)
                     }) {
-                        Label("Always Allow", systemImage: "shield.checkered")
+                        Label(selectedArgConditions == nil ? "Always Allow" : "Always Allow (scoped)", systemImage: "shield.checkered")
                     }
                     .buttonStyle(.bordered)
                     .tint(.blue)

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -59,7 +59,7 @@ final class RuleStore: ObservableObject {
 
     func evaluateDeny(payload: PreToolUsePayload) -> Decision? {
         for i in rules.indices where rules[i].verdict == .block && !rules[i].isDisabled {
-            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
+            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath, toolInput: payload.toolInput) {
                 var reason = "Always deny: \(rules[i].name)"
                 if let explanation = rules[i].explanation, !explanation.isEmpty {
                     reason += " — \(explanation)"
@@ -72,7 +72,7 @@ final class RuleStore: ObservableObject {
 
     func evaluateAllow(payload: PreToolUsePayload) -> Decision? {
         for i in rules.indices where rules[i].verdict == .allow && !rules[i].isDisabled {
-            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
+            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath, toolInput: payload.toolInput) {
                 return Decision(verdict: .allow, reason: "Always allow: \(rules[i].name)")
             }
         }
@@ -82,7 +82,7 @@ final class RuleStore: ObservableObject {
     /// User-created prompt rules — high priority, checked before allow rules.
     func evaluateUserPrompt(payload: PreToolUsePayload) -> Decision? {
         for i in rules.indices where rules[i].verdict == .prompt && !rules[i].builtIn && !rules[i].isDisabled {
-            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
+            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath, toolInput: payload.toolInput) {
                 return Decision(verdict: .block, reason: "Always prompt: \(rules[i].name)", askUser: true, triggeringRuleId: rules[i].id)
             }
         }
@@ -92,7 +92,7 @@ final class RuleStore: ObservableObject {
     /// Overridable built-in prompt rules (MCP exfil defaults, infra-apply, scheduler), checked after allow rules so a user allow rule can override.
     func evaluateBuiltInPrompt(payload: PreToolUsePayload) -> Decision? {
         for i in rules.indices where rules[i].verdict == .prompt && rules[i].builtIn && rules[i].overridable && !rules[i].isDisabled {
-            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
+            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath, toolInput: payload.toolInput) {
                 return Decision(verdict: .block, reason: "Default rule: \(rules[i].name)", askUser: true, triggeringRuleId: rules[i].id)
             }
         }
@@ -103,7 +103,7 @@ final class RuleStore: ObservableObject {
     /// checked BEFORE allow rules so a broad allow rule can't silence the checkpoint.
     func evaluateBuiltInPromptNonOverridable(payload: PreToolUsePayload) -> Decision? {
         for i in rules.indices where rules[i].verdict == .prompt && rules[i].builtIn && !rules[i].overridable && !rules[i].isDisabled {
-            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath) {
+            if rules[i].matches(toolName: payload.toolName, command: payload.command, filePath: payload.filePath, toolInput: payload.toolInput) {
                 return Decision(verdict: .block, reason: "Checkpoint: \(rules[i].name)", askUser: true, triggeringRuleId: rules[i].id, nonSuppressible: rules[i].nonSuppressible)
             }
         }
@@ -141,12 +141,12 @@ final class RuleStore: ObservableObject {
         audit(action: "rule_removed", origin: origin, rule: rule)
     }
 
-    func updateRule(id: UUID, pattern: String, isRegex: Bool, verdict: DecisionVerdict, explanation: String?, origin: String = "panel") {
+    func updateRule(id: UUID, pattern: String, isRegex: Bool, verdict: DecisionVerdict, explanation: String?, argConditions: [String: String]? = nil, origin: String = "panel") {
         guard let idx = rules.firstIndex(where: { $0.id == id }) else { return }
         let old = rules[idx]
         rules[idx] = PersistentRule(
             replacing: old, pattern: pattern, isRegex: isRegex,
-            verdict: verdict, explanation: explanation
+            verdict: verdict, explanation: explanation, argConditions: argConditions
         )
         saveRules()
         audit(action: "rule_updated", origin: origin, rule: rules[idx],
@@ -154,6 +154,14 @@ final class RuleStore: ObservableObject {
     }
 
     private func audit(action: String, origin: String, rule: PersistentRule, detail: String? = nil) {
+        // Arg-scoped rules record their conditions so the journal shows the
+        // narrowed form, not what looks like a blanket allow.
+        var detail = detail
+        if let conditions = rule.argConditions, !conditions.isEmpty {
+            let scope = conditions.sorted { $0.key < $1.key }
+                .map { "\($0.key)=/\($0.value)/" }.joined(separator: ", ")
+            detail = [detail, "args: \(scope)"].compactMap { $0 }.joined(separator: " · ")
+        }
         auditLog?.record(
             action: action, origin: origin,
             toolName: rule.toolName, pattern: rule.pattern,
@@ -617,9 +625,18 @@ struct PersistentRule: Codable, Identifiable {
     /// surfaces in the UI rather than silently re-engaging on reboot). Toggle
     /// from the Rules tab; defaults to false (rule active).
     var isDisabled: Bool
+    /// Per-argument conditions (arg name → regex) narrowing when this rule fires,
+    /// e.g. scoping an MCP allow to `channel` values in an allowlist. Each regex is
+    /// full-string anchored at match time and EVERY condition must match; an absent
+    /// arg fails closed. Allow rules only — on a deny/prompt rule conditions would
+    /// narrow the guard (a loosening), so both inits and the decoder drop them
+    /// unless verdict == .allow. Tighten-only: conditions can only shrink an allow.
+    let argConditions: [String: String]?
 
     /// Pre-compiled regex (rebuilt on first access, not persisted).
     private var _compiledRegex: NSRegularExpression?
+    /// Pre-compiled anchored arg-condition regexes (rebuilt on first use, not persisted).
+    private var _compiledArgRegexes: [String: NSRegularExpression] = [:]
     var compiledRegex: NSRegularExpression? {
         mutating get {
             if _compiledRegex == nil {
@@ -630,7 +647,7 @@ struct PersistentRule: Codable, Identifiable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, toolName, pattern, isRegex, verdict, createdAt, explanation, builtIn, overridable, isDisabled, nonSuppressible
+        case id, name, toolName, pattern, isRegex, verdict, createdAt, explanation, builtIn, overridable, isDisabled, nonSuppressible, argConditions
     }
 
     /// Backward-compatible decoding — isRegex, explanation, builtIn, isDisabled,
@@ -649,6 +666,8 @@ struct PersistentRule: Codable, Identifiable {
         overridable = try c.decodeIfPresent(Bool.self, forKey: .overridable) ?? true
         isDisabled = try c.decodeIfPresent(Bool.self, forKey: .isDisabled) ?? false
         nonSuppressible = try c.decodeIfPresent(Bool.self, forKey: .nonSuppressible) ?? false
+        argConditions = Self.sanitizedConditions(
+            try c.decodeIfPresent([String: String].self, forKey: .argConditions), verdict: verdict)
     }
 
     init(
@@ -660,7 +679,8 @@ struct PersistentRule: Codable, Identifiable {
         builtIn: Bool = false,
         overridable: Bool = true,
         isDisabled: Bool = false,
-        nonSuppressible: Bool = false
+        nonSuppressible: Bool = false,
+        argConditions: [String: String]? = nil
     ) {
         self.id = UUID()
         self.toolName = toolName
@@ -668,7 +688,9 @@ struct PersistentRule: Codable, Identifiable {
         self.isRegex = isRegex
         self.verdict = verdict
         self.createdAt = Date()
+        self.argConditions = Self.sanitizedConditions(argConditions, verdict: verdict)
         self.name = "\(toolName): \(isRegex ? "/" : "")\(pattern)\(isRegex ? "/" : "")"
+            + Self.conditionsSuffix(self.argConditions)
         self.explanation = explanation
         self.builtIn = builtIn
         self.overridable = overridable
@@ -678,14 +700,16 @@ struct PersistentRule: Codable, Identifiable {
     }
 
     /// Update a rule's editable fields while preserving identity (id, toolName, createdAt, builtIn).
-    init(replacing old: PersistentRule, pattern: String, isRegex: Bool, verdict: DecisionVerdict, explanation: String?) {
+    init(replacing old: PersistentRule, pattern: String, isRegex: Bool, verdict: DecisionVerdict, explanation: String?, argConditions: [String: String]? = nil) {
         self.id = old.id
         self.toolName = old.toolName
         self.pattern = pattern
         self.isRegex = isRegex
         self.verdict = verdict
         self.createdAt = old.createdAt
+        self.argConditions = Self.sanitizedConditions(argConditions, verdict: verdict)
         self.name = "\(old.toolName): \(isRegex ? "/" : "")\(pattern)\(isRegex ? "/" : "")"
+            + Self.conditionsSuffix(self.argConditions)
         self.explanation = explanation
         self.builtIn = old.builtIn
         self.overridable = old.overridable
@@ -694,8 +718,26 @@ struct PersistentRule: Codable, Identifiable {
         self._compiledRegex = Self.compilePattern(pattern, isRegex: isRegex)
     }
 
-    mutating func matches(toolName: String, command: String?, filePath: String?) -> Bool {
+    /// Drop conditions on non-allow verdicts (they'd narrow a deny/prompt — a
+    /// loosening) and strip blank keys/patterns; empty result collapses to nil.
+    private static func sanitizedConditions(_ conditions: [String: String]?, verdict: DecisionVerdict) -> [String: String]? {
+        guard verdict == .allow, let conditions else { return nil }
+        let cleaned = conditions.filter {
+            !$0.key.trimmingCharacters(in: .whitespaces).isEmpty
+                && !$0.value.trimmingCharacters(in: .whitespaces).isEmpty
+        }
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
+    private static func conditionsSuffix(_ conditions: [String: String]?) -> String {
+        guard let conditions, !conditions.isEmpty else { return "" }
+        let parts = conditions.sorted { $0.key < $1.key }.map { "\($0.key)=/\($0.value)/" }
+        return " [\(parts.joined(separator: ", "))]"
+    }
+
+    mutating func matches(toolName: String, command: String?, filePath: String?, toolInput: [String: AnyCodable]? = nil) -> Bool {
         guard self.toolName == toolName || self.toolName == "*" else { return false }
+        guard argConditionsSatisfied(by: toolInput) else { return false }
 
         let raw: String
         switch toolName {
@@ -760,6 +802,41 @@ struct PersistentRule: Codable, Identifiable {
 
     private func matchesRegex(_ regex: NSRegularExpression, in string: String) -> Bool {
         regex.firstMatch(in: string, range: NSRange(string.startIndex..., in: string)) != nil
+    }
+
+    /// Every condition's regex must fully match the stringified arg value.
+    /// Fail closed: absent arg, non-scalar value, or an uncompilable pattern
+    /// all reject — the rule simply doesn't fire and evaluation falls through.
+    private mutating func argConditionsSatisfied(by toolInput: [String: AnyCodable]?) -> Bool {
+        guard let conditions = argConditions, !conditions.isEmpty else { return true }
+        for (arg, pattern) in conditions {
+            guard let value = toolInput?[arg].flatMap(Self.scalarString),
+                  let regex = compiledArgRegex(arg: arg, pattern: pattern),
+                  matchesRegex(regex, in: value) else { return false }
+        }
+        return true
+    }
+
+    /// Stringify scalar arg values so conditions can also pin ints/bools
+    /// (e.g. `limit=/50/`). Dicts, arrays, and null stay nil → fail closed.
+    /// Also used by the approval panel to decide which args are scopable.
+    static func scalarString(_ value: AnyCodable) -> String? {
+        switch value.value {
+        case let s as String: return s
+        case let b as Bool: return b ? "true" : "false"
+        case let i as Int: return String(i)
+        case let d as Double: return String(d)
+        default: return nil
+        }
+    }
+
+    /// Anchored `\A(?:pattern)\z` so a condition can't substring-match
+    /// (`C123` must not pass `C1234`) — strictly narrower, tighten-only.
+    private mutating func compiledArgRegex(arg: String, pattern: String) -> NSRegularExpression? {
+        if let cached = _compiledArgRegexes[arg] { return cached }
+        guard let regex = try? NSRegularExpression(pattern: "\\A(?:\(pattern))\\z") else { return nil }
+        _compiledArgRegexes[arg] = regex
+        return regex
     }
 
     private func matchesAnySegment(_ regex: NSRegularExpression, in command: String) -> Bool {

--- a/Sources/Gavel/Monitor/MonitorViewModel.swift
+++ b/Sources/Gavel/Monitor/MonitorViewModel.swift
@@ -141,8 +141,8 @@ final class MonitorViewModel: ObservableObject {
         approvalCoordinator.ruleStore?.removeRule(id: id)
     }
 
-    func updateRule(id: UUID, pattern: String, isRegex: Bool, verdict: DecisionVerdict, explanation: String?) {
-        approvalCoordinator.ruleStore?.updateRule(id: id, pattern: pattern, isRegex: isRegex, verdict: verdict, explanation: explanation)
+    func updateRule(id: UUID, pattern: String, isRegex: Bool, verdict: DecisionVerdict, explanation: String?, argConditions: [String: String]? = nil) {
+        approvalCoordinator.ruleStore?.updateRule(id: id, pattern: pattern, isRegex: isRegex, verdict: verdict, explanation: explanation, argConditions: argConditions)
     }
 
     func setRuleDisabled(id: UUID, isDisabled: Bool) {

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -875,6 +875,26 @@ struct RulesView: View {
     @State private var editIsRegex: Bool = false
     @State private var editVerdict: DecisionVerdict = .block
     @State private var editExplanation: String = ""
+    @State private var newArgConditions: [ArgConditionDraft] = []
+    @State private var editArgConditions: [ArgConditionDraft] = []
+
+    /// Editable arg-condition row (arg name → regex) for the add/edit forms.
+    struct ArgConditionDraft: Identifiable {
+        let id = UUID()
+        var name: String = ""
+        var pattern: String = ""
+    }
+
+    /// Compact drafts to the dict form the model stores; blank rows drop out.
+    private static func conditionsDict(_ drafts: [ArgConditionDraft]) -> [String: String]? {
+        var dict: [String: String] = [:]
+        for draft in drafts {
+            let name = draft.name.trimmingCharacters(in: .whitespaces)
+            let pattern = draft.pattern.trimmingCharacters(in: .whitespaces)
+            if !name.isEmpty && !pattern.isEmpty { dict[name] = pattern }
+        }
+        return dict.isEmpty ? nil : dict
+    }
 
     private let toolOptions = ["*", "Bash", "Edit", "MultiEdit", "Write", "Read", "Glob", "Grep", "Agent"]
 
@@ -1101,6 +1121,12 @@ struct RulesView: View {
                 .disabled(newPattern.isEmpty)
             }
 
+            // Arg conditions — narrow an allow rule to specific argument values
+            // (MCP tools). Allow-only: on deny/prompt they'd weaken the guard.
+            if newVerdict == .allow {
+                argConditionEditor($newArgConditions)
+            }
+
             // Explanation field for deny rules — Claude sees this when blocked
             if newVerdict == .block {
                 TextEditor(text: $newExplanation)
@@ -1139,11 +1165,48 @@ struct RulesView: View {
             pattern: sanitized,
             isRegex: newIsRegex,
             verdict: newVerdict,
-            explanation: explText
+            explanation: explText,
+            argConditions: Self.conditionsDict(newArgConditions)
         )
         viewModel.addRule(rule)
         newPattern = ""
         newExplanation = ""
+        newArgConditions = []
+    }
+
+    /// Rows of "arg = /regex/" conditions for allow rules. Regexes are
+    /// full-string anchored at match time; an absent arg fails closed.
+    private func argConditionEditor(_ drafts: Binding<[ArgConditionDraft]>) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Text("Arg conditions (allow only when every arg fully matches its regex; absent arg = no match)")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                Button(action: { drafts.wrappedValue.append(ArgConditionDraft()) }) {
+                    Image(systemName: "plus.circle")
+                }
+                .buttonStyle(.plain)
+                .help("Add an argument condition (e.g. channel = C0123ABC|C0456DEF)")
+            }
+            ForEach(drafts) { $draft in
+                HStack(spacing: 6) {
+                    TextField("arg name", text: $draft.name)
+                        .font(.system(.caption, design: .monospaced))
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 140)
+                    Text("=").foregroundColor(.secondary)
+                    Text("/").font(.system(.caption, design: .monospaced)).foregroundColor(.orange)
+                    TextField("regex", text: $draft.pattern)
+                        .font(.system(.caption, design: .monospaced))
+                        .textFieldStyle(.roundedBorder)
+                    Text("/").font(.system(.caption, design: .monospaced)).foregroundColor(.orange)
+                    Button(action: { drafts.wrappedValue.removeAll { $0.id == draft.id } }) {
+                        Image(systemName: "minus.circle")
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
     }
 
     // MARK: - Import/Export
@@ -1290,6 +1353,15 @@ struct RulesView: View {
                         }
                     }
 
+                    if let conditions = rule.argConditions, !conditions.isEmpty {
+                        Text(conditions.sorted { $0.key < $1.key }
+                            .map { "\($0.key) = /\($0.value)/" }
+                            .joined(separator: " · "))
+                            .font(.caption2)
+                            .foregroundColor(.teal)
+                            .lineLimit(1)
+                    }
+
                     if let explanation = rule.explanation, !explanation.isEmpty {
                         Text(explanation)
                             .font(.caption2)
@@ -1345,6 +1417,10 @@ struct RulesView: View {
                             .tint(.orange)
                     }
 
+                    if editVerdict == .allow {
+                        argConditionEditor($editArgConditions)
+                    }
+
                     HStack(spacing: 8) {
                         Picker("", selection: $editVerdict) {
                             Text("Deny").tag(DecisionVerdict.block)
@@ -1388,6 +1464,9 @@ struct RulesView: View {
         editIsRegex = rule.isRegex
         editVerdict = rule.verdict
         editExplanation = rule.explanation ?? ""
+        editArgConditions = (rule.argConditions ?? [:])
+            .sorted { $0.key < $1.key }
+            .map { ArgConditionDraft(name: $0.key, pattern: $0.value) }
     }
 
     private func saveEdit(_ rule: PersistentRule) {
@@ -1396,7 +1475,8 @@ struct RulesView: View {
             pattern: editPattern,
             isRegex: editIsRegex,
             verdict: editVerdict,
-            explanation: editExplanation.isEmpty ? nil : editExplanation
+            explanation: editExplanation.isEmpty ? nil : editExplanation,
+            argConditions: Self.conditionsDict(editArgConditions)
         )
         editingRuleId = nil
     }

--- a/Tests/GavelTests/ApprovalEngineTests.swift
+++ b/Tests/GavelTests/ApprovalEngineTests.swift
@@ -82,7 +82,7 @@ final class ApprovalEngineTests: XCTestCase {
         typealias A = ApprovalCoordinator.Action
         XCTAssertTrue(A.allowPatternForSession(pattern: "*", context: nil, updatedCommand: nil, updatedInput: nil).createsDurableAllow)
         XCTAssertTrue(A.suppressRuleForSession(ruleId: UUID(), context: nil, updatedCommand: nil, updatedInput: nil).createsDurableAllow)
-        XCTAssertTrue(A.alwaysAllowPattern(pattern: "*", isRegex: false).createsDurableAllow)
+        XCTAssertTrue(A.alwaysAllowPattern(pattern: "*", isRegex: false, argConditions: nil).createsDurableAllow)
 
         XCTAssertFalse(A.allow(context: nil, updatedCommand: nil, updatedInput: nil).createsDurableAllow)
         XCTAssertFalse(A.deny(context: nil).createsDurableAllow)

--- a/Tests/GavelTests/PatternMatcherTests.swift
+++ b/Tests/GavelTests/PatternMatcherTests.swift
@@ -1063,4 +1063,159 @@ final class PatternMatcherTests: XCTestCase {
         let expanded = PatternMatcher.expandInlineVariables(cmd)
         XCTAssertTrue(expanded.contains("curl -d"))
     }
+
+    // MARK: - Arg-scoped allow rules (argConditions)
+
+    private func slackReadInput(channel: String = "C0AAA", workspace: String = "defiance", limit: Int = 50) -> [String: AnyCodable] {
+        ["channel": AnyCodable(channel), "workspace": AnyCodable(workspace), "limit": AnyCodable(limit)]
+    }
+
+    /// The realistic authored shape: wildcard tool, glob pattern on the MCP
+    /// tool name, conditions pinning channel + workspace.
+    private func scopedSlackAllow(conditions: [String: String]? = [
+        "channel": "C0AAA|C0BBB", "workspace": "defiance"
+    ]) -> PersistentRule {
+        PersistentRule(
+            toolName: "*", pattern: "mcp__Slack__read_history", isRegex: false,
+            verdict: .allow, argConditions: conditions)
+    }
+
+    func testNilArgConditionsBackwardCompatible() {
+        var rule = scopedSlackAllow(conditions: nil)
+        XCTAssertNil(rule.argConditions)
+        // Name-only allow matches regardless of args — today's behavior.
+        XCTAssertTrue(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil))
+        XCTAssertTrue(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(channel: "C9ZZZ")))
+    }
+
+    func testArgConditionsInAllowlistMatches() {
+        var rule = scopedSlackAllow()
+        XCTAssertTrue(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(channel: "C0AAA")))
+        XCTAssertTrue(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(channel: "C0BBB")))
+    }
+
+    func testArgConditionsOutOfAllowlistRejected() {
+        var rule = scopedSlackAllow()
+        XCTAssertFalse(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(channel: "C9ZZZ")))
+    }
+
+    func testArgConditionsAllMustMatch() {
+        var rule = scopedSlackAllow()
+        // channel in allowlist but wrong workspace → reject
+        XCTAssertFalse(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(workspace: "macedon")))
+    }
+
+    func testArgConditionAbsentArgFailsClosed() {
+        var rule = scopedSlackAllow()
+        // No toolInput at all → no match
+        XCTAssertFalse(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil))
+        // workspace key missing → no match
+        XCTAssertFalse(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: ["channel": AnyCodable("C0AAA")]))
+    }
+
+    func testArgConditionNonScalarArgFailsClosed() {
+        var rule = scopedSlackAllow(conditions: ["channel": ".*"])
+        let input: [String: AnyCodable] = ["channel": AnyCodable(["C0AAA": AnyCodable("x")])]
+        XCTAssertFalse(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: input))
+    }
+
+    func testArgConditionRegexIsFullAnchored() {
+        // "C0AAA" must not substring-match a longer channel ID
+        var rule = scopedSlackAllow(conditions: ["channel": "C0AAA"])
+        XCTAssertFalse(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(channel: "C0AAA-extra")))
+        XCTAssertFalse(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(channel: "xC0AAA")))
+        XCTAssertTrue(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(channel: "C0AAA")))
+    }
+
+    func testArgConditionAnchoringNotBypassedByNewline() {
+        // \A...\z anchors (not ^...$) — a value with a trailing newline or an
+        // embedded allowlisted line must not slip through
+        var rule = scopedSlackAllow(conditions: ["channel": "C0AAA"])
+        XCTAssertFalse(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(channel: "C0AAA\nC9ZZZ")))
+        XCTAssertFalse(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(channel: "C0AAA\n")))
+    }
+
+    func testArgConditionMatchesIntArg() {
+        var rule = scopedSlackAllow(conditions: ["limit": "50"])
+        XCTAssertTrue(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(limit: 50)))
+        XCTAssertFalse(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(limit: 500)))
+    }
+
+    func testArgConditionInvalidRegexFailsClosed() {
+        var rule = scopedSlackAllow(conditions: ["channel": "C0AAA("])
+        XCTAssertFalse(rule.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput()))
+    }
+
+    func testArgConditionsStrippedOnDenyAndPromptVerdicts() {
+        // Conditions on a deny/prompt would NARROW the guard (a loosening) —
+        // the model must drop them so the deny stays as broad as authored.
+        let deny = PersistentRule(
+            toolName: "*", pattern: "mcp__Slack__read_history", isRegex: false,
+            verdict: .block, argConditions: ["channel": "C0AAA"])
+        XCTAssertNil(deny.argConditions)
+        let prompt = PersistentRule(
+            toolName: "*", pattern: "mcp__Slack__read_history", isRegex: false,
+            verdict: .prompt, argConditions: ["channel": "C0AAA"])
+        XCTAssertNil(prompt.argConditions)
+        // And the deny still fires on any channel
+        var d = deny
+        XCTAssertTrue(d.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(channel: "C9ZZZ")))
+    }
+
+    func testArgConditionsBlankEntriesDropped() {
+        let rule = PersistentRule(
+            toolName: "*", pattern: "mcp__Slack__read_history", isRegex: false,
+            verdict: .allow, argConditions: ["": "x", "channel": "  ", "workspace": "defiance"])
+        XCTAssertEqual(rule.argConditions, ["workspace": "defiance"])
+    }
+
+    func testArgConditionsEncodeDecodeRoundTrip() throws {
+        let rule = scopedSlackAllow()
+        let data = try JSONEncoder().encode(rule)
+        var decoded = try JSONDecoder().decode(PersistentRule.self, from: data)
+        XCTAssertEqual(decoded.argConditions, rule.argConditions)
+        XCTAssertFalse(decoded.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(channel: "C9ZZZ")))
+        XCTAssertTrue(decoded.matches(toolName: "mcp__Slack__read_history", command: nil, filePath: nil, toolInput: slackReadInput(channel: "C0AAA")))
+    }
+
+    func testDecoderStripsConditionsOnNonAllowJSON() throws {
+        // Hand-crafted JSON (e.g. an imported rules file) with conditions on a
+        // deny — decoder drops them so a deny can't be narrowed from outside the UI.
+        let json = """
+        {"id":"\(UUID().uuidString)","name":"x","toolName":"*","pattern":"mcp__Slack__send_message",
+         "isRegex":false,"verdict":"block","createdAt":700000000,
+         "argConditions":{"channel":"C0AAA"}}
+        """
+        let decoded = try JSONDecoder().decode(PersistentRule.self, from: Data(json.utf8))
+        XCTAssertNil(decoded.argConditions)
+    }
+
+    func testOldRulesJSONWithoutConditionsDecodes() throws {
+        let json = """
+        {"id":"\(UUID().uuidString)","name":"x","toolName":"*","pattern":"mcp__Slack__read_history",
+         "isRegex":false,"verdict":"allow","createdAt":700000000}
+        """
+        let decoded = try JSONDecoder().decode(PersistentRule.self, from: Data(json.utf8))
+        XCTAssertNil(decoded.argConditions)
+    }
+
+    func testEvaluateAllowEndToEndScopedMCP() {
+        let path = NSTemporaryDirectory() + "gavel-argscope-test-\(UUID().uuidString)/rules.json"
+        defer { try? FileManager.default.removeItem(atPath: (path as NSString).deletingLastPathComponent) }
+        let store = RuleStore(configPath: path)
+        store.addRule(scopedSlackAllow(), origin: "test")
+
+        func payload(_ input: [String: AnyCodable]) -> PreToolUsePayload {
+            PreToolUsePayload(toolName: "mcp__Slack__read_history", toolInput: input)
+        }
+
+        // In-allowlist read → allow decision
+        XCTAssertNotNil(store.evaluateAllow(payload: payload(slackReadInput(channel: "C0BBB"))))
+        // Out-of-allowlist channel → falls through (nil) → would prompt
+        XCTAssertNil(store.evaluateAllow(payload: payload(slackReadInput(channel: "C9ZZZ"))))
+        // Agent omits the arg entirely → fail closed → would prompt
+        XCTAssertNil(store.evaluateAllow(payload: payload(["workspace": AnyCodable("defiance")])))
+        // Different MCP tool with matching args → name guard rejects
+        XCTAssertNil(store.evaluateAllow(payload: PreToolUsePayload(toolName: "mcp__Slack__search_messages", toolInput: slackReadInput())))
+    }
 }


### PR DESCRIPTION
## What

Adds optional `argConditions` (arg name → regex) to persistent **allow** rules so an MCP allow can be narrowed to specific argument values — e.g. allow `mcp__Slack__read_history` only when `channel` matches `C0AAA|C0BBB` **and** `workspace` matches `defiance`. Today the matcher only sees `toolName`/`command`/`filePath`, so an MCP allow is all-or-nothing on the tool name (reads ANY channel/DM). This unblocks read-only background watchers (Slack thread watchers, Telegram Saved-Messages-only, scoped-AWS-by-account) without a blanket read allow.

## Safety property (tighten-only)

For a read-only ALLOW scoped to an allowlist, the agent can't escalate by lying about the arg: naming a non-allowlisted channel fails the allow and falls through to the normal prompt; naming an allowlisted channel is exactly what was permitted. The MCP server reads the arg the rule matched — there's no gap between what was matched and what executes.

Enforced narrowing:
- **Fail closed**: absent arg, non-scalar value (dict/array/null), or an uncompilable condition regex → rule doesn't fire → prompt.
- **Full-string anchored** (`\A(?:…)\z`): `C123` cannot substring-match `C1234`, and embedded/trailing newlines can't smuggle a second value past the anchor.
- **Every** condition must match — conditions only ever shrink an allow.
- **Allow rules only**: on a deny/prompt rule, conditions would narrow the guard (a loosening). Both inits *and* the decoder strip conditions unless `verdict == allow`, so a hand-crafted/imported rules file can't weaken a deny either.
- Write-tool loosening is explicitly out of scope: nothing here relaxes any existing deny/prompt path; a scoped allow is strictly narrower than the name-only allow the user could already create.

## Changes

- `PersistentRule.argConditions` persisted in rules.json; backward compatible (old files decode to `nil` = today's behavior; rules without conditions match exactly as before).
- `matches(...)` gains a defaulted `toolInput:` param; all five `RuleStore.evaluate*` paths pass `payload.toolInput`.
- Approval panel: MCP approvals show per-arg scope rows (checkbox + editable regex prefilled with the escaped current value); Always Allow becomes "Always Allow (scoped)" when any row is ticked.
- Monitor rules tab: author/edit `arg = /regex/` rows on allow rules; rule rows display conditions.
- Audit journal records the conditions so a scoped allow doesn't read as a blanket one.

## Tests

16 new tests in `PatternMatcherTests`: fail-closed on absent/non-scalar args, all-conditions-must-match, full-anchor + newline bypass, int stringification, invalid-regex fail-closed, deny/prompt stripping (init and decoder), blank-entry sanitization, encode/decode round-trip, old-JSON backward compat, and an end-to-end `RuleStore.evaluateAllow` pass (in-allowlist → allow; out-of-allowlist / missing arg / different tool → fall through).

`swift test`: 751 tests, one pre-existing environmental failure (`testLiveClaudeSessionDiscoveryAgainstPsWitness`, fails on main too — live process discovery, untouched by this diff).

Live validation via `just dev-daemon` (scoped Slack watcher runs silently; out-of-allowlist read prompts) to follow before merge.