### PR TITLE
feat(approval): pattern-based allows on the command page for non-MCP tools

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -270,6 +270,27 @@ final class ApprovalCoordinator: ObservableObject {
             return "\(payload.toolName) [\(scope)]"
         }
 
+        // Pattern-based allows for non-MCP tools (Bash, file tools) — the
+        // page twin of the panel's pattern field + Always/Session Allow.
+        let suggestedPattern: String? = (nonSuppressible || isMCP) ? nil
+            : SessionRule.suggestPattern(toolName: payload.toolName, command: payload.command, filePath: payload.filePath)
+        let createPatternAllow: ((String) -> String)? = suggestedPattern == nil ? nil : { [weak self] pattern in
+            let rule = PersistentRule(
+                toolName: payload.toolName, pattern: Self.sanitizeDashes(pattern),
+                isRegex: false, verdict: .allow)
+            DispatchQueue.main.async {
+                self?.ruleStore?.addRule(rule, origin: "command-page:always-allow-pattern")
+            }
+            return rule.name
+        }
+        let createSessionPatternAllow: ((String) -> String)? = suggestedPattern == nil ? nil : { pattern in
+            let rule = SessionRule(toolName: payload.toolName, pattern: pattern)
+            DispatchQueue.main.async {
+                session.sessionRules.append(rule)
+            }
+            return "\(payload.toolName): \(pattern)"
+        }
+
         let label = session.label.isEmpty ? "PID \(session.pid)" : session.label
         let content = CommandContent(
             sessionLabel: label,
@@ -279,8 +300,9 @@ final class ApprovalCoordinator: ObservableObject {
             args: args,
             triggerReason: triggerReason,
             withheldInline: withheldInline,
-            offersScopedAllow: offersScopedAllow)
-        let nonce = DiffReviewServer.shared.register(command: content, resolvable: resolvable, createScopedAllow: createScopedAllow, createScopedSessionAllow: createScopedSessionAllow)
+            offersScopedAllow: offersScopedAllow,
+            suggestedPattern: suggestedPattern)
+        let nonce = DiffReviewServer.shared.register(command: content, resolvable: resolvable, createScopedAllow: createScopedAllow, createScopedSessionAllow: createScopedSessionAllow, createPatternAllow: createPatternAllow, createSessionPatternAllow: createSessionPatternAllow)
         gavelLog("[review] command link created pid=\(session.pid) tool=\(payload.toolName) scopedAllow=\(offersScopedAllow) nonce=\(nonce.prefix(8))…")
         return "\(base)/review/\(nonce)"
     }

--- a/Sources/Gavel/Review/CommandHTML.swift
+++ b/Sources/Gavel/Review/CommandHTML.swift
@@ -26,13 +26,17 @@ struct CommandContent {
     /// card — the page shows it anyway (tailnet-only), with a banner saying why.
     let withheldInline: Bool
     /// True when this approval may author a scoped Always Allow from the page
-    /// (MCP call with scalar args, not Allow-once-only). Must match whether a
+    /// (MCP call, not Allow-once-only). Must match whether a
     /// createScopedAllow callback was registered with the server.
     let offersScopedAllow: Bool
+    /// Prefill for the pattern-allow section (non-MCP tools: Bash, file
+    /// tools). Nil hides the section — set only when the matching pattern
+    /// callbacks were registered with the server.
+    let suggestedPattern: String?
 
     init(sessionLabel: String, toolName: String, cwd: String?, command: String?,
          args: [CommandArg], triggerReason: String?, withheldInline: Bool,
-         offersScopedAllow: Bool = false) {
+         offersScopedAllow: Bool = false, suggestedPattern: String? = nil) {
         self.sessionLabel = sessionLabel
         self.toolName = toolName
         self.cwd = cwd
@@ -41,6 +45,7 @@ struct CommandContent {
         self.triggerReason = triggerReason
         self.withheldInline = withheldInline
         self.offersScopedAllow = offersScopedAllow
+        self.suggestedPattern = suggestedPattern
     }
 }
 
@@ -74,6 +79,9 @@ enum CommandHTML {
         }
         if content.offersScopedAllow {
             body += scopedAllowSection(content)
+        }
+        if let suggested = content.suggestedPattern {
+            body += patternAllowSection(content, suggested: suggested)
         }
         if body.isEmpty {
             body = "<p class=\"empty\">No command text or arguments on this call.</p>"
@@ -135,6 +143,26 @@ enum CommandHTML {
         <div class="scopedbtns">
         <button id="scopedsessionbtn" class="scoped session" disabled onclick="submitScoped('allow_session_scoped')">Allow for session (scoped)</button>
         <button id="scopedbtn" class="scoped" disabled onclick="submitScoped('allow_scoped')">Always Allow (scoped)</button>
+        </div>
+        </section>
+        """
+    }
+
+    /// Pattern-based allow authoring for non-MCP tools (Bash, file tools) —
+    /// the phone twin of the Mac panel's pattern field + Always/Session
+    /// Allow. Glob semantics match SessionRule/PersistentRule: * is the only
+    /// wildcard, and Bash compound commands must match EVERY segment.
+    private static func patternAllowSection(_ content: CommandContent, suggested: String) -> String {
+        """
+        <section class="block">
+        <h2>Allow by pattern</h2>
+        <p class="scopehint">Glob for \(DiffHTML.esc(content.toolName)) (* matches anything; a compound Bash command must match every segment). Edit before granting — the prefill is this exact call.</p>
+        <div class="scoperow">
+        <input class="pat" id="allowpattern" value="\(DiffHTML.escAttr(suggested))" autocapitalize="off" autocorrect="off">
+        </div>
+        <div class="scopedbtns">
+        <button class="scoped session" onclick="submitPattern('allow_session_pattern')">Allow for session (pattern)</button>
+        <button class="scoped" onclick="submitPattern('allow_pattern')">Always Allow (pattern)</button>
         </div>
         </section>
         """
@@ -249,6 +277,15 @@ enum CommandHTML {
            verdict === 'allow_session_scoped'
              ? '✅ Scoped session allow created (expires with the session) — command proceeding.'
              : '✅ Scoped allow rule created — command proceeding.');
+    }
+    function submitPattern(verdict) {
+      const pat = document.getElementById('allowpattern');
+      const pattern = pat ? pat.value.trim() : '';
+      if (!pattern) { alert('Pattern is empty.'); return; }
+      post({ verdict: verdict, note: noteValue(), pattern: pattern },
+           verdict === 'allow_session_pattern'
+             ? '✅ Session pattern allow created (expires with the session) — command proceeding.'
+             : '✅ Always-allow pattern rule created — command proceeding.');
     }
     function submitVerdict(verdict) {
       post({ verdict: verdict, note: noteValue() },

--- a/Sources/Gavel/Review/DiffReviewServer.swift
+++ b/Sources/Gavel/Review/DiffReviewServer.swift
@@ -8,12 +8,15 @@ struct ReviewVerdictSubmission: Codable {
     let comments: [ReviewComment]?
     /// arg name → regex for verdict "allow_scoped" (command pages only).
     let conditions: [String: String]?
+    /// Glob for verdict "allow_pattern"/"allow_session_pattern" (non-MCP pages).
+    let pattern: String?
 
-    init(verdict: String, note: String?, comments: [ReviewComment]? = nil, conditions: [String: String]? = nil) {
+    init(verdict: String, note: String?, comments: [ReviewComment]? = nil, conditions: [String: String]? = nil, pattern: String? = nil) {
         self.verdict = verdict
         self.note = note
         self.comments = comments
         self.conditions = conditions
+        self.pattern = pattern
     }
 }
 
@@ -54,6 +57,11 @@ final class DiffReviewServer {
         /// Session-lifetime twin: appends a scoped SessionRule (dies with the
         /// session) and returns a description. Gated identically.
         let createScopedSessionAllow: (([String: String]) -> String)?
+        /// Pattern-based allows for non-MCP pages (Bash/file tools) — the
+        /// page twin of the panel's pattern field. Persistent and session
+        /// variants; absent → verdicts "allow_pattern"/"allow_session_pattern" 400.
+        let createPatternAllow: ((String) -> String)?
+        let createSessionPatternAllow: ((String) -> String)?
         let createdAt = Date()
         /// Set (under the server lock) once any source resolves the approval.
         var resolvedBy: ResolvableApproval.Source?
@@ -64,12 +72,14 @@ final class DiffReviewServer {
         /// set this, so it can't be back-filled once the race is over.
         var viewedAt: Date?
 
-        init(nonce: String, content: PageContent, resolvable: ResolvableApproval, createScopedAllow: (([String: String]) -> String)? = nil, createScopedSessionAllow: (([String: String]) -> String)? = nil) {
+        init(nonce: String, content: PageContent, resolvable: ResolvableApproval, createScopedAllow: (([String: String]) -> String)? = nil, createScopedSessionAllow: (([String: String]) -> String)? = nil, createPatternAllow: ((String) -> String)? = nil, createSessionPatternAllow: ((String) -> String)? = nil) {
             self.nonce = nonce
             self.content = content
             self.resolvable = resolvable
             self.createScopedAllow = createScopedAllow
             self.createScopedSessionAllow = createScopedSessionAllow
+            self.createPatternAllow = createPatternAllow
+            self.createSessionPatternAllow = createSessionPatternAllow
         }
     }
 
@@ -153,11 +163,11 @@ final class DiffReviewServer {
     /// has to transit Telegram. `createScopedAllow` (when the approval may
     /// author a durable allow) turns submitted arg conditions into a
     /// persistent rule and returns its name.
-    func register(command: CommandContent, resolvable: ResolvableApproval, createScopedAllow: (([String: String]) -> String)? = nil, createScopedSessionAllow: (([String: String]) -> String)? = nil) -> String {
-        register(page: .command(command), resolvable: resolvable, reviewedNoun: "the full command", createScopedAllow: createScopedAllow, createScopedSessionAllow: createScopedSessionAllow)
+    func register(command: CommandContent, resolvable: ResolvableApproval, createScopedAllow: (([String: String]) -> String)? = nil, createScopedSessionAllow: (([String: String]) -> String)? = nil, createPatternAllow: ((String) -> String)? = nil, createSessionPatternAllow: ((String) -> String)? = nil) -> String {
+        register(page: .command(command), resolvable: resolvable, reviewedNoun: "the full command", createScopedAllow: createScopedAllow, createScopedSessionAllow: createScopedSessionAllow, createPatternAllow: createPatternAllow, createSessionPatternAllow: createSessionPatternAllow)
     }
 
-    private func register(page: PageContent, resolvable: ResolvableApproval, reviewedNoun: String, createScopedAllow: (([String: String]) -> String)? = nil, createScopedSessionAllow: (([String: String]) -> String)? = nil) -> String {
+    private func register(page: PageContent, resolvable: ResolvableApproval, reviewedNoun: String, createScopedAllow: (([String: String]) -> String)? = nil, createScopedSessionAllow: (([String: String]) -> String)? = nil, createPatternAllow: ((String) -> String)? = nil, createSessionPatternAllow: ((String) -> String)? = nil) -> String {
         pruneStale()
 
         var bytes = [UInt8](repeating: 0, count: 16)
@@ -167,7 +177,7 @@ final class DiffReviewServer {
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
 
-        let session = ReviewSession(nonce: nonce, content: page, resolvable: resolvable, createScopedAllow: createScopedAllow, createScopedSessionAllow: createScopedSessionAllow)
+        let session = ReviewSession(nonce: nonce, content: page, resolvable: resolvable, createScopedAllow: createScopedAllow, createScopedSessionAllow: createScopedSessionAllow, createPatternAllow: createPatternAllow, createSessionPatternAllow: createSessionPatternAllow)
         lock.lock()
         sessions[nonce] = session
         lock.unlock()
@@ -331,6 +341,27 @@ final class DiffReviewServer {
                     verdict: .allow,
                     reason: sessionScoped
                         ? "Approved from command review page — session allow (scoped): \(ruleName)"
+                        : "Approved from command review page — always allow: \(ruleName)",
+                    additionalContext: note.map { "Approver note from review page: \($0)" })
+            } else if submission.verdict == "allow_pattern" || submission.verdict == "allow_session_pattern" {
+                // Pattern-based allow authoring (non-MCP pages) — same gating
+                // shape as the scoped verbs: callback presence is the
+                // capability, pattern must be non-empty and glob-compilable.
+                let sessionPattern = submission.verdict == "allow_session_pattern"
+                let pattern = submission.pattern?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                guard let create = sessionPattern ? session.createSessionPatternAllow : session.createPatternAllow,
+                      !pattern.isEmpty,
+                      PersistentRule.compilePattern(pattern, isRegex: false) != nil else {
+                    send(connection, status: 400, body: "bad request")
+                    return
+                }
+                let ruleName = create(pattern)
+                gavelLog("[review] pattern \(sessionPattern ? "session" : "persistent") allow authored nonce=\(session.nonce.prefix(8))…")
+                let note = submission.note.flatMap { $0.isEmpty ? nil : $0 }
+                decision = Decision(
+                    verdict: .allow,
+                    reason: sessionPattern
+                        ? "Approved from command review page — session allow (pattern): \(ruleName)"
                         : "Approved from command review page — always allow: \(ruleName)",
                     additionalContext: note.map { "Approver note from review page: \($0)" })
             } else {

--- a/Tests/GavelTests/CommandReviewTests.swift
+++ b/Tests/GavelTests/CommandReviewTests.swift
@@ -26,7 +26,8 @@ final class CommandReviewTests: XCTestCase {
         command: String? = "aws s3 cp s3://bucket/very-long-key /tmp/x --profile Prod-123",
         args: [CommandArg] = [],
         withheldInline: Bool = false,
-        offersScopedAllow: Bool = false
+        offersScopedAllow: Bool = false,
+        suggestedPattern: String? = nil
     ) -> CommandContent {
         CommandContent(
             sessionLabel: "argscope",
@@ -36,7 +37,8 @@ final class CommandReviewTests: XCTestCase {
             args: args,
             triggerReason: "Default rule: something fired",
             withheldInline: withheldInline,
-            offersScopedAllow: offersScopedAllow)
+            offersScopedAllow: offersScopedAllow,
+            suggestedPattern: suggestedPattern)
     }
 
     /// Pump the main queue — proposal adjudication and rule authoring hop to
@@ -500,6 +502,70 @@ final class CommandReviewTests: XCTestCase {
         let res = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"allow_scoped","conditions":{"channel":"general"}}"#)
         XCTAssertEqual(res.status, 409)
         XCTAssertFalse(created, "stale submissions must not author rules")
+    }
+
+    // MARK: - Pattern allows from the command page (non-MCP tools)
+
+    func testBashPageShowsPatternSectionAndMCPDoesNot() throws {
+        let bash = server.register(
+            command: makeCommand(suggestedPattern: "aws s3 cp *"),
+            resolvable: ResolvableApproval { _ in },
+            createPatternAllow: { _ in "rule" })
+        let bashPage = try request("/review/\(bash)")
+        XCTAssertTrue(bashPage.body.contains("Allow by pattern"))
+        XCTAssertTrue(bashPage.body.contains("aws s3 cp *"))
+
+        let mcp = server.register(command: scopableSlackContent(), resolvable: ResolvableApproval { _ in }, createScopedAllow: { _ in "rule" })
+        let mcpPage = try request("/review/\(mcp)")
+        XCTAssertFalse(mcpPage.body.contains("Allow by pattern"))
+    }
+
+    func testPatternAllowCreatesRuleAndResolves() throws {
+        var decision: Decision?
+        var received: String?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(
+            command: makeCommand(suggestedPattern: "aws s3 cp *"),
+            resolvable: resolvable,
+            createPatternAllow: { pattern in received = pattern; return "Bash: aws s3 cp *" })
+
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"allow_pattern","pattern":"aws s3 cp *","note":"routine sync"}"#)
+        XCTAssertEqual(res.status, 200)
+
+        XCTAssertEqual(received, "aws s3 cp *")
+        let d = try XCTUnwrap(decision)
+        XCTAssertEqual(d.verdict, .allow)
+        XCTAssertEqual(d.reason?.contains("always allow: Bash: aws s3 cp *"), true)
+        XCTAssertEqual(d.additionalContext?.contains("routine sync"), true)
+    }
+
+    func testSessionPatternAllowResolvesWithSessionWording() throws {
+        var decision: Decision?
+        let resolvable = ResolvableApproval { decision = $0 }
+        let nonce = server.register(
+            command: makeCommand(suggestedPattern: "swift build*"),
+            resolvable: resolvable,
+            createSessionPatternAllow: { pattern in "Bash: \(pattern)" })
+
+        let res = try request("/review/\(nonce)/verdict", method: "POST", body: #"{"verdict":"allow_session_pattern","pattern":"swift build*"}"#)
+        XCTAssertEqual(res.status, 200)
+        XCTAssertEqual(decision?.reason?.contains("session allow (pattern)"), true)
+    }
+
+    func testPatternVerdictsRejectedWithoutCallbackOrPattern() throws {
+        var created = false
+        let resolvable = ResolvableApproval { _ in }
+        // MCP page: no pattern callbacks registered.
+        let mcp = server.register(command: scopableSlackContent(), resolvable: resolvable, createScopedAllow: { _ in created = true; return "r" })
+        XCTAssertEqual(try request("/review/\(mcp)/verdict", method: "POST", body: #"{"verdict":"allow_pattern","pattern":"*"}"#).status, 400)
+
+        // Bash page: empty/missing pattern.
+        let bash = server.register(
+            command: makeCommand(suggestedPattern: "x*"), resolvable: ResolvableApproval { _ in },
+            createPatternAllow: { _ in created = true; return "r" })
+        XCTAssertEqual(try request("/review/\(bash)/verdict", method: "POST", body: #"{"verdict":"allow_pattern","pattern":"  "}"#).status, 400)
+        XCTAssertEqual(try request("/review/\(bash)/verdict", method: "POST", body: #"{"verdict":"allow_pattern"}"#).status, 400)
+        XCTAssertFalse(created)
     }
 
     // MARK: - Session-scoped allow from the command page


### PR DESCRIPTION
Straight from a dogfood deny-note left on the page itself ("no scope for me to set"): Bash approvals' pages offered only Allow once / Deny, while the Mac panel has pattern-based session/persistent allows. Non-MCP pages now render an **Allow by pattern** section — editable glob prefilled with the panel's `suggestPattern`, purple **Allow for session (pattern)** and blue **Always Allow (pattern)** buttons.

- New verdicts `allow_pattern` / `allow_session_pattern` (+ `pattern` field) on the existing route; gated by `createPatternAllow` / `createSessionPatternAllow` callbacks the coordinator registers only for suppressible non-MCP approvals — a crafted POST against an MCP page or Allow-once-only path is a 400, as is an empty or non-compiling glob.
- Rules created are byte-identical shapes to the panel's: `PersistentRule(toolName, glob, allow)` through the audited store (`origin=command-page:always-allow-pattern`), `SessionRule(toolName, glob)` appended on main.
- MCP pages keep arg-scoping; the two sections are mutually exclusive by design.

Tests: 4 new (section rendering split Bash/MCP, persistent + session happy paths with reason wording, 400s for missing callback / blank / missing pattern). 787 total; sole failure is the pre-existing live-process-discovery test.

Merging without an immediate release — the espey-dm-watcher dogfood session is live and a daemon restart would drop its session state; ships in the next train.