### PR TITLE
feat(approval): full-command review page + rule adjudication from Telegram

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -197,15 +197,63 @@ final class ApprovalCoordinator: ObservableObject {
             guard source == .telegram || source == .web else { return }
             DispatchQueue.main.async { self?.dismissPending(id: pendingId, pid: session.pid) }
         }
-        let text = withheld != nil
-            ? RemoteApprovalBridge.withheldBody(payload: payload, session: session)
-            : RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: pending.triggerReason)
         let isCommit = payload.toolName == "Bash" && (payload.command?.contains("commit") ?? false)
         // Review link even on credential-withheld commits: the page never
         // shows the command, secret hunks are withheld on-page, and a
         // withheld commit is exactly when phone-side verification matters.
         let reviewURL = isCommit ? makeReviewLink(payload: payload, session: session, resolvable: resolvable) : nil
-        bridge.notify(resolvable: resolvable, text: text, pid: session.pid, toolName: payload.toolName, withheld: withheld != nil, allowSession: allowSession, offerCommentClean: isCommit && withheld == nil, leaseDomain: leaseDomain, allowSite: allowSite, reviewURL: reviewURL)
+        // Full-command link on EVERY mirrored approval — Telegram keeps the
+        // redacted/truncated summary, full fidelity lives on the tailnet page.
+        let commandURL = makeCommandLink(payload: payload, session: session, resolvable: resolvable, triggerReason: pending.triggerReason, withheldInline: withheld != nil)
+        let text = withheld != nil
+            ? RemoteApprovalBridge.withheldBody(payload: payload, session: session, hasCommandLink: commandURL != nil)
+            : RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: pending.triggerReason, hasCommandLink: commandURL != nil)
+        bridge.notify(resolvable: resolvable, text: text, pid: session.pid, toolName: payload.toolName, withheld: withheld != nil, allowSession: allowSession, offerCommentClean: isCommit && withheld == nil, leaseDomain: leaseDomain, allowSite: allowSite, reviewURL: reviewURL, commandURL: commandURL)
+    }
+
+    /// Register the full, unredacted command with the review server and
+    /// return its tailnet URL. Failures are soft — nil just means the
+    /// Telegram card goes out with the redacted inline text only.
+    private func makeCommandLink(payload: PreToolUsePayload, session: Session, resolvable: ResolvableApproval, triggerReason: String?, withheldInline: Bool) -> String? {
+        do {
+            try DiffReviewServer.shared.start()
+        } catch {
+            gavelLog("[review] server start failed: \(error.localizedDescription)")
+            return nil
+        }
+        guard let base = TailscaleServe.cachedReviewBaseURL() else { return nil }
+
+        let primary = payload.command ?? payload.filePath
+        // Everything except the primary text becomes an args row, so MCP
+        // calls (no command/filePath) still show their full input.
+        let primaryKeys: Set<String> = payload.command != nil ? ["command"] : (payload.filePath != nil ? ["file_path", "path"] : [])
+        let args = payload.toolInput
+            .filter { !primaryKeys.contains($0.key) }
+            .map { (name: $0.key, value: Self.displayString($0.value)) }
+            .sorted { $0.name < $1.name }
+
+        let label = session.label.isEmpty ? "PID \(session.pid)" : session.label
+        let content = CommandContent(
+            sessionLabel: label,
+            toolName: payload.toolName,
+            cwd: payload.cwd ?? session.cwd,
+            command: primary,
+            args: args,
+            triggerReason: triggerReason,
+            withheldInline: withheldInline)
+        let nonce = DiffReviewServer.shared.register(command: content, resolvable: resolvable)
+        gavelLog("[review] command link created pid=\(session.pid) tool=\(payload.toolName) nonce=\(nonce.prefix(8))…")
+        return "\(base)/review/\(nonce)"
+    }
+
+    /// Full-fidelity display of a tool arg: strings verbatim, everything
+    /// else (numbers, bools, nested dicts/arrays) as compact JSON.
+    static func displayString(_ value: AnyCodable) -> String {
+        if let s = value.stringValue { return s }
+        if let data = try? JSONEncoder().encode(value), let json = String(data: data, encoding: .utf8) {
+            return json
+        }
+        return "\(value.value)"
     }
 
     /// Snapshot the pending commit's diff, register it with the review
@@ -232,7 +280,7 @@ final class ApprovalCoordinator: ObservableObject {
             gavelLog("[review] server start failed: \(error.localizedDescription)")
             return nil
         }
-        guard let base = TailscaleServe.reviewBaseURL() else { return nil }
+        guard let base = TailscaleServe.cachedReviewBaseURL() else { return nil }
         let content = ReviewContent(
             repoName: URL(fileURLWithPath: cwd).lastPathComponent,
             commitMessage: captured.commitMessage,

--- a/Sources/Gavel/Approval/ProposalStore.swift
+++ b/Sources/Gavel/Approval/ProposalStore.swift
@@ -47,6 +47,11 @@ final class ProposalStore {
     /// Fired on the main thread after any mutation, with a snapshot of pending proposals.
     var onChange: (([RuleProposal]) -> Void)?
 
+    /// Fired (main thread) once per successfully queued proposal — the hook
+    /// for mirroring it to the phone. Delivery is best-effort; the inbox
+    /// here stays the source of truth either way.
+    var onSubmitted: ((RuleProposal) -> Void)?
+
     /// Set at wiring time; used for dedupe against existing rules and for accept.
     weak var ruleStore: RuleStore?
 
@@ -132,6 +137,9 @@ final class ProposalStore {
         lock.unlock()
 
         notifyChanged()
+        DispatchQueue.main.async { [weak self] in
+            self?.onSubmitted?(proposal)
+        }
         return .queued(proposal.id)
     }
 

--- a/Sources/Gavel/Remote/RemoteApprovalBridge.swift
+++ b/Sources/Gavel/Remote/RemoteApprovalBridge.swift
@@ -44,6 +44,11 @@ final class RemoteApprovalBridge {
     private var coalescedCount = 0
     private var lastCoalesceNotice: Date?
 
+    /// Proposal inbox for phone adjudication. Tighten-only is enforced at
+    /// submit time in ProposalStore, so an Accept from the phone can only
+    /// ever create a deny/prompt rule — never widen permissions.
+    weak var proposalStore: ProposalStore?
+
     /// Fired when pairing captures a chat id, so the daemon can persist it.
     var onPaired: ((Int64) -> Void)?
     /// Fired when the pinned chat sends `[[/stop-phone]]`, so the daemon can kill phone approval.
@@ -85,7 +90,7 @@ final class RemoteApprovalBridge {
     /// `leaseDomain`/`allowSite` (both required together) add a browsing-lease
     /// button for chrome navigate approvals — the phone twin of the panel's
     /// "Allow Site" (see BrowsingLease).
-    func notify(resolvable: ResolvableApproval, text: String, pid: Int = 0, toolName: String = "", withheld: Bool = false, allowSession: (() -> Void)?, offerCommentClean: Bool = false, leaseDomain: String? = nil, allowSite: (() -> Void)? = nil, reviewURL: String? = nil) {
+    func notify(resolvable: ResolvableApproval, text: String, pid: Int = 0, toolName: String = "", withheld: Bool = false, allowSession: (() -> Void)?, offerCommentClean: Bool = false, leaseDomain: String? = nil, allowSite: (() -> Void)? = nil, reviewURL: String? = nil, commandURL: String? = nil) {
         lock.lock(); let chat = chatId; lock.unlock()
         guard let chat else { return }
 
@@ -113,11 +118,18 @@ final class RemoteApprovalBridge {
         }
 
         var keyboard: [[TelegramButton]] = []
-        // Review link leads the keyboard: on a commit approval the intended
-        // flow is review first, then verdict (on the page or via the buttons).
+        // Link buttons lead the keyboard: the intended flow is review first,
+        // then verdict (on the page or via the buttons below). The command
+        // link is how the FULL text reaches the phone — the inline body stays
+        // redacted/truncated so fidelity never transits Telegram.
+        var linkRow: [TelegramButton] = []
         if let reviewURL {
-            keyboard.append([TelegramButton(text: "🔍 Review diff", url: reviewURL)])
+            linkRow.append(TelegramButton(text: "🔍 Review diff", url: reviewURL))
         }
+        if let commandURL {
+            linkRow.append(TelegramButton(text: withheld ? "🔒 View full command" : "📄 Full command", url: commandURL))
+        }
+        if !linkRow.isEmpty { keyboard.append(linkRow) }
         keyboard.append(
             [TelegramButton(text: "✅ Allow once", callbackData: "a:\(nonce)"),
              TelegramButton(text: "🛑 Deny", callbackData: "d:\(nonce)")])
@@ -155,6 +167,62 @@ final class RemoteApprovalBridge {
         lock.lock(); let chat = chatId; lock.unlock()
         guard let chat else { return }
         transport.sendMessage(chatId: chat, text: text, keyboard: nil, completion: { _ in })
+    }
+
+    /// Mirror a new rule proposal to the phone with Accept/Reject buttons.
+    /// The Monitor inbox stays the source of truth: a proposal that never
+    /// reaches the phone (flood control, phone off) is still adjudicable there,
+    /// and a button tap on an already-adjudicated proposal is a no-op.
+    func notifyProposal(_ proposal: RuleProposal) {
+        lock.lock(); let chat = chatId; lock.unlock()
+        guard let chat else { return }
+        guard consumeSendToken() else {
+            remoteLog?("proposal coalesced id=\(proposal.id) — flood control, Monitor-fallback")
+            return
+        }
+        let verdictLabel = proposal.verdict == .block ? "DENY" : "ASK"
+        var lines = [
+            "📐 Claude proposed a rule — inert until accepted",
+            "\(verdictLabel) \(proposal.toolName): \(proposal.isRegex ? "/" : "")\(proposal.pattern)\(proposal.isRegex ? "/" : "")",
+            proposal.reason,
+        ]
+        if let example = proposal.example, !example.isEmpty {
+            lines.append("e.g. \(SecretRedactor.redact(example))")
+        }
+        lines.append("from session \(proposal.sessionPid)")
+        let keyboard = [[
+            TelegramButton(text: "✅ Accept rule", callbackData: "pa:\(proposal.id.uuidString)"),
+            TelegramButton(text: "❌ Reject", callbackData: "pj:\(proposal.id.uuidString)"),
+        ]]
+        transport.sendMessage(chatId: chat, text: lines.joined(separator: "\n"), keyboard: keyboard) { [weak self] result in
+            if case .success(let mid) = result {
+                self?.remoteLog?("proposal sent id=\(proposal.id) mid=\(mid)")
+            }
+        }
+    }
+
+    /// Handle an Accept/Reject tap on a proposal card. Runs through the same
+    /// audited ProposalStore path as the Monitor buttons (accepted-via=telegram).
+    private func adjudicateProposal(action: String, idText: String, callback: TelegramCallback, chat: Int64) {
+        guard let store = proposalStore, let id = UUID(uuidString: idText) else {
+            transport.answerCallbackQuery(id: callback.id, text: "Unavailable", completion: nil)
+            return
+        }
+        if action == "pa" {
+            if let rule = store.accept(id: id, via: "telegram") {
+                remoteLog?("proposal accepted id=\(id) via=telegram")
+                transport.answerCallbackQuery(id: callback.id, text: "Rule added", completion: nil)
+                transport.editMessageText(chatId: chat, messageId: callback.messageId, text: "✅ Rule accepted from phone: \(rule.name)", completion: nil)
+            } else {
+                transport.answerCallbackQuery(id: callback.id, text: "Already handled", completion: nil)
+                transport.editMessageText(chatId: chat, messageId: callback.messageId, text: "↪️ Proposal already handled (Monitor or expired)", completion: nil)
+            }
+        } else {
+            store.reject(id: id, via: "telegram")
+            remoteLog?("proposal rejected id=\(id) via=telegram")
+            transport.answerCallbackQuery(id: callback.id, text: "Rejected", completion: nil)
+            transport.editMessageText(chatId: chat, messageId: callback.messageId, text: "❌ Proposal rejected from phone", completion: nil)
+        }
     }
 
     // MARK: - Inbound poll loop
@@ -255,6 +323,13 @@ final class RemoteApprovalBridge {
         }
         let action = String(parts[0])
         let nonce = String(parts[1])
+
+        // Proposal adjudication rides the same callback channel but has no
+        // pending-approval correlation — route before the nonce lookup.
+        if action == "pa" || action == "pj" {
+            adjudicateProposal(action: action, idText: nonce, callback: callback, chat: pinned)
+            return
+        }
 
         lock.lock(); let corr = byNonce[nonce]; lock.unlock()
         guard let corr else {
@@ -419,7 +494,7 @@ final class RemoteApprovalBridge {
     }
 
     /// Build the redacted, control-stripped message body for an approval — full command, capped near Telegram's limit.
-    static func summaryBody(payload: PreToolUsePayload, session: Session, triggerReason: String?) -> String {
+    static func summaryBody(payload: PreToolUsePayload, session: Session, triggerReason: String?, hasCommandLink: Bool = false) -> String {
         let label = session.label.isEmpty ? "PID \(session.pid)" : session.label
         var lines = ["Gavel approval — \(sanitizeForDisplay(label))", "Tool: \(payload.toolName)"]
         if let cwd = session.cwd {
@@ -430,7 +505,8 @@ final class RemoteApprovalBridge {
         if !raw.isEmpty {
             let cleaned = sanitizeForDisplay(SecretRedactor.redact(raw))
             if cleaned.count > GavelConstants.telegramBodyMaxChars {
-                lines.append(String(cleaned.prefix(GavelConstants.telegramBodyMaxChars)) + "… (truncated — full on Mac)")
+                lines.append(String(cleaned.prefix(GavelConstants.telegramBodyMaxChars))
+                    + (hasCommandLink ? "… (truncated — full at the link)" : "… (truncated — full on Mac)"))
             } else {
                 lines.append(cleaned)
             }
@@ -440,14 +516,16 @@ final class RemoteApprovalBridge {
     }
 
     /// Metadata-only body for a credential-gated approval — names the session so it can be verified in Claude, never the command.
-    static func withheldBody(payload: PreToolUsePayload, session: Session) -> String {
+    static func withheldBody(payload: PreToolUsePayload, session: Session, hasCommandLink: Bool = false) -> String {
         let label = session.label.isEmpty ? "PID \(session.pid)" : session.label
         var lines = ["🔒 Gavel — command withheld", "Session: \(sanitizeForDisplay(label))", "Tool: \(payload.toolName)"]
         if let cwd = session.cwd {
             let tail = cwd.split(separator: "/").suffix(2).joined(separator: "/")
             if !tail.isEmpty { lines.append("cwd: …/\(tail)") }
         }
-        lines.append("Sensitive content detected — command not shown. Verify it in the Claude session, then Allow or Deny below.")
+        lines.append(hasCommandLink
+            ? "Sensitive content detected — command not shown here. Open the full-command link (tailnet-only) to review it, then Allow or Deny."
+            : "Sensitive content detected — command not shown. Verify it in the Claude session, then Allow or Deny below.")
         return lines.joined(separator: "\n")
     }
 

--- a/Sources/Gavel/Review/CommandHTML.swift
+++ b/Sources/Gavel/Review/CommandHTML.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+/// Everything the full-command review page needs, assembled at approval time.
+///
+/// This page exists so the FULL, unredacted command never has to transit
+/// Telegram: the inline card stays redacted/truncated, and fidelity lives
+/// here — served loopback-only, reachable exclusively over the tailnet
+/// (same security model as the diff review page).
+struct CommandContent {
+    let sessionLabel: String
+    let toolName: String
+    let cwd: String?
+    /// The primary text (Bash command / file path), when the tool has one.
+    let command: String?
+    /// Remaining tool args rendered as name → value rows (MCP calls live here).
+    let args: [(name: String, value: String)]
+    let triggerReason: String?
+    /// True when the credential gate withheld the command from the Telegram
+    /// card — the page shows it anyway (tailnet-only), with a banner saying why.
+    let withheldInline: Bool
+}
+
+/// Server-side renderer for the mobile full-command page. Fully
+/// self-contained (inline CSS/JS, no external fetches), same as DiffHTML.
+enum CommandHTML {
+
+    static func page(content: CommandContent) -> String {
+        var banners = ""
+        if content.withheldInline {
+            banners += banner("Withheld from Telegram — possible credential in the command. This page never leaves your tailnet.")
+        }
+        if let reason = content.triggerReason, !reason.isEmpty {
+            banners += banner(DiffHTML.esc(reason))
+        }
+
+        var metaRows = ""
+        if let cwd = content.cwd, !cwd.isEmpty {
+            metaRows += metaRow("cwd", cwd)
+        }
+
+        var body = ""
+        if let command = content.command, !command.isEmpty {
+            body += "<section class=\"block\"><h2>Command</h2><pre>\(DiffHTML.esc(command))</pre></section>"
+        }
+        if !content.args.isEmpty {
+            let rows = content.args.map { arg in
+                "<div class=\"arg\"><div class=\"aname\">\(DiffHTML.esc(arg.name))</div><pre>\(DiffHTML.esc(arg.value))</pre></div>"
+            }.joined()
+            body += "<section class=\"block\"><h2>Arguments</h2>\(rows)</section>"
+        }
+        if body.isEmpty {
+            body = "<p class=\"empty\">No command text or arguments on this call.</p>"
+        }
+
+        let title = DiffHTML.esc("Approval — \(content.toolName)")
+        return """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>\(title)</title>
+        <style>\(css)</style>
+        </head>
+        <body>
+        <header>
+        <h1>\(DiffHTML.esc(content.toolName))</h1>
+        <p class="msg">\(DiffHTML.esc(content.sessionLabel))</p>
+        \(metaRows)
+        </header>
+        \(banners)
+        <main>\(body)</main>
+        <footer id="bar">
+        <textarea id="note" placeholder="Note to Claude (optional)"></textarea>
+        <div class="btns">
+        <button class="reject" onclick="submitVerdict('deny')">Deny</button>
+        <button class="approve" onclick="submitVerdict('allow')">Allow once</button>
+        </div>
+        </footer>
+        <script>\(js)</script>
+        </body>
+        </html>
+        """
+    }
+
+    private static func banner(_ escapedText: String) -> String {
+        "<div class=\"banner\">\(escapedText)</div>"
+    }
+
+    private static func metaRow(_ label: String, _ value: String) -> String {
+        "<p class=\"meta\"><span class=\"mlabel\">\(DiffHTML.esc(label))</span> \(DiffHTML.esc(value))</p>"
+    }
+
+    private static let css = """
+    :root { color-scheme: light dark; }
+    * { box-sizing: border-box; margin: 0; }
+    body { font-family: -apple-system, system-ui, sans-serif; font-size: 15px;
+           background: #f5f5f7; color: #1d1d1f; padding-bottom: 170px; }
+    header { padding: 14px 16px 8px; }
+    h1 { font-size: 17px; font-family: ui-monospace, monospace; word-break: break-all; }
+    h2 { font-size: 12px; text-transform: uppercase; letter-spacing: .04em;
+         opacity: .6; padding: 10px 12px 4px; }
+    .msg { font-style: italic; opacity: .8; margin-top: 4px; }
+    .meta { font-size: 13px; opacity: .75; margin-top: 4px; word-break: break-all; }
+    .mlabel { font-weight: 600; opacity: .8; margin-right: 4px; }
+    .banner { background: #fff8c5; border: 1px solid #d4a72c66; margin: 6px 12px;
+              padding: 8px 12px; border-radius: 8px; font-size: 13px; }
+    .block { background: #fff; margin: 8px 8px; border-radius: 10px; overflow: hidden;
+             border: 1px solid #0000001a; }
+    pre { font-family: ui-monospace, monospace; font-size: 12.5px; line-height: 1.5;
+          padding: 8px 12px 12px; overflow-x: auto; white-space: pre-wrap;
+          word-break: break-word; }
+    .arg { border-top: 1px solid #0000000d; }
+    .arg:first-of-type { border-top: none; }
+    .aname { font-family: ui-monospace, monospace; font-size: 11px; font-weight: 700;
+             opacity: .65; padding: 8px 12px 0; }
+    .empty { padding: 24px; text-align: center; opacity: .7; }
+    footer { position: fixed; bottom: 0; left: 0; right: 0; background: #fffffff2;
+             backdrop-filter: blur(10px); border-top: 1px solid #0002; padding: 10px 0
+             calc(10px + env(safe-area-inset-bottom)); }
+    textarea { width: calc(100% - 24px); margin: 0 12px 8px; padding: 8px;
+               border-radius: 8px; border: 1px solid #0003; font-size: 15px;
+               font-family: inherit; min-height: 44px; background: inherit; color: inherit; }
+    .btns { display: flex; gap: 10px; padding: 0 12px; }
+    .btns button { flex: 1; padding: 12px; border-radius: 10px; border: none;
+                   font-size: 16px; font-weight: 600; }
+    .approve { background: #1a7f37; color: #fff; }
+    .reject { background: #cf222e; color: #fff; }
+    button:disabled { opacity: .5; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #161618; color: #f5f5f7; }
+      .block { background: #1e1e20; border-color: #ffffff1a; }
+      .banner { background: #3a3117; border-color: #d4a72c44; }
+      footer { background: #161618f2; border-color: #fff2; }
+      textarea { border-color: #fff3; }
+    }
+    """
+
+    private static let js = """
+    function submitVerdict(verdict) {
+      const note = document.getElementById('note').value.trim();
+      document.querySelectorAll('.btns button').forEach(function (b) { b.disabled = true; });
+      fetch(location.pathname + '/verdict', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ verdict: verdict, note: note || null })
+      }).then(function (r) {
+        if (r.ok) {
+          finish(verdict === 'allow' ? '✅ Allowed — command proceeding.' : '🛑 Denied.');
+        } else if (r.status === 409) {
+          finish('Already resolved elsewhere (Mac panel or Telegram).');
+        } else {
+          fail('Submit failed: HTTP ' + r.status);
+        }
+      }).catch(function (e) { fail('Submit failed: ' + e); });
+    }
+    function finish(msg) {
+      document.body.innerHTML = '<header><h1>' + msg + '</h1><p class="msg">You can close this tab.</p></header>';
+    }
+    function fail(msg) {
+      document.querySelectorAll('.btns button').forEach(function (b) { b.disabled = false; });
+      alert(msg);
+    }
+    """
+}

--- a/Sources/Gavel/Review/DiffReviewServer.swift
+++ b/Sources/Gavel/Review/DiffReviewServer.swift
@@ -27,9 +27,15 @@ final class DiffReviewServer {
 
     static let shared = DiffReviewServer()
 
+    /// What a registered nonce serves: a commit diff or a full-command page.
+    enum PageContent {
+        case diff(ReviewContent)
+        case command(CommandContent)
+    }
+
     final class ReviewSession {
         let nonce: String
-        let content: ReviewContent
+        let content: PageContent
         let resolvable: ResolvableApproval
         let createdAt = Date()
         /// Set (under the server lock) once any source resolves the approval.
@@ -41,7 +47,7 @@ final class DiffReviewServer {
         /// set this, so it can't be back-filled once the race is over.
         var viewedAt: Date?
 
-        init(nonce: String, content: ReviewContent, resolvable: ResolvableApproval) {
+        init(nonce: String, content: PageContent, resolvable: ResolvableApproval) {
             self.nonce = nonce
             self.content = content
             self.resolvable = resolvable
@@ -116,10 +122,21 @@ final class DiffReviewServer {
 
     // MARK: - Registration
 
-    /// Registers a review for a pending approval and returns its nonce.
+    /// Registers a commit-diff review for a pending approval and returns its nonce.
     /// The review dies with the approval: any resolution (mac / telegram /
     /// timeout / web) flips it to the "already resolved" page.
     func register(content: ReviewContent, resolvable: ResolvableApproval) -> String {
+        register(page: .diff(content), resolvable: resolvable, reviewedNoun: "the diff")
+    }
+
+    /// Registers a full-command page for a pending approval — the phone-side
+    /// twin of the Mac panel's command view, so the unredacted command never
+    /// has to transit Telegram.
+    func register(command: CommandContent, resolvable: ResolvableApproval) -> String {
+        register(page: .command(command), resolvable: resolvable, reviewedNoun: "the full command")
+    }
+
+    private func register(page: PageContent, resolvable: ResolvableApproval, reviewedNoun: String) -> String {
         pruneStale()
 
         var bytes = [UInt8](repeating: 0, count: 16)
@@ -129,7 +146,7 @@ final class DiffReviewServer {
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
 
-        let session = ReviewSession(nonce: nonce, content: content, resolvable: resolvable)
+        let session = ReviewSession(nonce: nonce, content: page, resolvable: resolvable)
         lock.lock()
         sessions[nonce] = session
         lock.unlock()
@@ -154,8 +171,8 @@ final class DiffReviewServer {
             // Standalone form when there's no note; appended line otherwise.
             let hasNote = !(decision.additionalContext?.isEmpty ?? true)
             return decision.appendingContext(hasNote
-                ? "User reviewed the diff before approving."
-                : "User approved this via Gavel — user reviewed the diff before approving")
+                ? "User reviewed \(reviewedNoun) before approving."
+                : "User approved this via Gavel — user reviewed \(reviewedNoun) before approving")
         }
         return nonce
     }
@@ -236,8 +253,15 @@ final class DiffReviewServer {
             if firstView {
                 gavelLog("[review] page viewed nonce=\(session.nonce.prefix(8))…")
             }
-            let page = resolvedBy.map { DiffHTML.resolvedPage(by: label($0)) }
-                ?? DiffHTML.page(content: session.content)
+            let page: String
+            if let resolvedBy {
+                page = DiffHTML.resolvedPage(by: label(resolvedBy))
+            } else {
+                switch session.content {
+                case .diff(let content): page = DiffHTML.page(content: content)
+                case .command(let content): page = CommandHTML.page(content: content)
+                }
+            }
             send(connection, status: 200, body: page, contentType: "text/html; charset=utf-8")
             return
         }
@@ -328,6 +352,17 @@ final class DiffReviewServer {
             reason += comments.isEmpty ? ":" : " (\(comments.count) comment\(comments.count == 1 ? "" : "s")):"
             reason += "\n" + (lines.isEmpty ? "See the review page — no comment text was attached." : lines.joined(separator: "\n"))
             return Decision(verdict: .block, reason: reason)
+        // Full-command page verbs — same wire route, allow/deny semantics.
+        case "allow":
+            let note = submission.note.flatMap { $0.isEmpty ? nil : $0 }
+            return Decision(
+                verdict: .allow, reason: "Approved from command review page",
+                additionalContext: note.map { "Approver note from review page: \($0)" })
+        case "deny":
+            let note = submission.note.flatMap { $0.isEmpty ? nil : $0 }
+            return Decision(
+                verdict: .block,
+                reason: "Denied from command review page" + (note.map { " — \($0)" } ?? ""))
         default:
             return nil
         }

--- a/Sources/Gavel/Review/TailscaleServe.swift
+++ b/Sources/Gavel/Review/TailscaleServe.swift
@@ -7,8 +7,11 @@ import Foundation
 /// authenticated tailnet peers. A dedicated HTTPS port keeps the mapping
 /// from clobbering any serve config the user runs on 443.
 ///
-/// No caching: status + registration re-run per review so a `tailscale
-/// serve reset` or daemon flap between commits can't leave stale links.
+/// Discovery + registration re-run per link with a short (60s) result
+/// cache: fresh enough that a `tailscale serve reset` or daemon flap can't
+/// leave stale links for long, but a burst of approvals (every one now
+/// carries a full-command link) doesn't fork two CLI probes each — and a
+/// down tailscale (10s command deadline) can't add 10s to every approval.
 ///
 /// A Mac can run SEVERAL independent backends at once: the Tailscale.app
 /// system extension plus any number of homebrew tailscaleds with custom
@@ -92,6 +95,33 @@ enum TailscaleServe {
             "/usr/local/bin/tailscale",
             "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
         ].filter { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    private static var cachedBase: (url: String?, at: Date)?
+    private static let cacheLock = NSLock()
+    static let cacheTTL: TimeInterval = 60
+
+    /// Cached front-end for `reviewBaseURL()` — successes AND failures both
+    /// hold for `cacheTTL` so per-approval links stay cheap either way.
+    static func cachedReviewBaseURL(now: Date = Date()) -> String? {
+        cacheLock.lock()
+        if let cached = cachedBase, now.timeIntervalSince(cached.at) < cacheTTL {
+            cacheLock.unlock()
+            return cached.url
+        }
+        cacheLock.unlock()
+        let url = reviewBaseURL()
+        cacheLock.lock()
+        cachedBase = (url, now)
+        cacheLock.unlock()
+        return url
+    }
+
+    /// Test seam — drop the cache so stubs take effect immediately.
+    static func resetCache() {
+        cacheLock.lock()
+        cachedBase = nil
+        cacheLock.unlock()
     }
 
     /// Base URL for review links (e.g. "https://host.tailnet.ts.net:8443"),

--- a/Sources/Gavel/main.swift
+++ b/Sources/Gavel/main.swift
@@ -121,6 +121,10 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
         sessionManager.onPhoneStopped = { [weak bridge] affected in
             bridge?.sendNotice("🛑 Phone approval OFF — \(affected) session(s) disabled, Default Phone off.")
         }
+        bridge.proposalStore = proposalStore
+        proposalStore.onSubmitted = { [weak bridge] proposal in
+            bridge?.notifyProposal(proposal)
+        }
         approvalCoordinator.remoteBridge = bridge
         remoteBridge = bridge
         bridge.start()
@@ -129,7 +133,7 @@ class GavelAppDelegate: NSObject, NSApplicationDelegate {
     @objc private func configureTelegram() {
         let alert = NSAlert()
         alert.messageText = "Configure Telegram Remote Approval"
-        alert.informativeText = "Paste your bot token from @BotFather. After saving, open your bot in Telegram and send /start to pair this chat. Remote approval must also be enabled per session in the Sessions tab. Command text is sent to Telegram's servers; for payloads with detected credentials the command is withheld and only metadata plus the approval buttons are sent."
+        alert.informativeText = "Paste your bot token from @BotFather. After saving, open your bot in Telegram and send /start to pair this chat. Remote approval must also be enabled per session in the Sessions tab. Only a redacted, truncated summary is sent to Telegram's servers — the full command is served on a tailnet-only page linked from each card, and for payloads with detected credentials even the summary is withheld."
         let field = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
         field.placeholderString = "123456789:ABCdef..."
         alert.accessoryView = field

--- a/Tests/GavelTests/CommandReviewTests.swift
+++ b/Tests/GavelTests/CommandReviewTests.swift
@@ -1,0 +1,345 @@
+import XCTest
+
+@testable import Gavel
+
+/// Full-command review page + Telegram proposal adjudication.
+final class CommandReviewTests: XCTestCase {
+
+    private var server: DiffReviewServer!
+    private var port: UInt16!
+    private let owner: Int64 = 42
+
+    override func setUpWithError() throws {
+        server = DiffReviewServer()
+        try server.start(port: 0)
+        port = try XCTUnwrap(server.boundPort)
+    }
+
+    override func tearDown() {
+        server.stop()
+        server = nil
+    }
+
+    // MARK: - Helpers
+
+    private func makeCommand(
+        command: String? = "aws s3 cp s3://bucket/very-long-key /tmp/x --profile Prod-123",
+        args: [(name: String, value: String)] = [],
+        withheldInline: Bool = false
+    ) -> CommandContent {
+        CommandContent(
+            sessionLabel: "argscope",
+            toolName: command != nil ? "Bash" : "mcp__Slack__read_history",
+            cwd: "/Users/x/code/project",
+            command: command,
+            args: args,
+            triggerReason: "Default rule: something fired",
+            withheldInline: withheldInline)
+    }
+
+    private struct HTTPResult {
+        let status: Int
+        let body: String
+    }
+
+    private func request(_ path: String, method: String = "GET", body: String? = nil) throws -> HTTPResult {
+        var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port!)\(path)")!)
+        req.httpMethod = method
+        if let body {
+            req.httpBody = Data(body.utf8)
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        var result: HTTPResult?
+        let done = DispatchSemaphore(value: 0)
+        URLSession.shared.dataTask(with: req) { data, response, _ in
+            if let http = response as? HTTPURLResponse {
+                result = HTTPResult(
+                    status: http.statusCode,
+                    body: String(decoding: data ?? Data(), as: UTF8.self))
+            }
+            done.signal()
+        }.resume()
+        guard done.wait(timeout: .now() + 10) == .success else {
+            throw XCTSkip("HTTP request timed out")
+        }
+        return try XCTUnwrap(result)
+    }
+
+    // MARK: - Command page rendering
+
+    func testCommandPageRendersFullCommandUnredacted() throws {
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(command: makeCommand(), resolvable: resolvable)
+
+        let res = try request("/review/\(nonce)")
+        XCTAssertEqual(res.status, 200)
+        // The whole point: the FULL command, not the Telegram-truncated form.
+        XCTAssertTrue(res.body.contains("aws s3 cp s3://bucket/very-long-key /tmp/x --profile Prod-123"))
+        XCTAssertTrue(res.body.contains("argscope"))
+        XCTAssertTrue(res.body.contains("/Users/x/code/project"))
+        XCTAssertTrue(res.body.contains("Default rule: something fired"))
+    }
+
+    func testCommandPageRendersMCPArgs() throws {
+        let resolvable = ResolvableApproval { _ in }
+        let content = makeCommand(command: nil, args: [
+            (name: "channel", value: "general"),
+            (name: "workspace", value: "defiance"),
+        ])
+        let nonce = server.register(command: content, resolvable: resolvable)
+
+        let res = try request("/review/\(nonce)")
+        XCTAssertTrue(res.body.contains("mcp__Slack__read_history"))
+        XCTAssertTrue(res.body.contains("channel"))
+        XCTAssertTrue(res.body.contains("general"))
+        XCTAssertTrue(res.body.contains("workspace"))
+        XCTAssertTrue(res.body.contains("defiance"))
+    }
+
+    func testCommandPageEscapesHTML() throws {
+        let resolvable = ResolvableApproval { _ in }
+        let content = makeCommand(command: "echo '<script>alert(1)</script>'")
+        let nonce = server.register(command: content, resolvable: resolvable)
+
+        let res = try request("/review/\(nonce)")
+        XCTAssertFalse(res.body.contains("<script>alert(1)</script>"))
+        XCTAssertTrue(res.body.contains("&lt;script&gt;alert(1)&lt;/script&gt;"))
+    }
+
+    func testWithheldBannerShownOnPage() throws {
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(command: makeCommand(withheldInline: true), resolvable: resolvable)
+
+        let res = try request("/review/\(nonce)")
+        XCTAssertTrue(res.body.contains("Withheld from Telegram"))
+    }
+
+    // MARK: - Command page verdicts
+
+    func testAllowVerdictResolvesWithNote() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(command: makeCommand(), resolvable: resolvable)
+
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"allow","note":"checked the profile"}"#)
+        XCTAssertEqual(res.status, 200)
+
+        let d = try XCTUnwrap(decision)
+        XCTAssertEqual(d.verdict, .allow)
+        XCTAssertEqual(d.additionalContext?.contains("checked the profile"), true)
+    }
+
+    func testDenyVerdictCarriesNoteInReason() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(command: makeCommand(), resolvable: resolvable)
+
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"deny","note":"wrong account"}"#)
+        XCTAssertEqual(res.status, 200)
+
+        let d = try XCTUnwrap(decision)
+        XCTAssertEqual(d.verdict, .block)
+        XCTAssertEqual(d.reason?.contains("wrong account"), true)
+    }
+
+    func testResolvedCommandPageStopsServingCommand() throws {
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(command: makeCommand(), resolvable: resolvable)
+
+        _ = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"allow"}"#)
+        let page = try request("/review/\(nonce)")
+        XCTAssertEqual(page.status, 200)
+        XCTAssertTrue(page.body.contains("Already resolved"))
+        XCTAssertFalse(page.body.contains("aws s3 cp"))
+    }
+
+    func testReviewedSignalMentionsFullCommand() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(command: makeCommand(), resolvable: resolvable)
+
+        // View the page first, then approve from another source (phone/Mac).
+        _ = try request("/review/\(nonce)")
+        _ = resolvable.resolve(Decision(verdict: .allow, reason: "Approved from phone"), from: .telegram)
+
+        let d = try XCTUnwrap(decision)
+        XCTAssertEqual(d.additionalContext?.contains("reviewed the full command"), true)
+    }
+
+    func testUnviewedApprovalHasNoReviewedSignal() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        _ = server.register(command: makeCommand(), resolvable: resolvable)
+
+        _ = resolvable.resolve(Decision(verdict: .allow, reason: "Approved from phone"), from: .telegram)
+        let d = try XCTUnwrap(decision)
+        XCTAssertNil(d.additionalContext)
+    }
+
+    // MARK: - Telegram command-link button
+
+    func testCommandURLButtonPresent() throws {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        let approval = ResolvableApproval { _ in }
+
+        bridge.notify(
+            resolvable: approval, text: "body", allowSession: nil,
+            commandURL: "https://mac.tail1234.ts.net:8443/review/xyz")
+
+        let keyboard = try XCTUnwrap(fake.sentMessages.last?.keyboard)
+        let first = try XCTUnwrap(keyboard.first?.first)
+        XCTAssertEqual(first.text, "📄 Full command")
+        XCTAssertEqual(first.url, "https://mac.tail1234.ts.net:8443/review/xyz")
+        XCTAssertNil(first.callbackData)
+    }
+
+    func testWithheldCommandURLButtonRelabeled() throws {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        let approval = ResolvableApproval { _ in }
+
+        bridge.notify(
+            resolvable: approval, text: "body", withheld: true, allowSession: nil,
+            commandURL: "https://mac.tail1234.ts.net:8443/review/xyz")
+
+        let keyboard = try XCTUnwrap(fake.sentMessages.last?.keyboard)
+        XCTAssertEqual(keyboard.first?.first?.text, "🔒 View full command")
+    }
+
+    func testReviewAndCommandLinksShareTheLeadingRow() throws {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        let approval = ResolvableApproval { _ in }
+
+        bridge.notify(
+            resolvable: approval, text: "commit?", allowSession: nil,
+            reviewURL: "https://mac.tail1234.ts.net:8443/review/diff1",
+            commandURL: "https://mac.tail1234.ts.net:8443/review/cmd1")
+
+        let keyboard = try XCTUnwrap(fake.sentMessages.last?.keyboard)
+        let linkRow = try XCTUnwrap(keyboard.first)
+        XCTAssertEqual(linkRow.map(\.text), ["🔍 Review diff", "📄 Full command"])
+    }
+
+    func testSummaryBodyTruncationPointsAtLink() {
+        let long = String(repeating: "x", count: GavelConstants.telegramBodyMaxChars + 100)
+        let payload = PreToolUsePayload(toolName: "Bash", toolInput: ["command": AnyCodable(long)])
+        let session = Session(pid: 1)
+
+        let linked = RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: nil, hasCommandLink: true)
+        XCTAssertTrue(linked.contains("full at the link"))
+
+        let unlinked = RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: nil)
+        XCTAssertTrue(unlinked.contains("full on Mac"))
+    }
+
+    // MARK: - Proposal adjudication from Telegram
+
+    private func makeStores() -> (ProposalStore, RuleStore) {
+        let dir = NSTemporaryDirectory() + "gavel-cmdreview-test-\(UUID().uuidString)"
+        let ruleStore = RuleStore(configPath: dir + "/rules.json")
+        let proposals = ProposalStore(path: dir + "/proposals.json")
+        proposals.ruleStore = ruleStore
+        return (proposals, ruleStore)
+    }
+
+    private func submitProposal(_ store: ProposalStore) -> UUID {
+        let result = store.submit(
+            toolName: "Bash", pattern: "rm\\s+-rf\\s+/", isRegex: true, verdict: "deny",
+            reason: "Catastrophic delete pattern seen in session", example: "rm -rf / --no-preserve-root",
+            sessionPid: 111, sessionId: nil)
+        guard case .queued(let id) = result else {
+            XCTFail("proposal not queued: \(result)")
+            return UUID()
+        }
+        return id
+    }
+
+    private func proposalCallback(action: String, id: UUID, messageId: Int = 100) -> TelegramUpdate {
+        TelegramUpdate(
+            updateId: 1,
+            callback: TelegramCallback(id: "cb1", fromId: owner, chatId: owner, messageId: messageId, data: "\(action):\(id.uuidString)"),
+            message: nil)
+    }
+
+    func testProposalNotifySendsCardWithAdjudicationButtons() throws {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        let (proposals, _) = makeStores()
+        bridge.proposalStore = proposals
+        let id = submitProposal(proposals)
+        let proposal = try XCTUnwrap(proposals.proposals.first { $0.id == id })
+
+        bridge.notifyProposal(proposal)
+
+        let sent = try XCTUnwrap(fake.sentMessages.last)
+        XCTAssertTrue(sent.text.contains("Claude proposed a rule"))
+        XCTAssertTrue(sent.text.contains("rm\\s+-rf\\s+/"))
+        XCTAssertTrue(sent.text.contains("DENY"))
+        let callbacks = (sent.keyboard ?? []).flatMap { $0 }.compactMap(\.callbackData)
+        XCTAssertTrue(callbacks.contains("pa:\(id.uuidString)"))
+        XCTAssertTrue(callbacks.contains("pj:\(id.uuidString)"))
+    }
+
+    func testProposalAcceptFromPhoneCreatesRule() throws {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        let (proposals, ruleStore) = makeStores()
+        bridge.proposalStore = proposals
+        let id = submitProposal(proposals)
+
+        bridge.handle(proposalCallback(action: "pa", id: id))
+
+        XCTAssertTrue(ruleStore.rules.contains { $0.pattern == "rm\\s+-rf\\s+/" && $0.verdict == .block })
+        XCTAssertTrue(proposals.proposals.isEmpty)
+        XCTAssertEqual(fake.edits.last?.text.contains("Rule accepted from phone"), true)
+    }
+
+    func testProposalRejectFromPhoneDropsWithoutRule() throws {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        let (proposals, ruleStore) = makeStores()
+        bridge.proposalStore = proposals
+        let id = submitProposal(proposals)
+
+        bridge.handle(proposalCallback(action: "pj", id: id))
+
+        XCTAssertFalse(ruleStore.rules.contains { $0.pattern == "rm\\s+-rf\\s+/" })
+        XCTAssertTrue(proposals.proposals.isEmpty)
+        XCTAssertEqual(fake.edits.last?.text.contains("rejected from phone"), true)
+    }
+
+    func testProposalTapAfterMonitorAdjudicationIsNoOp() throws {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        let (proposals, ruleStore) = makeStores()
+        bridge.proposalStore = proposals
+        let id = submitProposal(proposals)
+
+        proposals.reject(id: id, via: "monitor")
+        let rulesBefore = ruleStore.rules.count
+        bridge.handle(proposalCallback(action: "pa", id: id))
+
+        XCTAssertEqual(ruleStore.rules.count, rulesBefore)
+        XCTAssertEqual(fake.answers.last?.text, "Already handled")
+    }
+
+    func testProposalCallbackFromWrongChatIgnored() throws {
+        let fake = FakeTelegramTransport()
+        let bridge = RemoteApprovalBridge(transport: fake, chatId: owner)
+        let (proposals, ruleStore) = makeStores()
+        bridge.proposalStore = proposals
+        let id = submitProposal(proposals)
+
+        let stranger = TelegramUpdate(
+            updateId: 1,
+            callback: TelegramCallback(id: "cb2", fromId: 666, chatId: 666, messageId: 5, data: "pa:\(id.uuidString)"),
+            message: nil)
+        bridge.handle(stranger)
+
+        XCTAssertFalse(ruleStore.rules.contains { $0.pattern == "rm\\s+-rf\\s+/" })
+        XCTAssertEqual(proposals.proposals.count, 1)
+        XCTAssertEqual(fake.answers.last?.text, "Not authorized")
+    }
+}


### PR DESCRIPTION
## What

Closes the two remaining gaps in the phone approval workflow, both using the diff-review exposure model (loopback-only server, tailnet reachability exclusively via `tailscale serve`, per-approval nonce as the sole capability):

### 1. Full command on every Telegram card — via a tailnet link, never inline

Every mirrored approval now carries a **📄 Full command** button linking to a page that shows the complete, unredacted command (or the full MCP arg set), session label, cwd, and trigger reason. The inline Telegram body stays redacted + truncated exactly as today — that text transits Telegram's servers; the page never leaves the tailnet.

**The link is always present, not just for redacted payloads**: the 3,500-char inline truncation bites on any long command, Telegram mangles code-ish text, and one habit (tap the link when you need the truth) beats two. Design points:

- Credential-withheld cards keep their metadata-only inline text and get a **🔒 View full command** button pointing at the page (which shows a "withheld from Telegram" banner explaining why).
- The page offers **Allow once / Deny (+ note to Claude)** as a `.web` resolver racing the Mac panel and the Telegram buttons — same exactly-one-decision guarantee.
- The PR #198 reviewed-signal generalizes: opening the page before approving (from *any* responder) appends "user reviewed the full command before approving" to the decision context.
- Commits keep the diff-review link and gain the command link in the same button row.
- `TailscaleServe` gains a 60s result cache (successes **and** failures) — links now go out per-approval, and without it a down tailscale would add its 10s CLI deadline to every approval in the queue.

### 2. Rule-proposal adjudication from the phone

A queued `gavel-hook propose-rule` proposal now mirrors to Telegram with **✅ Accept rule / ❌ Reject** buttons (`pa:`/`pj:` on the existing callback channel). Adjudication runs through the same audited `ProposalStore` path as the Monitor buttons (`accepted-via=telegram` in the audit journal).

Safety: tighten-only was already enforced server-side at submit (allow proposals are rejected before they ever reach the inbox), so a phone Accept can only create deny/prompt rules — the phone cannot widen permissions through this channel. The Monitor inbox stays the source of truth: proposals dropped by flood control or sent while the phone is unpaired remain adjudicable there, and a tap on an already-adjudicated proposal is a no-op ("Already handled").

## Tests

18 new tests in `CommandReviewTests`: page renders full command/MCP args unredacted, HTML injection escaped, withheld banner, allow/deny verdict mapping with notes, resolved page stops serving content, reviewed-signal wording, button labels/rows, truncation message points at the link, and the proposal flow end-to-end against real `ProposalStore` + `RuleStore` on temp paths (accept creates the rule, reject doesn't, post-adjudication tap is a no-op, wrong-chat callback ignored).

`swift test`: 753 tests, one pre-existing environmental failure (`testLiveClaudeSessionDiscoveryAgainstPsWitness` — live process discovery, fails on main too).

## Follow-up (after #200 and this both land)

Scoped Always-Allow authoring on the command page — per-arg checkbox rows prefilled from the live call, the phone twin of #200's panel rows. That makes "allow this Slack watcher for exactly this channel+workspace" a from-the-phone operation.