### PR TITLE
fix(approval): mobile font rendering on the review pages

### DIFF
--- a/Sources/Gavel/Review/CommandHTML.swift
+++ b/Sources/Gavel/Review/CommandHTML.swift
@@ -148,10 +148,11 @@ enum CommandHTML {
     private static let css = """
     :root { color-scheme: light dark; }
     * { box-sizing: border-box; margin: 0; }
-    body { font-family: -apple-system, system-ui, sans-serif; font-size: 15px;
+    body { font-family: -apple-system, system-ui, 'Segoe UI', Roboto, sans-serif; font-size: 15px;
+           -webkit-text-size-adjust: 100%; text-size-adjust: 100%;
            background: #f5f5f7; color: #1d1d1f; padding-bottom: 170px; }
     header { padding: 14px 16px 8px; }
-    h1 { font-size: 17px; font-family: ui-monospace, monospace; word-break: break-all; }
+    h1 { font-size: 17px; font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Roboto Mono', monospace; word-break: break-all; }
     h2 { font-size: 12px; text-transform: uppercase; letter-spacing: .04em;
          opacity: .6; padding: 10px 12px 4px; }
     .msg { font-style: italic; opacity: .8; margin-top: 4px; }
@@ -161,19 +162,19 @@ enum CommandHTML {
               padding: 8px 12px; border-radius: 8px; font-size: 13px; }
     .block { background: #fff; margin: 8px 8px; border-radius: 10px; overflow: hidden;
              border: 1px solid #0000001a; }
-    pre { font-family: ui-monospace, monospace; font-size: 12.5px; line-height: 1.5;
+    pre { font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Roboto Mono', monospace; font-size: 12.5px; line-height: 1.5;
           padding: 8px 12px 12px; overflow-x: auto; white-space: pre-wrap;
           word-break: break-word; }
     .arg { border-top: 1px solid #0000000d; }
     .arg:first-of-type { border-top: none; }
-    .aname { font-family: ui-monospace, monospace; font-size: 11px; font-weight: 700;
+    .aname { font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Roboto Mono', monospace; font-size: 11px; font-weight: 700;
              opacity: .65; padding: 8px 12px 0; }
     .empty { padding: 24px; text-align: center; opacity: .7; }
     .scopehint { font-size: 12px; opacity: .7; padding: 0 12px 6px; }
     .scoperow { display: flex; align-items: center; gap: 8px; padding: 4px 12px; }
-    .scoperow label { flex: 0 0 34%; font-family: ui-monospace, monospace;
+    .scoperow label { flex: 0 0 34%; font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Roboto Mono', monospace;
                       font-size: 12.5px; word-break: break-all; }
-    .scoperow .pat { flex: 1; font-family: ui-monospace, monospace; font-size: 12.5px;
+    .scoperow .pat { flex: 1; font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Roboto Mono', monospace; font-size: 16px;
                      padding: 6px 8px; border-radius: 8px; border: 1px solid #0003;
                      background: inherit; color: inherit; min-width: 0; }
     .scopedbtns { display: flex; gap: 10px; margin: 10px 12px 12px; }
@@ -184,7 +185,7 @@ enum CommandHTML {
              backdrop-filter: blur(10px); border-top: 1px solid #0002; padding: 10px 0
              calc(10px + env(safe-area-inset-bottom)); }
     textarea { width: calc(100% - 24px); margin: 0 12px 8px; padding: 8px;
-               border-radius: 8px; border: 1px solid #0003; font-size: 15px;
+               border-radius: 8px; border: 1px solid #0003; font-size: 16px;
                font-family: inherit; min-height: 44px; background: inherit; color: inherit; }
     .btns { display: flex; gap: 10px; padding: 0 12px; }
     .btns button { flex: 1; padding: 12px; border-radius: 10px; border: none;

--- a/Sources/Gavel/Review/DiffHTML.swift
+++ b/Sources/Gavel/Review/DiffHTML.swift
@@ -168,7 +168,8 @@ enum DiffHTML {
     private static let css = """
     :root { color-scheme: light dark; }
     * { box-sizing: border-box; margin: 0; }
-    body { font-family: -apple-system, system-ui, sans-serif; font-size: 15px;
+    body { font-family: -apple-system, system-ui, 'Segoe UI', Roboto, sans-serif; font-size: 15px;
+           -webkit-text-size-adjust: 100%; text-size-adjust: 100%;
            background: #f5f5f7; color: #1d1d1f; padding-bottom: 170px; }
     header { padding: 14px 16px 8px; }
     h1 { font-size: 17px; }
@@ -180,14 +181,16 @@ enum DiffHTML {
     .file { background: #fff; margin: 8px 8px; border-radius: 10px; overflow: hidden;
             border: 1px solid #0000001a; }
     summary { padding: 10px 12px; font-weight: 600; font-size: 13px;
-              font-family: ui-monospace, monospace; word-break: break-all; cursor: pointer; }
+              font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Roboto Mono', monospace; word-break: break-all; cursor: pointer; }
     .tag { font-size: 11px; padding: 1px 6px; border-radius: 6px; margin-left: 4px;
-           background: #ddf4ff; color: #0969da; font-family: -apple-system, system-ui; }
+           background: #ddf4ff; color: #0969da; font-family: -apple-system, system-ui;
+           white-space: nowrap; word-break: normal; display: inline-block; }
     .tag.del { background: #ffebe9; color: #cf222e; }
+    .fstats { white-space: nowrap; }
     .hunk { border-top: 1px solid #0000000d; }
-    .hheader { font-family: ui-monospace, monospace; font-size: 11px; opacity: .6;
+    .hheader { font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Roboto Mono', monospace; font-size: 11px; opacity: .6;
                padding: 6px 12px; background: #f0f4f8; }
-    .lines { overflow-x: auto; font-family: ui-monospace, monospace; font-size: 12px;
+    .lines { overflow-x: auto; font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Roboto Mono', monospace; font-size: 12px;
              line-height: 1.5; }
     .ln { display: flex; white-space: pre; }
     .ln .no { flex: 0 0 38px; text-align: right; padding-right: 8px; opacity: .4;
@@ -200,7 +203,7 @@ enum DiffHTML {
     .cbtn { margin: 8px 12px; font-size: 12px; padding: 4px 10px; border-radius: 8px;
             border: 1px solid #0002; background: transparent; }
     textarea { width: calc(100% - 24px); margin: 0 12px 10px; padding: 8px;
-               border-radius: 8px; border: 1px solid #0003; font-size: 15px;
+               border-radius: 8px; border: 1px solid #0003; font-size: 16px;
                font-family: inherit; min-height: 60px; background: inherit; color: inherit; }
     .hidden { display: none; }
     .empty { padding: 24px; text-align: center; opacity: .7; }


### PR DESCRIPTION
Screenshotted the rendered review pages at iPhone viewport (Playwright-driven Chromium, light + dark) to chase the "fonts look odd" report. Three real defects:

1. **`ui-monospace` is WebKit-only.** Chrome, Android, and Telegram in-app webviews fell through to the bare generic `monospace` (Courier-ish). Now: `ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Roboto Mono', monospace`.
2. **iOS text auto-inflation.** Safari inflates text adjacent to wide `overflow-x` code blocks (the diff's `.lines` is the textbook trigger), so parts of the page render at visibly different sizes — the likely "odd fonts". `-webkit-text-size-adjust: 100%` pins it. (Safari-only behavior; not reproducible in the Chromium shots, verify on the phone after release.)
3. **iOS focus-zoom.** Inputs under 16px make Safari zoom the viewport on focus — note textareas and the scope regex inputs are now 16px.

Bonus caught in the screenshots: file-header badges inherited `word-break: break-all` and could shatter mid-word ("ne / w" on the *new* pill); now nowrap inline-blocks, and per-file stats no longer wrap.

CSS-only; 781 tests pass (the one failure is the pre-existing live-process-discovery test).