### PR TITLE
fix(approval): show every MCP arg on the card + free-form scope conditions

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -239,9 +239,10 @@ final class ApprovalCoordinator: ObservableObject {
             }
             .sorted { lhs, rhs in lhs.name < rhs.name }
 
-        // Scoped-allow authoring mirrors the Mac panel's gating: MCP calls
-        // with at least one scalar arg, never on Allow-once-only paths.
-        let offersScopedAllow = !nonSuppressible && args.contains(where: \.scopable)
+        // Scoped-allow authoring mirrors the Mac panel's gating: MCP calls,
+        // never on Allow-once-only paths. No scalar args is fine — the page
+        // has free-form condition rows for args the call omitted.
+        let offersScopedAllow = !nonSuppressible && isMCP
         let createScopedAllow: (([String: String]) -> String)? = !offersScopedAllow ? nil : { [weak self] conditions in
             let rule = PersistentRule(
                 toolName: payload.toolName, pattern: "*", isRegex: false,

--- a/Sources/Gavel/Remote/RemoteApprovalBridge.swift
+++ b/Sources/Gavel/Remote/RemoteApprovalBridge.swift
@@ -507,7 +507,10 @@ final class RemoteApprovalBridge {
             let tail = cwd.split(separator: "/").suffix(2).joined(separator: "/")
             if !tail.isEmpty { lines.append("cwd: …/\(tail)") }
         }
-        let raw = payload.command ?? payload.filePath ?? firstStringInput(payload) ?? ""
+        // Bash/file tools show their primary text; MCP calls show EVERY arg
+        // as name: value lines — a single arbitrary first-string used to hide
+        // e.g. `workspace` behind `text`, making cards undecidable inline.
+        let raw = payload.command ?? payload.filePath ?? allArgsSummary(payload) ?? ""
         if !raw.isEmpty {
             let cleaned = sanitizeForDisplay(SecretRedactor.redact(raw))
             if cleaned.count > GavelConstants.telegramBodyMaxChars {
@@ -535,9 +538,31 @@ final class RemoteApprovalBridge {
         return lines.joined(separator: "\n")
     }
 
-    private static func firstStringInput(_ payload: PreToolUsePayload) -> String? {
-        for (_, v) in payload.toolInput { if let s = v.stringValue { return s } }
-        return nil
+    /// All tool args as sorted "name: value" lines. Long values (message
+    /// bodies) are clipped per-line so short args like channel/workspace
+    /// can't be pushed past the overall body cap by a big text field.
+    private static func allArgsSummary(_ payload: PreToolUsePayload) -> String? {
+        let lines = payload.toolInput
+            .compactMap { key, value -> (String, String)? in
+                guard let text = argDisplayValue(value) else { return nil }
+                return (key, text)
+            }
+            .sorted { $0.0 < $1.0 }
+            .map { name, text -> String in
+                let clipped = text.count > 400 ? String(text.prefix(400)) + "…" : text
+                return "\(name): \(clipped)"
+            }
+        return lines.isEmpty ? nil : lines.joined(separator: "\n")
+    }
+
+    private static func argDisplayValue(_ value: AnyCodable) -> String? {
+        switch value.value {
+        case let s as String: return s.isEmpty ? nil : s
+        case let b as Bool: return b ? "true" : "false"
+        case let i as Int: return String(i)
+        case let d as Double: return String(d)
+        default: return nil
+        }
     }
 
     private static func sanitizeForDisplay(_ text: String) -> String {

--- a/Sources/Gavel/Review/CommandHTML.swift
+++ b/Sources/Gavel/Review/CommandHTML.swift
@@ -129,6 +129,9 @@ enum CommandHTML {
         <h2>Always allow, scoped to</h2>
         <p class="scopehint">Creates an allow rule for \(DiffHTML.esc(content.toolName)) limited to args fully matching these regexes. Absent args never match — future calls outside the scope still prompt. Session rules expire when the session ends; Always rules persist.</p>
         \(rows)
+        <div id="customrows"></div>
+        <button class="addcond" onclick="addCustomRow()">+ condition on another arg</button>
+        <p class="scopehint">For an arg this call omitted (e.g. an optional workspace). Heads-up: calls that omit a conditioned arg never match the rule — they'll still prompt.</p>
         <div class="scopedbtns">
         <button id="scopedsessionbtn" class="scoped session" disabled onclick="submitScoped('allow_session_scoped')">Allow for session (scoped)</button>
         <button id="scopedbtn" class="scoped" disabled onclick="submitScoped('allow_scoped')">Always Allow (scoped)</button>
@@ -177,6 +180,12 @@ enum CommandHTML {
     .scoperow .pat { flex: 1; font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Roboto Mono', monospace; font-size: 16px;
                      padding: 6px 8px; border-radius: 8px; border: 1px solid #0003;
                      background: inherit; color: inherit; min-width: 0; }
+    .addcond { display: block; margin: 6px 12px 4px; padding: 6px 10px; font-size: 13px;
+               border-radius: 8px; border: 1px dashed #0004; background: transparent;
+               color: inherit; }
+    .scoperow .argname { flex: 0 0 34%; font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Roboto Mono', monospace;
+                         font-size: 16px; padding: 6px 8px; border-radius: 8px;
+                         border: 1px solid #0003; background: inherit; color: inherit; min-width: 0; }
     .scopedbtns { display: flex; gap: 10px; margin: 10px 12px 12px; }
     .scoped { flex: 1; padding: 12px; border-radius: 10px; border: none; font-size: 14px;
               font-weight: 600; background: #0969da; color: #fff; }
@@ -200,21 +209,42 @@ enum CommandHTML {
       footer { background: #161618f2; border-color: #fff2; }
       textarea { border-color: #fff3; }
       .scoperow .pat { border-color: #fff3; }
+      .scoperow .argname { border-color: #fff3; }
+      .addcond { border-color: #fff4; }
     }
     """
 
     private static let js = """
+    function customConditions() {
+      const out = {};
+      document.querySelectorAll('#customrows .scoperow').forEach(function (row) {
+        const name = row.querySelector('.argname').value.trim();
+        const pat = row.querySelector('.pat').value.trim();
+        if (name && pat) out[name] = pat;
+      });
+      return out;
+    }
     function scopeChanged() {
-      const any = document.querySelectorAll('.scopecheck:checked').length > 0;
+      const any = document.querySelectorAll('.scopecheck:checked').length > 0
+        || Object.keys(customConditions()).length > 0;
       document.querySelectorAll('.scoped').forEach(function (b) { b.disabled = !any; });
     }
+    function addCustomRow() {
+      const row = document.createElement('div');
+      row.className = 'scoperow';
+      row.innerHTML = '<input class="argname" placeholder="arg name" autocapitalize="off" autocorrect="off">'
+        + '<input class="pat" placeholder="regex" autocapitalize="off" autocorrect="off">';
+      row.querySelectorAll('input').forEach(function (i) { i.addEventListener('input', scopeChanged); });
+      document.getElementById('customrows').appendChild(row);
+      row.querySelector('.argname').focus();
+    }
     function submitScoped(verdict) {
-      const conditions = {};
+      const conditions = customConditions();
       document.querySelectorAll('.scopecheck:checked').forEach(function (c) {
         const pat = document.getElementById('pat-' + c.dataset.arg);
         if (pat && pat.value.trim()) conditions[c.dataset.arg] = pat.value.trim();
       });
-      if (Object.keys(conditions).length === 0) { alert('Tick at least one argument to scope the rule.'); return; }
+      if (Object.keys(conditions).length === 0) { alert('Tick or add at least one argument to scope the rule.'); return; }
       post({ verdict: verdict, note: noteValue(), conditions: conditions },
            verdict === 'allow_session_scoped'
              ? '✅ Scoped session allow created (expires with the session) — command proceeding.'

--- a/Tests/GavelTests/CommandReviewTests.swift
+++ b/Tests/GavelTests/CommandReviewTests.swift
@@ -232,6 +232,42 @@ final class CommandReviewTests: XCTestCase {
         XCTAssertEqual(linkRow.map(\.text), ["🔍 Review diff", "📄 Full command"])
     }
 
+    func testSummaryBodyListsAllMCPArgs() {
+        // The old body showed ONE arbitrary first-string arg — a send_message
+        // card could show `text` and hide channel/workspace entirely.
+        let payload = PreToolUsePayload(toolName: "mcp__Slack__send_message", toolInput: [
+            "channel": AnyCodable("Jayson Rawlins"),
+            "workspace": AnyCodable("defiance"),
+            "limit": AnyCodable(50),
+            "text": AnyCodable(String(repeating: "long message body ", count: 60)),
+        ])
+        let body = RemoteApprovalBridge.summaryBody(payload: payload, session: Session(pid: 1), triggerReason: nil)
+
+        XCTAssertTrue(body.contains("channel: Jayson Rawlins"))
+        XCTAssertTrue(body.contains("workspace: defiance"))
+        XCTAssertTrue(body.contains("limit: 50"))
+        // Long values clip per-line so they can't drown the short args.
+        let textLine = body.split(separator: "\n").first { $0.hasPrefix("text: ") }
+        XCTAssertNotNil(textLine)
+        XCTAssertLessThan(textLine!.count, 420)
+        XCTAssertTrue(textLine!.hasSuffix("…"))
+    }
+
+    func testCommandPageOffersCustomConditionRows() throws {
+        let offered = server.register(command: scopableSlackContent(), resolvable: ResolvableApproval { _ in }, createScopedAllow: { _ in "rule" })
+        let page = try request("/review/\(offered)")
+        XCTAssertTrue(page.body.contains("customrows"))
+        XCTAssertTrue(page.body.contains("condition on another arg"))
+
+        // Non-MCP pages (no scoped section) don't offer the affordance.
+        // (The page JS mentions the customrows id unconditionally, so assert
+        // on the button markup, which only the scoped section renders.)
+        let plain = server.register(command: makeCommand(), resolvable: ResolvableApproval { _ in })
+        let plainPage = try request("/review/\(plain)")
+        XCTAssertFalse(plainPage.body.contains("condition on another arg"))
+        XCTAssertFalse(plainPage.body.contains("<div id=\"customrows\">"))
+    }
+
     func testSummaryBodyTruncationPointsAtLink() {
         let long = String(repeating: "x", count: GavelConstants.telegramBodyMaxChars + 100)
         let payload = PreToolUsePayload(toolName: "Bash", toolInput: ["command": AnyCodable(long)])


### PR DESCRIPTION
Live watcher dogfooding caught two gaps in one card (the workspace arg was invisible and unscopeable):

1. **Inline card body showed one arbitrary MCP arg.** `firstStringInput` grabbed whichever string iterated first out of the unordered `tool_input` dict — a `send_message` card could show `text` while hiding `channel`/`workspace`. Now every scalar arg renders as a sorted `name: value` line; long values clip per-line (400 chars) so a message body can't drown the short args. Redaction + overall Telegram cap unchanged.

2. **No way to scope on an omitted arg.** Scope rows were only rendered for args present in the call, so an optional `workspace` the caller omitted couldn't be conditioned. The scoped section gains "+ condition on another arg" rows (name + regex), and the fail-closed consequence is stated right there: calls that omit a conditioned arg never match — they still prompt. That's the correct posture (an omitted workspace means "server default", which shouldn't be blanket-allowed), and the watcher pattern is to always pass args explicitly. Scoping is now offered on every suppressible MCP call, including ones with no scalar args.

No server-side changes needed — `cleanedConditions` already accepted arbitrary arg names and compile-validated the regexes.

Tests: 3 new (all-args body incl. per-line clipping, custom-row rendering + non-MCP negative). 783 total; the one failure is the pre-existing live-process-discovery test.