### PR TITLE
fix(session): key liveness on process start time so subagent cwd drift can't tombstone live sessions

### DIFF
--- a/Sources/Gavel/Daemon/HookRouter.swift
+++ b/Sources/Gavel/Daemon/HookRouter.swift
@@ -37,7 +37,10 @@ final class HookRouter {
         switch event.payload {
         case .preToolUse(let payload):
             if let sid = payload.sessionId { sessionManager.recordSessionId(sid, on: session) }
-            if let cwd = payload.cwd { sessionManager.recordCwd(cwd, on: session) }
+            // Sub-agent payloads can report an isolated worktree as cwd; the
+            // session row, transcript watcher, and review links must keep
+            // tracking the main conversation's directory.
+            if let cwd = payload.cwd, !payload.isSubAgent { sessionManager.recordCwd(cwd, on: session) }
 
             // AskUserQuestion and ExitPlanMode are user interaction tools —
             // don't intercept, let Claude's built-in UI handle them

--- a/Sources/Gavel/Daemon/SessionManager.swift
+++ b/Sources/Gavel/Daemon/SessionManager.swift
@@ -46,7 +46,7 @@ final class SessionManager: ObservableObject {
         homeDir: URL = FileManager.default.homeDirectoryForCurrentUser,
         autoStartTimers: Bool = true,
         autoDiscover: Bool = true,
-        liveness: @escaping (Int, String?) -> Bool = SessionManager.defaultLiveness
+        liveness: @escaping (Int, String?, Date?) -> Bool = SessionManager.defaultLiveness
     ) {
         let base = homeDir.path + "/.claude/gavel"
         self.defaultsPath = base + "/session-defaults.json"
@@ -77,7 +77,8 @@ final class SessionManager: ObservableObject {
             lock.unlock()
             return existing
         }
-        let session = Session(pid: pid, agent: agent)
+        let procStart = ProcessTree.startTime(of: Int32(pid))
+        let session = Session(pid: pid, startedAt: procStart, agent: agent, procStartedAt: procStart)
         session.isAutoApproveEnabled = defaultAutoApprove
         session.isSubAgentInheritEnabled = defaultSubAgentInherit
         session.isPaused = defaultPaused
@@ -271,7 +272,7 @@ final class SessionManager: ObservableObject {
     func clearDeadSessions() {
         lock.lock()
         let strayPids = sessions.compactMap { (pid, session) -> Int? in
-            (!session.isAlive || !isProcessAlive(pid: pid, cwd: session.cwd)) ? pid : nil
+            (!session.isAlive || !isProcessAlive(pid: pid, cwd: session.cwd, procStartedAt: session.procStartedAt)) ? pid : nil
         }
         for pid in strayPids {
             sessions.removeValue(forKey: pid)
@@ -303,6 +304,7 @@ final class SessionManager: ObservableObject {
         let isRemoteApprovalEnabled: Bool?
         let remoteApprovalUntil: Date?
         let tags: [SessionTag]?
+        let procStartedAt: Date?
     }
 
     private struct PersistedState: Codable {
@@ -345,7 +347,8 @@ final class SessionManager: ObservableObject {
             agent: session.agent,
             isRemoteApprovalEnabled: session.remoteApprovalSnapshot.enabled ? true : nil,
             remoteApprovalUntil: session.remoteApprovalSnapshot.until,
-            tags: session.tags.isEmpty ? nil : session.tags.snapshot
+            tags: session.tags.isEmpty ? nil : session.tags.snapshot,
+            procStartedAt: session.procStartedAt
         )
     }
 
@@ -367,7 +370,7 @@ final class SessionManager: ObservableObject {
         }
 
         for snap in live + dead {
-            if isProcessAlive(pid: snap.pid, cwd: snap.cwd) {
+            if isProcessAlive(pid: snap.pid, cwd: snap.cwd, procStartedAt: snap.procStartedAt) {
                 rehydrateLive(snap)
             } else if let sid = snap.sessionId {
                 rehydrateTombstone(snap, sessionId: sid)
@@ -377,7 +380,11 @@ final class SessionManager: ObservableObject {
 
     private func rehydrateLive(_ snap: PersistedSession) {
         let started = ProcessTree.startTime(of: Int32(snap.pid))
-        let session = Session(pid: snap.pid, cwd: snap.cwd, startedAt: started, agent: snap.agent ?? .claude)
+        // Legacy snapshots (pre-procStartedAt) were validated by the cwd
+        // fallback above; adopt the live process's start time as identity.
+        let session = Session(
+            pid: snap.pid, cwd: snap.cwd, startedAt: started, agent: snap.agent ?? .claude,
+            procStartedAt: snap.procStartedAt ?? started)
         session.sessionId = snap.sessionId
         session.isAutoApproveEnabled = snap.isAutoApproveEnabled ?? defaultAutoApprove
         session.isSubAgentInheritEnabled = snap.isSubAgentInheritEnabled ?? defaultSubAgentInherit
@@ -429,7 +436,7 @@ final class SessionManager: ObservableObject {
             let pidInt = Int(pid)
             if sessions[pidInt] != nil { continue }
             let started = ProcessTree.startTime(of: pid)
-            let session = Session(pid: pidInt, cwd: cwd, startedAt: started)
+            let session = Session(pid: pidInt, cwd: cwd, startedAt: started, procStartedAt: started)
             session.isAutoApproveEnabled = defaultAutoApprove
             session.isSubAgentInheritEnabled = defaultSubAgentInherit
             session.isPaused = defaultPaused
@@ -446,16 +453,29 @@ final class SessionManager: ObservableObject {
     }
 
     /// Liveness predicate for a tracked PID; overridable so tests can fake a live session.
-    var livenessCheck: (Int, String?) -> Bool
+    var livenessCheck: (Int, String?, Date?) -> Bool
 
-    func isProcessAlive(pid: Int, cwd: String?) -> Bool {
-        livenessCheck(pid, cwd)
+    func isProcessAlive(pid: Int, cwd: String?, procStartedAt: Date? = nil) -> Bool {
+        livenessCheck(pid, cwd, procStartedAt)
     }
 
-    // Match on cwd, not p_comm: Claude Code reports its version string (e.g. "2.1.158")
-    // as p_comm, so a recycled PID can't be ruled out by process name.
-    static func defaultLiveness(pid: Int, cwd expectedCwd: String?) -> Bool {
+    // PID-reuse detection. Primary signal: kernel process start time — a live
+    // PID whose start time doesn't match the recorded one was recycled.
+    // The cwd comparison survives only as a fallback for sessions without a
+    // recorded start time (legacy persisted files, or proc_pidinfo failure at
+    // creation). It must never be the primary check: hook payloads record
+    // worktree-subagent cwds that legitimately differ from the process's real
+    // cwd, and treating that as death tombstoned live sessions every 5s —
+    // destroying per-session state like the remote-approval grant (the
+    // "subagent approvals never reach Telegram" bug).
+    // p_comm is unusable either way: Claude Code reports its version string
+    // (e.g. "2.1.158") as the process name.
+    static func defaultLiveness(pid: Int, cwd expectedCwd: String?, procStartedAt: Date? = nil) -> Bool {
         guard kill(Int32(pid), 0) == 0 || errno == EPERM else { return false }
+        if let expected = procStartedAt {
+            guard let actual = ProcessTree.startTime(of: Int32(pid)) else { return false }
+            return abs(actual.timeIntervalSince(expected)) < 1.0
+        }
         guard let expectedCwd else { return true }
         guard let actual = ProcessTree.cwd(of: Int32(pid)) else { return false }
         return actual == expectedCwd
@@ -482,8 +502,9 @@ final class SessionManager: ObservableObject {
         for pid in pids {
             lock.lock()
             let cwd = sessions[pid]?.cwd
+            let procStart = sessions[pid]?.procStartedAt
             lock.unlock()
-            guard !isProcessAlive(pid: pid, cwd: cwd) else { continue }
+            guard !isProcessAlive(pid: pid, cwd: cwd, procStartedAt: procStart) else { continue }
             lock.lock()
             guard let session = sessions[pid] else {
                 lock.unlock()

--- a/Sources/Gavel/Models/Session.swift
+++ b/Sources/Gavel/Models/Session.swift
@@ -12,6 +12,13 @@ final class Session: ObservableObject, Identifiable {
     let startedAt: Date
     let agent: AgentKind
 
+    /// Kernel-recorded start time of the tracked process, captured at creation.
+    /// This is the session's process IDENTITY for liveness: a live PID whose
+    /// start time no longer matches was reused by a different process. The cwd
+    /// is NOT usable for this — hook payloads report worktree/subagent cwds
+    /// that legitimately diverge from the process's actual cwd.
+    let procStartedAt: Date?
+
     @Published var sessionId: String?
     @Published var cwd: String?
     @Published var model: String?
@@ -156,11 +163,12 @@ final class Session: ObservableObject, Identifiable {
         return remaining > 0 ? remaining : nil
     }
 
-    init(pid: Int, cwd: String? = nil, startedAt: Date? = nil, agent: AgentKind = .claude) {
+    init(pid: Int, cwd: String? = nil, startedAt: Date? = nil, agent: AgentKind = .claude, procStartedAt: Date? = nil) {
         self.pid = pid
         self.startedAt = startedAt ?? Date()
         self.cwd = cwd
         self.agent = agent
+        self.procStartedAt = procStartedAt
     }
 
     func revokeAutoApprove() {

--- a/Sources/Gavel/Monitor/MonitorWindow.swift
+++ b/Sources/Gavel/Monitor/MonitorWindow.swift
@@ -654,7 +654,7 @@ private struct SessionRow: View {
             .help("Read this session's transcript in a scrollable window.")
 
             Button("Sleep") {
-                if viewModel.sessionManager.isProcessAlive(pid: session.pid, cwd: session.cwd) {
+                if viewModel.sessionManager.isProcessAlive(pid: session.pid, cwd: session.cwd, procStartedAt: session.procStartedAt) {
                     kill(Int32(session.pid), SIGINT)
                 } else {
                     viewModel.sessionManager.cleanupDeadSessions()

--- a/Tests/GavelTests/NameUnnamedSessionsTests.swift
+++ b/Tests/GavelTests/NameUnnamedSessionsTests.swift
@@ -9,8 +9,8 @@ final class NameUnnamedSessionsTests: XCTestCase {
     private var writtenPaths: [String] = []
     private let deadPid = 1_999_998
 
-    private let liveOnOwnPid: (Int, String?) -> Bool = { pid, cwd in
-        pid == Int(getpid()) ? true : SessionManager.defaultLiveness(pid: pid, cwd: cwd)
+    private let liveOnOwnPid: (Int, String?, Date?) -> Bool = { pid, cwd, procStart in
+        pid == Int(getpid()) ? true : SessionManager.defaultLiveness(pid: pid, cwd: cwd, procStartedAt: procStart)
     }
 
     override func setUp() {

--- a/Tests/GavelTests/SessionLifecycleTests.swift
+++ b/Tests/GavelTests/SessionLifecycleTests.swift
@@ -8,9 +8,9 @@ final class SessionLifecycleTests: XCTestCase {
     private var tmpHome: URL!
     private var manager: SessionManager!
 
-    /// Stands in a live result for the test runner's own PID; everything else uses the real cwd check.
-    private let liveOnOwnPid: (Int, String?) -> Bool = { pid, cwd in
-        pid == Int(getpid()) ? true : SessionManager.defaultLiveness(pid: pid, cwd: cwd)
+    /// Stands in a live result for the test runner's own PID; everything else uses the real check.
+    private let liveOnOwnPid: (Int, String?, Date?) -> Bool = { pid, cwd, procStart in
+        pid == Int(getpid()) ? true : SessionManager.defaultLiveness(pid: pid, cwd: cwd, procStartedAt: procStart)
     }
 
     /// A PID effectively guaranteed not to exist on macOS. macOS reserves up
@@ -90,31 +90,71 @@ final class SessionLifecycleTests: XCTestCase {
 
     // MARK: - PID reuse
 
-    func testDefaultLivenessRejectsLivePidWithMismatchedCwd() {
+    func testDefaultLivenessMatchesOnProcessStartTimeNotCwd() {
+        let livePid = Int(getpid())
+        let realStart = ProcessTree.startTime(of: Int32(livePid))
+        XCTAssertNotNil(realStart, "Test runner must have a readable start time for this to be meaningful")
+        let driftedCwd = (ProcessTree.cwd(of: Int32(livePid)) ?? "") + "/somewhere-else"
+
+        XCTAssertTrue(
+            SessionManager.defaultLiveness(pid: livePid, cwd: driftedCwd, procStartedAt: realStart),
+            "A live PID with a matching start time is alive even when the recorded cwd drifted (worktree subagents report their worktree as cwd)"
+        )
+        XCTAssertFalse(
+            SessionManager.defaultLiveness(pid: livePid, cwd: driftedCwd, procStartedAt: realStart.map { $0.addingTimeInterval(-3600) }),
+            "A live PID whose start time doesn't match the recorded one was reused — dead"
+        )
+    }
+
+    func testDefaultLivenessFallsBackToCwdWithoutRecordedStartTime() {
         let livePid = Int(getpid())
         let realCwd = ProcessTree.cwd(of: Int32(livePid))
         XCTAssertNotNil(realCwd, "Test runner must have a readable cwd for this to be meaningful")
 
         XCTAssertTrue(
-            SessionManager.defaultLiveness(pid: livePid, cwd: realCwd),
-            "A live PID still in its recorded cwd is alive"
+            SessionManager.defaultLiveness(pid: livePid, cwd: realCwd, procStartedAt: nil),
+            "Legacy sessions (no recorded start time) still validate by cwd"
         )
         XCTAssertFalse(
-            SessionManager.defaultLiveness(pid: livePid, cwd: (realCwd ?? "") + "/somewhere-else"),
-            "A live PID whose cwd drifted from the recorded one was reused — dead"
+            SessionManager.defaultLiveness(pid: livePid, cwd: (realCwd ?? "") + "/somewhere-else", procStartedAt: nil),
+            "Legacy fallback: cwd mismatch without a start time still reads as PID reuse"
         )
     }
 
-    func testCleanupTombstonesPidReusedUnderDifferentCwd() {
+    func testCleanupKeepsLiveSessionWhoseCwdDriftedToWorktree() {
         manager.livenessCheck = SessionManager.defaultLiveness
-        let sid = "uuid-reused-pid"
+        let sid = "uuid-worktree-drift"
+        // session(for:) records the real process start time as identity.
         let session = manager.session(for: Int(getpid()))
         session.sessionId = sid
+        // A worktree-isolated subagent (or EnterWorktree) recorded a cwd the
+        // process isn't actually in. This must NOT read as PID reuse.
         session.cwd = "/tmp/some-other-recorded-path"
 
         manager.cleanupDeadSessions()
 
-        XCTAssertNil(manager.sessions[Int(getpid())], "PID whose cwd no longer matches must leave the live dict")
+        XCTAssertNotNil(manager.sessions[Int(getpid())],
+                        "A live PID with matching start time must survive cwd drift — tombstoning here destroyed per-session state (remote-approval grant, session rules)")
+        XCTAssertNil(manager.deadSessions[sid])
+    }
+
+    func testCleanupTombstonesReusedPid() {
+        let sid = "uuid-reused-pid"
+        let session = manager.session(for: Int(getpid()))
+        session.sessionId = sid
+        let recordedStart = session.procStartedAt
+        XCTAssertNotNil(recordedStart, "session(for:) must capture the process start time as identity")
+
+        // Fake kernel view: the process now at this PID has a DIFFERENT start
+        // time — PID reuse. Also asserts cleanup threads the session's
+        // recorded identity through to the liveness check.
+        manager.livenessCheck = { pid, _, procStart in
+            pid == Int(getpid()) ? procStart != recordedStart : false
+        }
+
+        manager.cleanupDeadSessions()
+
+        XCTAssertNil(manager.sessions[Int(getpid())], "PID whose start time no longer matches must leave the live dict")
         XCTAssertNotNil(manager.deadSessions[sid], "It must tombstone so the row flips to asleep")
     }
 

--- a/Tests/GavelTests/SubAgentCwdTests.swift
+++ b/Tests/GavelTests/SubAgentCwdTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+@testable import Gavel
+
+/// Sub-agent PreToolUse payloads (agent_id set) can report an isolated
+/// worktree as cwd. Recording that on the pid-keyed session repointed the
+/// row/watcher/review links — and, before liveness moved to process start
+/// time, made the cleanup timer read the session as a reused PID and
+/// tombstone it, destroying per-session state like the remote-approval
+/// grant (the "subagent approvals never mirror to Telegram" bug).
+final class SubAgentCwdTests: XCTestCase {
+
+    private var tmpHome: URL!
+    private var manager: SessionManager!
+    private var router: HookRouter!
+
+    override func setUp() {
+        super.setUp()
+        tmpHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gavel-subagent-cwd-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tmpHome, withIntermediateDirectories: true)
+        manager = SessionManager(homeDir: tmpHome, autoStartTimers: false, autoDiscover: false)
+        let engine = ApprovalEngine(ruleStore: RuleStore(configPath: "/dev/null"))
+        router = HookRouter(
+            sessionManager: manager, approvalEngine: engine,
+            approvalCoordinator: ApprovalCoordinator())
+    }
+
+    override func tearDown() {
+        router = nil
+        manager = nil
+        try? FileManager.default.removeItem(at: tmpHome)
+        super.tearDown()
+    }
+
+    private func bashEvent(pid: Int, cwd: String, agentId: String?) -> Data {
+        let agentField = agentId.map { "\"agent_id\": \"\($0)\"," } ?? ""
+        return """
+            {
+                "hookType": "PreToolUse",
+                "sessionPid": \(pid),
+                "timestamp": 1712600000.0,
+                "payload": {
+                    "type": "PreToolUse",
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "ls"},
+                    "session_id": "subagent-cwd-test",
+                    \(agentField)
+                    "cwd": "\(cwd)"
+                }
+            }
+            """.data(using: .utf8)!
+    }
+
+    private func drainMainQueue() {
+        let drained = expectation(description: "main queue drained")
+        DispatchQueue.main.async { drained.fulfill() }
+        wait(for: [drained], timeout: 1.0)
+    }
+
+    func testSubAgentCwdDoesNotOverwriteSessionCwd() {
+        let session = manager.session(for: 72001)
+        session.isAutoApproveEnabled = true
+        session.cwd = "/tmp/main-project"
+
+        router.handle(
+            data: bashEvent(
+                pid: 72001, cwd: "/tmp/main-project/.claude/worktrees/agent-abc",
+                agentId: "agent-abc"),
+            respond: { _ in })
+        drainMainQueue()
+
+        XCTAssertEqual(
+            session.cwd, "/tmp/main-project",
+            "A sub-agent's worktree cwd must not repoint the session")
+    }
+
+    func testMainPayloadCwdStillUpdatesSessionCwd() {
+        let session = manager.session(for: 72002)
+        session.isAutoApproveEnabled = true
+        session.cwd = "/tmp/old-project"
+
+        router.handle(
+            data: bashEvent(pid: 72002, cwd: "/tmp/new-project", agentId: nil),
+            respond: { _ in })
+        drainMainQueue()
+
+        XCTAssertEqual(
+            session.cwd, "/tmp/new-project",
+            "Main-conversation cwd updates must keep flowing")
+    }
+}


### PR DESCRIPTION
Fixes the first external bug report (Mike/Thraknor, via Discord): subagent-originated Gavel approvals reached the Mac panel but never mirrored to Telegram.

## Root cause

Worktree-isolated subagents report their worktree as the hook payload `cwd`. `recordCwd` stored it on the pid-keyed session, and `defaultLiveness` compared the recorded cwd against the process's actual cwd as a PID-reuse proxy. The 5s cleanup timer read the mismatch as PID reuse and tombstoned the live session; the next hook event recreated it from global defaults, silently destroying per-session state — the remote-approval grant, session rules, suppressed rules, and browsing leases. With `remoteApprove` defaulting off, that killed the Telegram mirror while the Mac panel kept prompting on the freshly recreated session. The flapping row is also the reporter's "session goes idle".

Reproduced live before the fix: one worktree subagent run produced 5 tombstone/recreate flaps in 30 seconds on a process that never exited.

## Fix

- Session liveness identity is now the kernel process start time (`PROC_PIDTBSDINFO`), captured at session creation and persisted in `active-sessions.json`. cwd comparison survives only as a fallback for legacy snapshots with no recorded start time.
- Subagent payloads (`agent_id` set) no longer overwrite the session cwd, so the monitor row, transcript watcher, and review links keep tracking the main conversation's directory.

## Verification

- 793 tests pass; new coverage: liveness start-time match/mismatch, legacy cwd fallback, cleanup keeping a live session with drifted cwd, cleanup tombstoning a genuinely reused PID, and router-level subagent-cwd isolation.
- Live dogfood via dev-daemon bounce: zero tombstone flaps during a worktree subagent run, and 3 parallel subagent probes (one worktree-isolated) each raised a Telegram card and were approved from the phone with the grant intact.