### PR TITLE
feat(approval): scoped Always Allow authoring on the command review page

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -204,7 +204,7 @@ final class ApprovalCoordinator: ObservableObject {
         let reviewURL = isCommit ? makeReviewLink(payload: payload, session: session, resolvable: resolvable) : nil
         // Full-command link on EVERY mirrored approval — Telegram keeps the
         // redacted/truncated summary, full fidelity lives on the tailnet page.
-        let commandURL = makeCommandLink(payload: payload, session: session, resolvable: resolvable, triggerReason: pending.triggerReason, withheldInline: withheld != nil)
+        let commandURL = makeCommandLink(payload: payload, session: session, resolvable: resolvable, triggerReason: pending.triggerReason, withheldInline: withheld != nil, nonSuppressible: pending.nonSuppressible)
         let text = withheld != nil
             ? RemoteApprovalBridge.withheldBody(payload: payload, session: session, hasCommandLink: commandURL != nil)
             : RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: pending.triggerReason, hasCommandLink: commandURL != nil)
@@ -214,7 +214,7 @@ final class ApprovalCoordinator: ObservableObject {
     /// Register the full, unredacted command with the review server and
     /// return its tailnet URL. Failures are soft — nil just means the
     /// Telegram card goes out with the redacted inline text only.
-    private func makeCommandLink(payload: PreToolUsePayload, session: Session, resolvable: ResolvableApproval, triggerReason: String?, withheldInline: Bool) -> String? {
+    private func makeCommandLink(payload: PreToolUsePayload, session: Session, resolvable: ResolvableApproval, triggerReason: String?, withheldInline: Bool, nonSuppressible: Bool) -> String? {
         do {
             try DiffReviewServer.shared.start()
         } catch {
@@ -225,12 +225,35 @@ final class ApprovalCoordinator: ObservableObject {
 
         let primary = payload.command ?? payload.filePath
         // Everything except the primary text becomes an args row, so MCP
-        // calls (no command/filePath) still show their full input.
+        // calls (no command/filePath) still show their full input. Scalar
+        // args of MCP calls can anchor a scoped Always Allow on the page.
+        let isMCP = payload.toolName.hasPrefix("mcp__")
         let primaryKeys: Set<String> = payload.command != nil ? ["command"] : (payload.filePath != nil ? ["file_path", "path"] : [])
         let args = payload.toolInput
-            .filter { !primaryKeys.contains($0.key) }
-            .map { (name: $0.key, value: Self.displayString($0.value)) }
-            .sorted { $0.name < $1.name }
+            .filter { argName, _ in !primaryKeys.contains(argName) }
+            .map { argName, argValue in
+                CommandArg(
+                    name: argName,
+                    value: Self.displayString(argValue),
+                    scopable: isMCP && PersistentRule.scalarString(argValue) != nil)
+            }
+            .sorted { lhs, rhs in lhs.name < rhs.name }
+
+        // Scoped-allow authoring mirrors the Mac panel's gating: MCP calls
+        // with at least one scalar arg, never on Allow-once-only paths.
+        let offersScopedAllow = !nonSuppressible && args.contains(where: \.scopable)
+        let createScopedAllow: (([String: String]) -> String)? = !offersScopedAllow ? nil : { [weak self] conditions in
+            let rule = PersistentRule(
+                toolName: payload.toolName, pattern: "*", isRegex: false,
+                verdict: .allow, argConditions: conditions)
+            // Rule mutations happen on main (house pattern for RuleStore) —
+            // the page's decision allows THIS call regardless, so the rule
+            // landing a tick later loses nothing.
+            DispatchQueue.main.async {
+                self?.ruleStore?.addRule(rule, origin: "command-page:always-allow-scoped")
+            }
+            return rule.name
+        }
 
         let label = session.label.isEmpty ? "PID \(session.pid)" : session.label
         let content = CommandContent(
@@ -240,9 +263,10 @@ final class ApprovalCoordinator: ObservableObject {
             command: primary,
             args: args,
             triggerReason: triggerReason,
-            withheldInline: withheldInline)
-        let nonce = DiffReviewServer.shared.register(command: content, resolvable: resolvable)
-        gavelLog("[review] command link created pid=\(session.pid) tool=\(payload.toolName) nonce=\(nonce.prefix(8))…")
+            withheldInline: withheldInline,
+            offersScopedAllow: offersScopedAllow)
+        let nonce = DiffReviewServer.shared.register(command: content, resolvable: resolvable, createScopedAllow: createScopedAllow)
+        gavelLog("[review] command link created pid=\(session.pid) tool=\(payload.toolName) scopedAllow=\(offersScopedAllow) nonce=\(nonce.prefix(8))…")
         return "\(base)/review/\(nonce)"
     }
 

--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -254,6 +254,20 @@ final class ApprovalCoordinator: ObservableObject {
             }
             return rule.name
         }
+        // Session-lifetime variant: same scoping, but the rule lives in
+        // session.sessionRules and dies with the session — for "let this
+        // watcher read this channel today" without a persistent grant.
+        let createScopedSessionAllow: (([String: String]) -> String)? = !offersScopedAllow ? nil : { conditions in
+            let rule = SessionRule(
+                toolName: payload.toolName, pattern: "*",
+                verdict: .allow, argConditions: conditions)
+            DispatchQueue.main.async {
+                session.sessionRules.append(rule)
+            }
+            let scope = conditions.sorted { $0.key < $1.key }
+                .map { "\($0.key)=/\($0.value)/" }.joined(separator: ", ")
+            return "\(payload.toolName) [\(scope)]"
+        }
 
         let label = session.label.isEmpty ? "PID \(session.pid)" : session.label
         let content = CommandContent(
@@ -265,7 +279,7 @@ final class ApprovalCoordinator: ObservableObject {
             triggerReason: triggerReason,
             withheldInline: withheldInline,
             offersScopedAllow: offersScopedAllow)
-        let nonce = DiffReviewServer.shared.register(command: content, resolvable: resolvable, createScopedAllow: createScopedAllow)
+        let nonce = DiffReviewServer.shared.register(command: content, resolvable: resolvable, createScopedAllow: createScopedAllow, createScopedSessionAllow: createScopedSessionAllow)
         gavelLog("[review] command link created pid=\(session.pid) tool=\(payload.toolName) scopedAllow=\(offersScopedAllow) nonce=\(nonce.prefix(8))…")
         return "\(base)/review/\(nonce)"
     }

--- a/Sources/Gavel/Approval/ArgConditionMatcher.swift
+++ b/Sources/Gavel/Approval/ArgConditionMatcher.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Shared arg-condition semantics for persistent AND session rules: every
+/// condition regex must FULLY match (`\A(?:…)\z`) the stringified scalar arg.
+/// Absent arg, non-scalar value, or an uncompilable pattern all fail closed —
+/// the rule doesn't fire and evaluation falls through to the normal prompt.
+enum ArgConditionMatcher {
+
+    /// Anchor so a condition can't substring-match (`C123` must not pass
+    /// `C1234`) and newlines can't smuggle a second value past the match.
+    static func compileAnchored(_ pattern: String) -> NSRegularExpression? {
+        try? NSRegularExpression(pattern: "\\A(?:\(pattern))\\z")
+    }
+
+    /// Uncached evaluation — used by SessionRule (session-lifetime structs,
+    /// low volume). PersistentRule keeps its own per-rule regex cache.
+    static func satisfied(_ conditions: [String: String]?, by toolInput: [String: AnyCodable]?) -> Bool {
+        guard let conditions, !conditions.isEmpty else { return true }
+        for (arg, pattern) in conditions {
+            guard let value = toolInput?[arg].flatMap(PersistentRule.scalarString),
+                  let regex = compileAnchored(pattern),
+                  regex.firstMatch(in: value, range: NSRange(value.startIndex..., in: value)) != nil
+            else { return false }
+        }
+        return true
+    }
+}

--- a/Sources/Gavel/Approval/RuleStore.swift
+++ b/Sources/Gavel/Approval/RuleStore.swift
@@ -830,11 +830,11 @@ struct PersistentRule: Codable, Identifiable {
         }
     }
 
-    /// Anchored `\A(?:pattern)\z` so a condition can't substring-match
+    /// Anchored via ArgConditionMatcher so a condition can't substring-match
     /// (`C123` must not pass `C1234`) — strictly narrower, tighten-only.
     private mutating func compiledArgRegex(arg: String, pattern: String) -> NSRegularExpression? {
         if let cached = _compiledArgRegexes[arg] { return cached }
-        guard let regex = try? NSRegularExpression(pattern: "\\A(?:\(pattern))\\z") else { return nil }
+        guard let regex = ArgConditionMatcher.compileAnchored(pattern) else { return nil }
         _compiledArgRegexes[arg] = regex
         return regex
     }

--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -207,7 +207,8 @@ final class HookRouter {
         if let rule = session.matchesSessionDeny(
             toolName: payload.toolName,
             command: payload.command,
-            filePath: payload.filePath
+            filePath: payload.filePath,
+            toolInput: payload.toolInput
         ) {
             session.stats.incrementBlock()
             let reason = "Session deny: \(rule.toolName): \(rule.pattern)"
@@ -236,7 +237,8 @@ final class HookRouter {
                     if let rule = session.matchesSessionRule(
                         toolName: payload.toolName,
                         command: payload.command,
-                        filePath: payload.filePath
+                        filePath: payload.filePath,
+                        toolInput: payload.toolInput
                     ) {
                         session.stats.incrementAllow()
                         emitFeed(.decision(badge: .allow, reason: "Session rule: \(rule.toolName): \(rule.pattern)", pid: session.pid, at: timestamp))
@@ -306,7 +308,8 @@ final class HookRouter {
         if let rule = session.matchesSessionRule(
             toolName: payload.toolName,
             command: payload.command,
-            filePath: payload.filePath
+            filePath: payload.filePath,
+            toolInput: payload.toolInput
         ) {
             session.stats.incrementAllow()
             emitFeed(.decision(badge: .allow, reason: "\(rule.toolName): \(rule.pattern)", pid: session.pid, at: timestamp))

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -173,13 +173,13 @@ final class Session: ObservableObject, Identifiable {
     }
 
     /// Check if a tool call matches any session allow rule.
-    func matchesSessionRule(toolName: String, command: String?, filePath: String?) -> SessionRule? {
-        sessionRules.first { $0.verdict == .allow && $0.matches(toolName: toolName, command: command, filePath: filePath) }
+    func matchesSessionRule(toolName: String, command: String?, filePath: String?, toolInput: [String: AnyCodable]? = nil) -> SessionRule? {
+        sessionRules.first { $0.verdict == .allow && $0.matches(toolName: toolName, command: command, filePath: filePath, toolInput: toolInput) }
     }
 
     /// Check if a tool call matches any session deny rule.
-    func matchesSessionDeny(toolName: String, command: String?, filePath: String?) -> SessionRule? {
-        sessionRules.first { $0.verdict == .block && $0.matches(toolName: toolName, command: command, filePath: filePath) }
+    func matchesSessionDeny(toolName: String, command: String?, filePath: String?, toolInput: [String: AnyCodable]? = nil) -> SessionRule? {
+        sessionRules.first { $0.verdict == .block && $0.matches(toolName: toolName, command: command, filePath: filePath, toolInput: toolInput) }
     }
 }
 
@@ -196,19 +196,26 @@ struct SessionRule: Identifiable {
     let pattern: String
     let verdict: DecisionVerdict
     let explanation: String?
+    /// Per-argument conditions (arg name → regex), same semantics as
+    /// PersistentRule.argConditions: full-match anchored, every condition
+    /// must pass, absent arg fails closed. Allow rules only — conditions on
+    /// a session deny would narrow it (a loosening), so the init drops them.
+    let argConditions: [String: String]?
 
-    init(toolName: String, pattern: String, verdict: DecisionVerdict = .allow, explanation: String? = nil) {
+    init(toolName: String, pattern: String, verdict: DecisionVerdict = .allow, explanation: String? = nil, argConditions: [String: String]? = nil) {
         self.toolName = toolName
         self.pattern = pattern
         self.verdict = verdict
         self.explanation = explanation
+        self.argConditions = (verdict == .allow && argConditions?.isEmpty == false) ? argConditions : nil
     }
 
     /// Match using simple glob-style wildcards (* only).
     /// For Bash commands, splits on command separators (&&, ||, ;, |) and
     /// requires EVERY segment to match — prevents poisoning via chained commands.
-    func matches(toolName: String, command: String?, filePath: String?) -> Bool {
+    func matches(toolName: String, command: String?, filePath: String?, toolInput: [String: AnyCodable]? = nil) -> Bool {
         guard self.toolName == toolName || self.toolName == "*" else { return false }
+        guard ArgConditionMatcher.satisfied(argConditions, by: toolInput) else { return false }
 
         let raw: String
         switch toolName {

--- a/Sources/Gavel/Remote/RemoteApprovalBridge.swift
+++ b/Sources/Gavel/Remote/RemoteApprovalBridge.swift
@@ -203,25 +203,31 @@ final class RemoteApprovalBridge {
 
     /// Handle an Accept/Reject tap on a proposal card. Runs through the same
     /// audited ProposalStore path as the Monitor buttons (accepted-via=telegram).
+    /// Adjudication hops to main: RuleStore/ProposalStore mutations are
+    /// main-thread throughout the app (Monitor buttons, panel actions), and
+    /// this callback arrives on the transport's queue.
     private func adjudicateProposal(action: String, idText: String, callback: TelegramCallback, chat: Int64) {
         guard let store = proposalStore, let id = UUID(uuidString: idText) else {
             transport.answerCallbackQuery(id: callback.id, text: "Unavailable", completion: nil)
             return
         }
-        if action == "pa" {
-            if let rule = store.accept(id: id, via: "telegram") {
-                remoteLog?("proposal accepted id=\(id) via=telegram")
-                transport.answerCallbackQuery(id: callback.id, text: "Rule added", completion: nil)
-                transport.editMessageText(chatId: chat, messageId: callback.messageId, text: "✅ Rule accepted from phone: \(rule.name)", completion: nil)
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if action == "pa" {
+                if let rule = store.accept(id: id, via: "telegram") {
+                    self.remoteLog?("proposal accepted id=\(id) via=telegram")
+                    self.transport.answerCallbackQuery(id: callback.id, text: "Rule added", completion: nil)
+                    self.transport.editMessageText(chatId: chat, messageId: callback.messageId, text: "✅ Rule accepted from phone: \(rule.name)", completion: nil)
+                } else {
+                    self.transport.answerCallbackQuery(id: callback.id, text: "Already handled", completion: nil)
+                    self.transport.editMessageText(chatId: chat, messageId: callback.messageId, text: "↪️ Proposal already handled (Monitor or expired)", completion: nil)
+                }
             } else {
-                transport.answerCallbackQuery(id: callback.id, text: "Already handled", completion: nil)
-                transport.editMessageText(chatId: chat, messageId: callback.messageId, text: "↪️ Proposal already handled (Monitor or expired)", completion: nil)
+                store.reject(id: id, via: "telegram")
+                self.remoteLog?("proposal rejected id=\(id) via=telegram")
+                self.transport.answerCallbackQuery(id: callback.id, text: "Rejected", completion: nil)
+                self.transport.editMessageText(chatId: chat, messageId: callback.messageId, text: "❌ Proposal rejected from phone", completion: nil)
             }
-        } else {
-            store.reject(id: id, via: "telegram")
-            remoteLog?("proposal rejected id=\(id) via=telegram")
-            transport.answerCallbackQuery(id: callback.id, text: "Rejected", completion: nil)
-            transport.editMessageText(chatId: chat, messageId: callback.messageId, text: "❌ Proposal rejected from phone", completion: nil)
         }
     }
 

--- a/Sources/Gavel/Review/CommandHTML.swift
+++ b/Sources/Gavel/Review/CommandHTML.swift
@@ -127,9 +127,12 @@ enum CommandHTML {
         return """
         <section class="block">
         <h2>Always allow, scoped to</h2>
-        <p class="scopehint">Creates a persistent allow rule for \(DiffHTML.esc(content.toolName)), limited to args fully matching these regexes. Absent args never match — future calls outside the scope still prompt.</p>
+        <p class="scopehint">Creates an allow rule for \(DiffHTML.esc(content.toolName)) limited to args fully matching these regexes. Absent args never match — future calls outside the scope still prompt. Session rules expire when the session ends; Always rules persist.</p>
         \(rows)
-        <button id="scopedbtn" class="scoped" disabled onclick="submitScoped()">Always Allow (scoped)</button>
+        <div class="scopedbtns">
+        <button id="scopedsessionbtn" class="scoped session" disabled onclick="submitScoped('allow_session_scoped')">Allow for session (scoped)</button>
+        <button id="scopedbtn" class="scoped" disabled onclick="submitScoped('allow_scoped')">Always Allow (scoped)</button>
+        </div>
         </section>
         """
     }
@@ -173,9 +176,10 @@ enum CommandHTML {
     .scoperow .pat { flex: 1; font-family: ui-monospace, monospace; font-size: 12.5px;
                      padding: 6px 8px; border-radius: 8px; border: 1px solid #0003;
                      background: inherit; color: inherit; min-width: 0; }
-    .scoped { display: block; margin: 10px 12px 12px; width: calc(100% - 24px);
-              padding: 12px; border-radius: 10px; border: none; font-size: 15px;
+    .scopedbtns { display: flex; gap: 10px; margin: 10px 12px 12px; }
+    .scoped { flex: 1; padding: 12px; border-radius: 10px; border: none; font-size: 14px;
               font-weight: 600; background: #0969da; color: #fff; }
+    .scoped.session { background: #6639ba; }
     footer { position: fixed; bottom: 0; left: 0; right: 0; background: #fffffff2;
              backdrop-filter: blur(10px); border-top: 1px solid #0002; padding: 10px 0
              calc(10px + env(safe-area-inset-bottom)); }
@@ -201,18 +205,19 @@ enum CommandHTML {
     private static let js = """
     function scopeChanged() {
       const any = document.querySelectorAll('.scopecheck:checked').length > 0;
-      const btn = document.getElementById('scopedbtn');
-      if (btn) btn.disabled = !any;
+      document.querySelectorAll('.scoped').forEach(function (b) { b.disabled = !any; });
     }
-    function submitScoped() {
+    function submitScoped(verdict) {
       const conditions = {};
       document.querySelectorAll('.scopecheck:checked').forEach(function (c) {
         const pat = document.getElementById('pat-' + c.dataset.arg);
         if (pat && pat.value.trim()) conditions[c.dataset.arg] = pat.value.trim();
       });
       if (Object.keys(conditions).length === 0) { alert('Tick at least one argument to scope the rule.'); return; }
-      post({ verdict: 'allow_scoped', note: noteValue(), conditions: conditions },
-           '✅ Scoped allow rule created — command proceeding.');
+      post({ verdict: verdict, note: noteValue(), conditions: conditions },
+           verdict === 'allow_session_scoped'
+             ? '✅ Scoped session allow created (expires with the session) — command proceeding.'
+             : '✅ Scoped allow rule created — command proceeding.');
     }
     function submitVerdict(verdict) {
       post({ verdict: verdict, note: noteValue() },

--- a/Sources/Gavel/Review/CommandHTML.swift
+++ b/Sources/Gavel/Review/CommandHTML.swift
@@ -6,6 +6,13 @@ import Foundation
 /// Telegram: the inline card stays redacted/truncated, and fidelity lives
 /// here — served loopback-only, reachable exclusively over the tailnet
 /// (same security model as the diff review page).
+struct CommandArg {
+    let name: String
+    let value: String
+    /// Scalar args of an MCP call can anchor a scoped Always Allow row.
+    let scopable: Bool
+}
+
 struct CommandContent {
     let sessionLabel: String
     let toolName: String
@@ -13,11 +20,28 @@ struct CommandContent {
     /// The primary text (Bash command / file path), when the tool has one.
     let command: String?
     /// Remaining tool args rendered as name → value rows (MCP calls live here).
-    let args: [(name: String, value: String)]
+    let args: [CommandArg]
     let triggerReason: String?
     /// True when the credential gate withheld the command from the Telegram
     /// card — the page shows it anyway (tailnet-only), with a banner saying why.
     let withheldInline: Bool
+    /// True when this approval may author a scoped Always Allow from the page
+    /// (MCP call with scalar args, not Allow-once-only). Must match whether a
+    /// createScopedAllow callback was registered with the server.
+    let offersScopedAllow: Bool
+
+    init(sessionLabel: String, toolName: String, cwd: String?, command: String?,
+         args: [CommandArg], triggerReason: String?, withheldInline: Bool,
+         offersScopedAllow: Bool = false) {
+        self.sessionLabel = sessionLabel
+        self.toolName = toolName
+        self.cwd = cwd
+        self.command = command
+        self.args = args
+        self.triggerReason = triggerReason
+        self.withheldInline = withheldInline
+        self.offersScopedAllow = offersScopedAllow
+    }
 }
 
 /// Server-side renderer for the mobile full-command page. Fully
@@ -47,6 +71,9 @@ enum CommandHTML {
                 "<div class=\"arg\"><div class=\"aname\">\(DiffHTML.esc(arg.name))</div><pre>\(DiffHTML.esc(arg.value))</pre></div>"
             }.joined()
             body += "<section class=\"block\"><h2>Arguments</h2>\(rows)</section>"
+        }
+        if content.offersScopedAllow {
+            body += scopedAllowSection(content)
         }
         if body.isEmpty {
             body = "<p class=\"empty\">No command text or arguments on this call.</p>"
@@ -83,6 +110,30 @@ enum CommandHTML {
         """
     }
 
+    /// Scoped Always Allow authoring — the phone twin of the Mac panel's
+    /// per-arg rows. Checked args become argConditions on a persistent allow
+    /// rule (regex, full match, absent arg fails closed), prefilled with the
+    /// escaped literal value of THIS call.
+    private static func scopedAllowSection(_ content: CommandContent) -> String {
+        let rows = content.args.filter(\.scopable).map { arg in
+            let escaped = DiffHTML.escAttr(NSRegularExpression.escapedPattern(for: arg.value))
+            return """
+            <div class="scoperow">
+            <label><input type="checkbox" class="scopecheck" data-arg="\(DiffHTML.escAttr(arg.name))" onchange="scopeChanged()"> \(DiffHTML.esc(arg.name))</label>
+            <input class="pat" id="pat-\(DiffHTML.escAttr(arg.name))" value="\(escaped)" autocapitalize="off" autocorrect="off">
+            </div>
+            """
+        }.joined()
+        return """
+        <section class="block">
+        <h2>Always allow, scoped to</h2>
+        <p class="scopehint">Creates a persistent allow rule for \(DiffHTML.esc(content.toolName)), limited to args fully matching these regexes. Absent args never match — future calls outside the scope still prompt.</p>
+        \(rows)
+        <button id="scopedbtn" class="scoped" disabled onclick="submitScoped()">Always Allow (scoped)</button>
+        </section>
+        """
+    }
+
     private static func banner(_ escapedText: String) -> String {
         "<div class=\"banner\">\(escapedText)</div>"
     }
@@ -115,6 +166,16 @@ enum CommandHTML {
     .aname { font-family: ui-monospace, monospace; font-size: 11px; font-weight: 700;
              opacity: .65; padding: 8px 12px 0; }
     .empty { padding: 24px; text-align: center; opacity: .7; }
+    .scopehint { font-size: 12px; opacity: .7; padding: 0 12px 6px; }
+    .scoperow { display: flex; align-items: center; gap: 8px; padding: 4px 12px; }
+    .scoperow label { flex: 0 0 34%; font-family: ui-monospace, monospace;
+                      font-size: 12.5px; word-break: break-all; }
+    .scoperow .pat { flex: 1; font-family: ui-monospace, monospace; font-size: 12.5px;
+                     padding: 6px 8px; border-radius: 8px; border: 1px solid #0003;
+                     background: inherit; color: inherit; min-width: 0; }
+    .scoped { display: block; margin: 10px 12px 12px; width: calc(100% - 24px);
+              padding: 12px; border-radius: 10px; border: none; font-size: 15px;
+              font-weight: 600; background: #0969da; color: #fff; }
     footer { position: fixed; bottom: 0; left: 0; right: 0; background: #fffffff2;
              backdrop-filter: blur(10px); border-top: 1px solid #0002; padding: 10px 0
              calc(10px + env(safe-area-inset-bottom)); }
@@ -133,20 +194,42 @@ enum CommandHTML {
       .banner { background: #3a3117; border-color: #d4a72c44; }
       footer { background: #161618f2; border-color: #fff2; }
       textarea { border-color: #fff3; }
+      .scoperow .pat { border-color: #fff3; }
     }
     """
 
     private static let js = """
+    function scopeChanged() {
+      const any = document.querySelectorAll('.scopecheck:checked').length > 0;
+      const btn = document.getElementById('scopedbtn');
+      if (btn) btn.disabled = !any;
+    }
+    function submitScoped() {
+      const conditions = {};
+      document.querySelectorAll('.scopecheck:checked').forEach(function (c) {
+        const pat = document.getElementById('pat-' + c.dataset.arg);
+        if (pat && pat.value.trim()) conditions[c.dataset.arg] = pat.value.trim();
+      });
+      if (Object.keys(conditions).length === 0) { alert('Tick at least one argument to scope the rule.'); return; }
+      post({ verdict: 'allow_scoped', note: noteValue(), conditions: conditions },
+           '✅ Scoped allow rule created — command proceeding.');
+    }
     function submitVerdict(verdict) {
-      const note = document.getElementById('note').value.trim();
-      document.querySelectorAll('.btns button').forEach(function (b) { b.disabled = true; });
+      post({ verdict: verdict, note: noteValue() },
+           verdict === 'allow' ? '✅ Allowed — command proceeding.' : '🛑 Denied.');
+    }
+    function noteValue() {
+      return document.getElementById('note').value.trim() || null;
+    }
+    function post(payload, doneMsg) {
+      document.querySelectorAll('.btns button, .scoped').forEach(function (b) { b.disabled = true; });
       fetch(location.pathname + '/verdict', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ verdict: verdict, note: note || null })
+        body: JSON.stringify(payload)
       }).then(function (r) {
         if (r.ok) {
-          finish(verdict === 'allow' ? '✅ Allowed — command proceeding.' : '🛑 Denied.');
+          finish(doneMsg);
         } else if (r.status === 409) {
           finish('Already resolved elsewhere (Mac panel or Telegram).');
         } else {
@@ -158,7 +241,8 @@ enum CommandHTML {
       document.body.innerHTML = '<header><h1>' + msg + '</h1><p class="msg">You can close this tab.</p></header>';
     }
     function fail(msg) {
-      document.querySelectorAll('.btns button').forEach(function (b) { b.disabled = false; });
+      document.querySelectorAll('.btns button, .scoped').forEach(function (b) { b.disabled = false; });
+      scopeChanged();
       alert(msg);
     }
     """

--- a/Sources/Gavel/Review/DiffReviewServer.swift
+++ b/Sources/Gavel/Review/DiffReviewServer.swift
@@ -51,6 +51,9 @@ final class DiffReviewServer {
         /// command pages whose approval may author a durable allow — its
         /// absence makes verdict "allow_scoped" a 400.
         let createScopedAllow: (([String: String]) -> String)?
+        /// Session-lifetime twin: appends a scoped SessionRule (dies with the
+        /// session) and returns a description. Gated identically.
+        let createScopedSessionAllow: (([String: String]) -> String)?
         let createdAt = Date()
         /// Set (under the server lock) once any source resolves the approval.
         var resolvedBy: ResolvableApproval.Source?
@@ -61,11 +64,12 @@ final class DiffReviewServer {
         /// set this, so it can't be back-filled once the race is over.
         var viewedAt: Date?
 
-        init(nonce: String, content: PageContent, resolvable: ResolvableApproval, createScopedAllow: (([String: String]) -> String)? = nil) {
+        init(nonce: String, content: PageContent, resolvable: ResolvableApproval, createScopedAllow: (([String: String]) -> String)? = nil, createScopedSessionAllow: (([String: String]) -> String)? = nil) {
             self.nonce = nonce
             self.content = content
             self.resolvable = resolvable
             self.createScopedAllow = createScopedAllow
+            self.createScopedSessionAllow = createScopedSessionAllow
         }
     }
 
@@ -149,11 +153,11 @@ final class DiffReviewServer {
     /// has to transit Telegram. `createScopedAllow` (when the approval may
     /// author a durable allow) turns submitted arg conditions into a
     /// persistent rule and returns its name.
-    func register(command: CommandContent, resolvable: ResolvableApproval, createScopedAllow: (([String: String]) -> String)? = nil) -> String {
-        register(page: .command(command), resolvable: resolvable, reviewedNoun: "the full command", createScopedAllow: createScopedAllow)
+    func register(command: CommandContent, resolvable: ResolvableApproval, createScopedAllow: (([String: String]) -> String)? = nil, createScopedSessionAllow: (([String: String]) -> String)? = nil) -> String {
+        register(page: .command(command), resolvable: resolvable, reviewedNoun: "the full command", createScopedAllow: createScopedAllow, createScopedSessionAllow: createScopedSessionAllow)
     }
 
-    private func register(page: PageContent, resolvable: ResolvableApproval, reviewedNoun: String, createScopedAllow: (([String: String]) -> String)? = nil) -> String {
+    private func register(page: PageContent, resolvable: ResolvableApproval, reviewedNoun: String, createScopedAllow: (([String: String]) -> String)? = nil, createScopedSessionAllow: (([String: String]) -> String)? = nil) -> String {
         pruneStale()
 
         var bytes = [UInt8](repeating: 0, count: 16)
@@ -163,7 +167,7 @@ final class DiffReviewServer {
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
 
-        let session = ReviewSession(nonce: nonce, content: page, resolvable: resolvable, createScopedAllow: createScopedAllow)
+        let session = ReviewSession(nonce: nonce, content: page, resolvable: resolvable, createScopedAllow: createScopedAllow, createScopedSessionAllow: createScopedSessionAllow)
         lock.lock()
         sessions[nonce] = session
         lock.unlock()
@@ -306,11 +310,13 @@ final class DiffReviewServer {
             }
 
             let decision: Decision?
-            if submission.verdict == "allow_scoped" {
-                // Durable-allow authoring: only pages registered with a
-                // createScopedAllow callback (MCP + not Allow-once-only) may
-                // do this, and every condition regex must be present + valid.
-                guard let create = session.createScopedAllow,
+            if submission.verdict == "allow_scoped" || submission.verdict == "allow_session_scoped" {
+                // Scoped-allow authoring (persistent or session-lifetime):
+                // only pages registered with the matching callback (MCP + not
+                // Allow-once-only) may do this, and every condition regex
+                // must be present + valid.
+                let sessionScoped = submission.verdict == "allow_session_scoped"
+                guard let create = sessionScoped ? session.createScopedSessionAllow : session.createScopedAllow,
                       let conditions = Self.cleanedConditions(submission.conditions) else {
                     send(connection, status: 400, body: "bad request")
                     return
@@ -319,11 +325,13 @@ final class DiffReviewServer {
                 // panel's Always Allow: if another responder wins the next
                 // instant, the explicitly-requested rule still persists.
                 let ruleName = create(conditions)
-                gavelLog("[review] scoped allow rule authored nonce=\(session.nonce.prefix(8))… args=\(conditions.keys.sorted().joined(separator: ","))")
+                gavelLog("[review] scoped \(sessionScoped ? "session" : "persistent") allow authored nonce=\(session.nonce.prefix(8))… args=\(conditions.keys.sorted().joined(separator: ","))")
                 let note = submission.note.flatMap { $0.isEmpty ? nil : $0 }
                 decision = Decision(
                     verdict: .allow,
-                    reason: "Approved from command review page — always allow: \(ruleName)",
+                    reason: sessionScoped
+                        ? "Approved from command review page — session allow (scoped): \(ruleName)"
+                        : "Approved from command review page — always allow: \(ruleName)",
                     additionalContext: note.map { "Approver note from review page: \($0)" })
             } else {
                 decision = Self.decision(for: submission)

--- a/Sources/Gavel/Review/DiffReviewServer.swift
+++ b/Sources/Gavel/Review/DiffReviewServer.swift
@@ -6,6 +6,15 @@ struct ReviewVerdictSubmission: Codable {
     let verdict: String
     let note: String?
     let comments: [ReviewComment]?
+    /// arg name → regex for verdict "allow_scoped" (command pages only).
+    let conditions: [String: String]?
+
+    init(verdict: String, note: String?, comments: [ReviewComment]? = nil, conditions: [String: String]? = nil) {
+        self.verdict = verdict
+        self.note = note
+        self.comments = comments
+        self.conditions = conditions
+    }
 }
 
 struct ReviewComment: Codable {
@@ -37,6 +46,11 @@ final class DiffReviewServer {
         let nonce: String
         let content: PageContent
         let resolvable: ResolvableApproval
+        /// Creates a persistent scoped allow rule from submitted arg
+        /// conditions and returns the rule's display name. Only set for
+        /// command pages whose approval may author a durable allow — its
+        /// absence makes verdict "allow_scoped" a 400.
+        let createScopedAllow: (([String: String]) -> String)?
         let createdAt = Date()
         /// Set (under the server lock) once any source resolves the approval.
         var resolvedBy: ResolvableApproval.Source?
@@ -47,10 +61,11 @@ final class DiffReviewServer {
         /// set this, so it can't be back-filled once the race is over.
         var viewedAt: Date?
 
-        init(nonce: String, content: PageContent, resolvable: ResolvableApproval) {
+        init(nonce: String, content: PageContent, resolvable: ResolvableApproval, createScopedAllow: (([String: String]) -> String)? = nil) {
             self.nonce = nonce
             self.content = content
             self.resolvable = resolvable
+            self.createScopedAllow = createScopedAllow
         }
     }
 
@@ -131,12 +146,14 @@ final class DiffReviewServer {
 
     /// Registers a full-command page for a pending approval — the phone-side
     /// twin of the Mac panel's command view, so the unredacted command never
-    /// has to transit Telegram.
-    func register(command: CommandContent, resolvable: ResolvableApproval) -> String {
-        register(page: .command(command), resolvable: resolvable, reviewedNoun: "the full command")
+    /// has to transit Telegram. `createScopedAllow` (when the approval may
+    /// author a durable allow) turns submitted arg conditions into a
+    /// persistent rule and returns its name.
+    func register(command: CommandContent, resolvable: ResolvableApproval, createScopedAllow: (([String: String]) -> String)? = nil) -> String {
+        register(page: .command(command), resolvable: resolvable, reviewedNoun: "the full command", createScopedAllow: createScopedAllow)
     }
 
-    private func register(page: PageContent, resolvable: ResolvableApproval, reviewedNoun: String) -> String {
+    private func register(page: PageContent, resolvable: ResolvableApproval, reviewedNoun: String, createScopedAllow: (([String: String]) -> String)? = nil) -> String {
         pruneStale()
 
         var bytes = [UInt8](repeating: 0, count: 16)
@@ -146,7 +163,7 @@ final class DiffReviewServer {
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
 
-        let session = ReviewSession(nonce: nonce, content: page, resolvable: resolvable)
+        let session = ReviewSession(nonce: nonce, content: page, resolvable: resolvable, createScopedAllow: createScopedAllow)
         lock.lock()
         sessions[nonce] = session
         lock.unlock()
@@ -276,15 +293,46 @@ final class DiffReviewServer {
                 send(connection, status: 413, body: "payload too large")
                 return
             }
-            guard let submission = try? JSONDecoder().decode(ReviewVerdictSubmission.self, from: request.body),
-                  let decision = Self.decision(for: submission) else {
+            guard let submission = try? JSONDecoder().decode(ReviewVerdictSubmission.self, from: request.body) else {
                 send(connection, status: 400, body: "bad request")
                 return
             }
             lock.lock()
             let alreadyResolved = session.resolvedBy != nil
             lock.unlock()
-            if alreadyResolved || !session.resolvable.resolve(decision, from: .web) {
+            if alreadyResolved {
+                send(connection, status: 409, body: "{\"status\":\"already_resolved\"}", contentType: "application/json")
+                return
+            }
+
+            let decision: Decision?
+            if submission.verdict == "allow_scoped" {
+                // Durable-allow authoring: only pages registered with a
+                // createScopedAllow callback (MCP + not Allow-once-only) may
+                // do this, and every condition regex must be present + valid.
+                guard let create = session.createScopedAllow,
+                      let conditions = Self.cleanedConditions(submission.conditions) else {
+                    send(connection, status: 400, body: "bad request")
+                    return
+                }
+                // Rule creation precedes the resolution race, matching the Mac
+                // panel's Always Allow: if another responder wins the next
+                // instant, the explicitly-requested rule still persists.
+                let ruleName = create(conditions)
+                gavelLog("[review] scoped allow rule authored nonce=\(session.nonce.prefix(8))… args=\(conditions.keys.sorted().joined(separator: ","))")
+                let note = submission.note.flatMap { $0.isEmpty ? nil : $0 }
+                decision = Decision(
+                    verdict: .allow,
+                    reason: "Approved from command review page — always allow: \(ruleName)",
+                    additionalContext: note.map { "Approver note from review page: \($0)" })
+            } else {
+                decision = Self.decision(for: submission)
+            }
+            guard let decision else {
+                send(connection, status: 400, body: "bad request")
+                return
+            }
+            if !session.resolvable.resolve(decision, from: .web) {
                 send(connection, status: 409, body: "{\"status\":\"already_resolved\"}", contentType: "application/json")
                 return
             }
@@ -323,6 +371,22 @@ final class DiffReviewServer {
         connection.send(content: response, completion: .contentProcessed { _ in
             connection.cancel()
         })
+    }
+
+    /// Trim submitted conditions, drop blank rows, and require every regex to
+    /// compile. Nil (→ 400) when nothing usable remains or a pattern is
+    /// invalid — a scoped rule must never be created from garbage input.
+    static func cleanedConditions(_ raw: [String: String]?) -> [String: String]? {
+        guard let raw else { return nil }
+        var cleaned: [String: String] = [:]
+        for (key, pattern) in raw {
+            let name = key.trimmingCharacters(in: .whitespaces)
+            let pat = pattern.trimmingCharacters(in: .whitespaces)
+            guard !name.isEmpty, !pat.isEmpty else { continue }
+            guard (try? NSRegularExpression(pattern: pat)) != nil else { return nil }
+            cleaned[name] = pat
+        }
+        return cleaned.isEmpty ? nil : cleaned
     }
 
     // MARK: - Verdict mapping

--- a/Tests/GavelTests/CommandReviewTests.swift
+++ b/Tests/GavelTests/CommandReviewTests.swift
@@ -466,6 +466,85 @@ final class CommandReviewTests: XCTestCase {
         XCTAssertFalse(created, "stale submissions must not author rules")
     }
 
+    // MARK: - Session-scoped allow from the command page
+
+    func testAllowSessionScopedCreatesSessionRuleAndResolves() throws {
+        var decision: Decision?
+        var received: [String: String]?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(
+            command: scopableSlackContent(), resolvable: resolvable,
+            createScopedSessionAllow: { conditions in
+                received = conditions
+                return "mcp__Slack__read_history [channel=/general/]"
+            })
+
+        let body = #"{"verdict":"allow_session_scoped","conditions":{"channel":"general"}}"#
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: body)
+        XCTAssertEqual(res.status, 200)
+
+        XCTAssertEqual(received, ["channel": "general"])
+        let d = try XCTUnwrap(decision)
+        XCTAssertEqual(d.verdict, .allow)
+        XCTAssertEqual(d.reason?.contains("session allow (scoped)"), true)
+    }
+
+    func testAllowSessionScopedWithoutCallbackIs400() throws {
+        // A page with only the persistent callback still 400s the session verb.
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(
+            command: scopableSlackContent(), resolvable: resolvable,
+            createScopedAllow: { _ in "rule" })
+
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"allow_session_scoped","conditions":{"channel":"x"}}"#)
+        XCTAssertEqual(res.status, 400)
+        XCTAssertFalse(resolvable.isResolved)
+    }
+
+    func testSessionRuleArgConditionsScopeMatching() {
+        let session = Session(pid: 1)
+        session.sessionRules.append(SessionRule(
+            toolName: "mcp__Slack__read_history", pattern: "*",
+            verdict: .allow, argConditions: ["channel": "general", "workspace": "defiance"]))
+
+        func input(channel: String, workspace: String = "defiance") -> [String: AnyCodable] {
+            ["channel": AnyCodable(channel), "workspace": AnyCodable(workspace)]
+        }
+        XCTAssertNotNil(session.matchesSessionRule(
+            toolName: "mcp__Slack__read_history", command: nil, filePath: nil,
+            toolInput: input(channel: "general")))
+        // Out-of-scope channel, wrong workspace, and absent args all fall through.
+        XCTAssertNil(session.matchesSessionRule(
+            toolName: "mcp__Slack__read_history", command: nil, filePath: nil,
+            toolInput: input(channel: "random")))
+        XCTAssertNil(session.matchesSessionRule(
+            toolName: "mcp__Slack__read_history", command: nil, filePath: nil,
+            toolInput: input(channel: "general", workspace: "macedon")))
+        XCTAssertNil(session.matchesSessionRule(
+            toolName: "mcp__Slack__read_history", command: nil, filePath: nil,
+            toolInput: ["channel": AnyCodable("general")]))
+        XCTAssertNil(session.matchesSessionRule(
+            toolName: "mcp__Slack__read_history", command: nil, filePath: nil))
+    }
+
+    func testSessionRuleAnchoringAndDenyStripMatchPersistentSemantics() {
+        // Anchoring: "C123" must not substring-match "C1234".
+        let anchored = SessionRule(
+            toolName: "mcp__T__t", pattern: "*", verdict: .allow, argConditions: ["c": "C123"])
+        XCTAssertTrue(anchored.matches(toolName: "mcp__T__t", command: nil, filePath: nil, toolInput: ["c": AnyCodable("C123")]))
+        XCTAssertFalse(anchored.matches(toolName: "mcp__T__t", command: nil, filePath: nil, toolInput: ["c": AnyCodable("C1234")]))
+
+        // Conditions on a session DENY would narrow it — init drops them.
+        let deny = SessionRule(
+            toolName: "mcp__T__t", pattern: "*", verdict: .block, argConditions: ["c": "C123"])
+        XCTAssertNil(deny.argConditions)
+        XCTAssertTrue(deny.matches(toolName: "mcp__T__t", command: nil, filePath: nil, toolInput: ["c": AnyCodable("other")]))
+
+        // Backward compat: nil conditions ignore toolInput entirely.
+        let plain = SessionRule(toolName: "mcp__T__t", pattern: "*")
+        XCTAssertTrue(plain.matches(toolName: "mcp__T__t", command: nil, filePath: nil, toolInput: ["c": AnyCodable("anything")]))
+    }
+
     /// End-to-end: the rule authored from the page actually scopes future
     /// matching — in-scope calls allow, out-of-scope calls fall through.
     func testScopedRuleFromPageScopesFutureEvaluation() throws {

--- a/Tests/GavelTests/CommandReviewTests.swift
+++ b/Tests/GavelTests/CommandReviewTests.swift
@@ -24,8 +24,9 @@ final class CommandReviewTests: XCTestCase {
 
     private func makeCommand(
         command: String? = "aws s3 cp s3://bucket/very-long-key /tmp/x --profile Prod-123",
-        args: [(name: String, value: String)] = [],
-        withheldInline: Bool = false
+        args: [CommandArg] = [],
+        withheldInline: Bool = false,
+        offersScopedAllow: Bool = false
     ) -> CommandContent {
         CommandContent(
             sessionLabel: "argscope",
@@ -34,7 +35,16 @@ final class CommandReviewTests: XCTestCase {
             command: command,
             args: args,
             triggerReason: "Default rule: something fired",
-            withheldInline: withheldInline)
+            withheldInline: withheldInline,
+            offersScopedAllow: offersScopedAllow)
+    }
+
+    /// Pump the main queue — proposal adjudication and rule authoring hop to
+    /// main before mutating stores.
+    private func drainMain() {
+        let e = expectation(description: "main drain")
+        DispatchQueue.main.async { e.fulfill() }
+        wait(for: [e], timeout: 2)
     }
 
     private struct HTTPResult {
@@ -83,8 +93,8 @@ final class CommandReviewTests: XCTestCase {
     func testCommandPageRendersMCPArgs() throws {
         let resolvable = ResolvableApproval { _ in }
         let content = makeCommand(command: nil, args: [
-            (name: "channel", value: "general"),
-            (name: "workspace", value: "defiance"),
+            CommandArg(name: "channel", value: "general", scopable: true),
+            CommandArg(name: "workspace", value: "defiance", scopable: true),
         ])
         let nonce = server.register(command: content, resolvable: resolvable)
 
@@ -290,6 +300,7 @@ final class CommandReviewTests: XCTestCase {
         let id = submitProposal(proposals)
 
         bridge.handle(proposalCallback(action: "pa", id: id))
+        drainMain()
 
         XCTAssertTrue(ruleStore.rules.contains { $0.pattern == "rm\\s+-rf\\s+/" && $0.verdict == .block })
         XCTAssertTrue(proposals.proposals.isEmpty)
@@ -304,6 +315,7 @@ final class CommandReviewTests: XCTestCase {
         let id = submitProposal(proposals)
 
         bridge.handle(proposalCallback(action: "pj", id: id))
+        drainMain()
 
         XCTAssertFalse(ruleStore.rules.contains { $0.pattern == "rm\\s+-rf\\s+/" })
         XCTAssertTrue(proposals.proposals.isEmpty)
@@ -320,6 +332,7 @@ final class CommandReviewTests: XCTestCase {
         proposals.reject(id: id, via: "monitor")
         let rulesBefore = ruleStore.rules.count
         bridge.handle(proposalCallback(action: "pa", id: id))
+        drainMain()
 
         XCTAssertEqual(ruleStore.rules.count, rulesBefore)
         XCTAssertEqual(fake.answers.last?.text, "Already handled")
@@ -337,9 +350,156 @@ final class CommandReviewTests: XCTestCase {
             callback: TelegramCallback(id: "cb2", fromId: 666, chatId: 666, messageId: 5, data: "pa:\(id.uuidString)"),
             message: nil)
         bridge.handle(stranger)
+        drainMain()
 
         XCTAssertFalse(ruleStore.rules.contains { $0.pattern == "rm\\s+-rf\\s+/" })
         XCTAssertEqual(proposals.proposals.count, 1)
         XCTAssertEqual(fake.answers.last?.text, "Not authorized")
+    }
+
+    // MARK: - Scoped Always Allow from the command page
+
+    private func scopableSlackContent() -> CommandContent {
+        makeCommand(command: nil, args: [
+            CommandArg(name: "channel", value: "general", scopable: true),
+            CommandArg(name: "limit", value: "50", scopable: true),
+            CommandArg(name: "filters", value: "{\"a\":1}", scopable: false),
+        ], offersScopedAllow: true)
+    }
+
+    func testScopeSectionRenderedOnlyWhenOffered() throws {
+        let offered = server.register(command: scopableSlackContent(), resolvable: ResolvableApproval { _ in }, createScopedAllow: { _ in "rule" })
+        let offeredPage = try request("/review/\(offered)")
+        XCTAssertTrue(offeredPage.body.contains("Always allow, scoped to"))
+        // Scopable args get rows; non-scalar args don't.
+        XCTAssertTrue(offeredPage.body.contains("pat-channel"))
+        XCTAssertTrue(offeredPage.body.contains("pat-limit"))
+        XCTAssertFalse(offeredPage.body.contains("pat-filters"))
+
+        let plain = server.register(command: makeCommand(), resolvable: ResolvableApproval { _ in })
+        let plainPage = try request("/review/\(plain)")
+        XCTAssertFalse(plainPage.body.contains("Always allow, scoped to"))
+    }
+
+    func testScopeRowPrefillsEscapedRegex() throws {
+        let content = makeCommand(command: nil, args: [
+            CommandArg(name: "query", value: "a.b+c", scopable: true),
+        ], offersScopedAllow: true)
+        let nonce = server.register(command: content, resolvable: ResolvableApproval { _ in }, createScopedAllow: { _ in "rule" })
+        let page = try request("/review/\(nonce)")
+        // Literal value must arrive regex-escaped so "a.b+c" can't match "axbbc".
+        XCTAssertTrue(page.body.contains("a\\.b\\+c"))
+    }
+
+    func testAllowScopedCreatesRuleAndResolvesAllow() throws {
+        var decision: Decision?
+        var received: [String: String]?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(
+            command: scopableSlackContent(), resolvable: resolvable,
+            createScopedAllow: { conditions in
+                received = conditions
+                return "mcp__Slack__read_history: * [channel=/general/]"
+            })
+
+        let body = #"{"verdict":"allow_scoped","note":"watcher scope","conditions":{"channel":"general","workspace":"defiance"}}"#
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: body)
+        XCTAssertEqual(res.status, 200)
+
+        XCTAssertEqual(received, ["channel": "general", "workspace": "defiance"])
+        let d = try XCTUnwrap(decision)
+        XCTAssertEqual(d.verdict, .allow)
+        XCTAssertEqual(d.reason?.contains("always allow: mcp__Slack__read_history"), true)
+        XCTAssertEqual(d.additionalContext?.contains("watcher scope"), true)
+    }
+
+    func testAllowScopedWithoutCallbackIs400() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(command: makeCommand(), resolvable: resolvable)
+
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"allow_scoped","conditions":{"channel":"x"}}"#)
+        XCTAssertEqual(res.status, 400)
+        XCTAssertNil(decision)
+        XCTAssertFalse(resolvable.isResolved)
+    }
+
+    func testAllowScopedWithEmptyConditionsIs400() throws {
+        var created = false
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(
+            command: scopableSlackContent(), resolvable: resolvable,
+            createScopedAllow: { _ in created = true; return "rule" })
+
+        for body in [#"{"verdict":"allow_scoped"}"#,
+                     #"{"verdict":"allow_scoped","conditions":{}}"#,
+                     #"{"verdict":"allow_scoped","conditions":{" ":"x","channel":"  "}}"#] {
+            let res = try request("/review/\(nonce)/verdict", method: "POST", body: body)
+            XCTAssertEqual(res.status, 400, "body: \(body)")
+        }
+        XCTAssertFalse(created)
+        XCTAssertFalse(resolvable.isResolved)
+    }
+
+    func testAllowScopedWithInvalidRegexIs400() throws {
+        var created = false
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(
+            command: scopableSlackContent(), resolvable: resolvable,
+            createScopedAllow: { _ in created = true; return "rule" })
+
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"allow_scoped","conditions":{"channel":"gen("}}"#)
+        XCTAssertEqual(res.status, 400)
+        XCTAssertFalse(created)
+    }
+
+    func testAllowScopedOnResolvedApprovalIs409WithoutRule() throws {
+        var created = false
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(
+            command: scopableSlackContent(), resolvable: resolvable,
+            createScopedAllow: { _ in created = true; return "rule" })
+
+        _ = resolvable.resolve(Decision(verdict: .allow, reason: "Mac won"), from: .mac)
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"allow_scoped","conditions":{"channel":"general"}}"#)
+        XCTAssertEqual(res.status, 409)
+        XCTAssertFalse(created, "stale submissions must not author rules")
+    }
+
+    /// End-to-end: the rule authored from the page actually scopes future
+    /// matching — in-scope calls allow, out-of-scope calls fall through.
+    func testScopedRuleFromPageScopesFutureEvaluation() throws {
+        let dir = NSTemporaryDirectory() + "gavel-scopedpage-test-\(UUID().uuidString)"
+        let ruleStore = RuleStore(configPath: dir + "/rules.json")
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        // Mirrors the coordinator's closure: exact tool name, glob "*",
+        // conditions from the page (rule added synchronously here; the
+        // coordinator hops to main for the live store).
+        let nonce = server.register(
+            command: scopableSlackContent(), resolvable: resolvable,
+            createScopedAllow: { conditions in
+                let rule = PersistentRule(
+                    toolName: "mcp__Slack__read_history", pattern: "*", isRegex: false,
+                    verdict: .allow, argConditions: conditions)
+                ruleStore.addRule(rule, origin: "test")
+                return rule.name
+            })
+
+        let body = #"{"verdict":"allow_scoped","conditions":{"channel":"general","workspace":"defiance"}}"#
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: body)
+        XCTAssertEqual(res.status, 200)
+        XCTAssertEqual(decision?.verdict, .allow)
+
+        func payload(channel: String, workspace: String = "defiance") -> PreToolUsePayload {
+            PreToolUsePayload(toolName: "mcp__Slack__read_history", toolInput: [
+                "channel": AnyCodable(channel), "workspace": AnyCodable(workspace), "limit": AnyCodable(50),
+            ])
+        }
+        XCTAssertNotNil(ruleStore.evaluateAllow(payload: payload(channel: "general")))
+        XCTAssertNil(ruleStore.evaluateAllow(payload: payload(channel: "random")))
+        XCTAssertNil(ruleStore.evaluateAllow(payload: payload(channel: "general", workspace: "macedon")))
     }
 }


### PR DESCRIPTION
## What

The capstone on #200 (arg-scoped allow rules) and #201 (full-command page): the command review page can now **author a scoped Always Allow from the phone**. MCP approvals render an "Always allow, scoped to" section — one checkbox row per scalar argument, each with an editable regex prefilled with the escaped literal value of the live call. Tick `channel` + `workspace`, hit **Always Allow (scoped)**, and a persistent allow rule with those `argConditions` is created and the call proceeds.

This completes the background-watcher story: "allow `mcp__Slack__read_history` for exactly this channel and workspace" no longer needs the Mac.

## How

- Page POSTs `{"verdict":"allow_scoped","conditions":{arg:regex},"note":...}` to the existing verdict route.
- The coordinator registers a `createScopedAllow` callback alongside the page; it builds the same rule shape as the Mac panel's scoped Always Allow (exact tool name, glob `*`, `argConditions`) through the audited RuleStore path (`origin=command-page:always-allow-scoped`), then the approval resolves as a `.web` allow naming the rule.

## Guardrails (mirroring the existing surfaces)

- Section only renders — and the callback only exists — for MCP calls with scalar args on suppressible paths. A crafted `allow_scoped` POST against any other page is a **400**; `nonSuppressible` (Allow-once-only) approvals can never author durable allows from the page, same as the panel and Telegram buttons.
- Conditions are trimmed, blank rows dropped, and **every regex must compile server-side** before any rule is authored.
- A stale submission against an already-resolved approval is a **409 and authors nothing**.
- Matching semantics are #200's matcher, unchanged: anchored full-match, absent-arg fail-closed, allow-only — this PR only adds an authoring surface.
- Rule mutations hop to main (house pattern for RuleStore). Also fixes a #201 oversight: Telegram proposal accept/reject was mutating ProposalStore/RuleStore on the transport callback thread; it now hops to main too.

## Tests

8 new in `CommandReviewTests` (26 total there): section renders only when offered and only for scopable args, prefill is regex-escaped (`a.b+c` → `a\.b\+c`), happy path creates the rule + allows with note, 400s for missing callback / empty or blank conditions / non-compiling regex, 409-authors-nothing for stale submissions, and an end-to-end pass where the rule authored via a real HTTP POST scopes future `RuleStore.evaluateAllow` calls (in-scope allows; wrong channel or workspace falls through). Existing proposal tests updated for the main-thread hop.

`swift test`: 777 tests, one pre-existing environmental failure (`testLiveClaudeSessionDiscoveryAgainstPsWitness`, fails on main too).