### PR TITLE
feat(approval): diff review everywhere — Mac panel button, command-page link, multi-line cd fix

### DIFF
--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -123,7 +123,7 @@ final class ApprovalCoordinator: ObservableObject {
         let firingRule = triggeringRuleId.flatMap { ruleStore?.rule(for: $0) }
         // Registered here (not in the remote mirror) so local-only sessions
         // get a review page too. Local git work only — no tailscale lookup.
-        let isCommit = payload.toolName == "Bash" && (payload.command?.contains("commit") ?? false)
+        let isCommit = payload.toolName == "Bash" && DiffCapture.isGitCommit(payload.command)
         let reviewNonce = isCommit ? registerDiffReview(payload: payload, session: session, resolvable: resolvable) : nil
         let pending = PendingApproval(
             payload: payload,
@@ -206,7 +206,7 @@ final class ApprovalCoordinator: ObservableObject {
             guard source == .telegram || source == .web else { return }
             DispatchQueue.main.async { self?.dismissPending(id: pendingId, pid: session.pid) }
         }
-        let isCommit = payload.toolName == "Bash" && (payload.command?.contains("commit") ?? false)
+        let isCommit = payload.toolName == "Bash" && DiffCapture.isGitCommit(payload.command)
         // Review link even on credential-withheld commits: the page never
         // shows the command, secret hunks are withheld on-page, and a
         // withheld commit is exactly when phone-side verification matters.

--- a/Sources/Gavel/Approval/ApprovalCoordinator.swift
+++ b/Sources/Gavel/Approval/ApprovalCoordinator.swift
@@ -61,6 +61,10 @@ final class ApprovalCoordinator: ObservableObject {
         let triggeringRuleIsRegex: Bool
         /// Allow-once only: the coordinator refuses session/persistent-allow actions for this approval.
         let nonSuppressible: Bool
+        /// URL path token of this commit's diff review page, shared by the
+        /// panel, Telegram, and the command page. Nil unless a commit's diff
+        /// was captured.
+        let reviewNonce: String?
         let resolvable: ResolvableApproval
         let respond: (Decision) -> Void
     }
@@ -117,6 +121,10 @@ final class ApprovalCoordinator: ObservableObject {
         }
 
         let firingRule = triggeringRuleId.flatMap { ruleStore?.rule(for: $0) }
+        // Registered here (not in the remote mirror) so local-only sessions
+        // get a review page too. Local git work only — no tailscale lookup.
+        let isCommit = payload.toolName == "Bash" && (payload.command?.contains("commit") ?? false)
+        let reviewNonce = isCommit ? registerDiffReview(payload: payload, session: session, resolvable: resolvable) : nil
         let pending = PendingApproval(
             payload: payload,
             session: session,
@@ -128,6 +136,7 @@ final class ApprovalCoordinator: ObservableObject {
             triggeringRulePattern: firingRule?.pattern,
             triggeringRuleIsRegex: firingRule?.isRegex ?? false,
             nonSuppressible: nonSuppressible,
+            reviewNonce: reviewNonce,
             resolvable: resolvable
         ) { decision in
             resolvable.resolve(decision, from: .mac)
@@ -201,20 +210,22 @@ final class ApprovalCoordinator: ObservableObject {
         // Review link even on credential-withheld commits: the page never
         // shows the command, secret hunks are withheld on-page, and a
         // withheld commit is exactly when phone-side verification matters.
-        let reviewURL = isCommit ? makeReviewLink(payload: payload, session: session, resolvable: resolvable) : nil
+        let tailnetReviewURL = pending.reviewNonce.flatMap { nonce in
+            TailscaleServe.cachedReviewBaseURL().map { "\($0)/review/\(nonce)" }
+        }
         // Full-command link on EVERY mirrored approval — Telegram keeps the
         // redacted/truncated summary, full fidelity lives on the tailnet page.
-        let commandURL = makeCommandLink(payload: payload, session: session, resolvable: resolvable, triggerReason: pending.triggerReason, withheldInline: withheld != nil, nonSuppressible: pending.nonSuppressible)
+        let commandURL = makeCommandLink(payload: payload, session: session, resolvable: resolvable, triggerReason: pending.triggerReason, withheldInline: withheld != nil, nonSuppressible: pending.nonSuppressible, reviewNonce: pending.reviewNonce)
         let text = withheld != nil
             ? RemoteApprovalBridge.withheldBody(payload: payload, session: session, hasCommandLink: commandURL != nil)
             : RemoteApprovalBridge.summaryBody(payload: payload, session: session, triggerReason: pending.triggerReason, hasCommandLink: commandURL != nil)
-        bridge.notify(resolvable: resolvable, text: text, pid: session.pid, toolName: payload.toolName, withheld: withheld != nil, allowSession: allowSession, offerCommentClean: isCommit && withheld == nil, leaseDomain: leaseDomain, allowSite: allowSite, reviewURL: reviewURL, commandURL: commandURL)
+        bridge.notify(resolvable: resolvable, text: text, pid: session.pid, toolName: payload.toolName, withheld: withheld != nil, allowSession: allowSession, offerCommentClean: isCommit && withheld == nil, leaseDomain: leaseDomain, allowSite: allowSite, reviewURL: tailnetReviewURL, commandURL: commandURL)
     }
 
     /// Register the full, unredacted command with the review server and
     /// return its tailnet URL. Failures are soft — nil just means the
     /// Telegram card goes out with the redacted inline text only.
-    private func makeCommandLink(payload: PreToolUsePayload, session: Session, resolvable: ResolvableApproval, triggerReason: String?, withheldInline: Bool, nonSuppressible: Bool) -> String? {
+    private func makeCommandLink(payload: PreToolUsePayload, session: Session, resolvable: ResolvableApproval, triggerReason: String?, withheldInline: Bool, nonSuppressible: Bool, reviewNonce: String? = nil) -> String? {
         do {
             try DiffReviewServer.shared.start()
         } catch {
@@ -301,7 +312,10 @@ final class ApprovalCoordinator: ObservableObject {
             triggerReason: triggerReason,
             withheldInline: withheldInline,
             offersScopedAllow: offersScopedAllow,
-            suggestedPattern: suggestedPattern)
+            suggestedPattern: suggestedPattern,
+            // Relative so the link works from whichever host serves the page
+            // (tailnet hostname or loopback).
+            reviewPath: reviewNonce.map { "/review/\($0)" })
         let nonce = DiffReviewServer.shared.register(command: content, resolvable: resolvable, createScopedAllow: createScopedAllow, createScopedSessionAllow: createScopedSessionAllow, createPatternAllow: createPatternAllow, createSessionPatternAllow: createSessionPatternAllow)
         gavelLog("[review] command link created pid=\(session.pid) tool=\(payload.toolName) scopedAllow=\(offersScopedAllow) nonce=\(nonce.prefix(8))…")
         return "\(base)/review/\(nonce)"
@@ -318,9 +332,9 @@ final class ApprovalCoordinator: ObservableObject {
     }
 
     /// Snapshot the pending commit's diff, register it with the review
-    /// server, and return the tailnet review URL. Every failure is soft —
-    /// a nil just means the Telegram message goes out without a link.
-    private func makeReviewLink(payload: PreToolUsePayload, session: Session, resolvable: ResolvableApproval) -> String? {
+    /// server, and return the page nonce. Every failure is soft — a nil just
+    /// means no review affordance anywhere (panel, Telegram, command page).
+    private func registerDiffReview(payload: PreToolUsePayload, session: Session, resolvable: ResolvableApproval) -> String? {
         guard let fallbackCwd = payload.cwd ?? session.cwd, let command = payload.command else {
             gavelLog("[review] no cwd/command on commit approval — no review link")
             return nil
@@ -341,7 +355,6 @@ final class ApprovalCoordinator: ObservableObject {
             gavelLog("[review] server start failed: \(error.localizedDescription)")
             return nil
         }
-        guard let base = TailscaleServe.cachedReviewBaseURL() else { return nil }
         let content = ReviewContent(
             repoName: URL(fileURLWithPath: cwd).lastPathComponent,
             commitMessage: captured.commitMessage,
@@ -351,7 +364,7 @@ final class ApprovalCoordinator: ObservableObject {
             untrackedOmitted: captured.untrackedOmitted)
         let nonce = DiffReviewServer.shared.register(content: content, resolvable: resolvable)
         gavelLog("[review] link created pid=\(session.pid) files=\(content.files.count) nonce=\(nonce.prefix(8))…")
-        return "\(base)/review/\(nonce)"
+        return nonce
     }
 
     /// Remove a pending approval resolved remotely from its session panel.

--- a/Sources/Gavel/Approval/ApprovalPanelView.swift
+++ b/Sources/Gavel/Approval/ApprovalPanelView.swift
@@ -272,6 +272,17 @@ struct ApprovalPanelView: View {
 
             Spacer()
 
+            if let reviewURL = approval.reviewNonce
+                .flatMap({ DiffReviewServer.shared.localURL(nonce: $0) })
+                .flatMap(URL.init(string:)) {
+                Button(action: { NSWorkspace.shared.open(reviewURL) }) {
+                    Label("Review diff", systemImage: "magnifyingglass")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .help("Open the pending commit's diff in your browser — same page as the phone's Review diff link")
+            }
+
             if sessionPanel.queueCount > 0 {
                 Text("+\(sessionPanel.queueCount) queued")
                     .font(.caption)

--- a/Sources/Gavel/Review/CommandHTML.swift
+++ b/Sources/Gavel/Review/CommandHTML.swift
@@ -33,10 +33,15 @@ struct CommandContent {
     /// tools). Nil hides the section — set only when the matching pattern
     /// callbacks were registered with the server.
     let suggestedPattern: String?
+    /// Relative path ("/review/<nonce>") to the pending commit's diff review
+    /// page, when one was captured. Relative on purpose: the same link works
+    /// whether the page was reached via the tailnet hostname or loopback.
+    let reviewPath: String?
 
     init(sessionLabel: String, toolName: String, cwd: String?, command: String?,
          args: [CommandArg], triggerReason: String?, withheldInline: Bool,
-         offersScopedAllow: Bool = false, suggestedPattern: String? = nil) {
+         offersScopedAllow: Bool = false, suggestedPattern: String? = nil,
+         reviewPath: String? = nil) {
         self.sessionLabel = sessionLabel
         self.toolName = toolName
         self.cwd = cwd
@@ -46,6 +51,7 @@ struct CommandContent {
         self.withheldInline = withheldInline
         self.offersScopedAllow = offersScopedAllow
         self.suggestedPattern = suggestedPattern
+        self.reviewPath = reviewPath
     }
 }
 
@@ -68,6 +74,9 @@ enum CommandHTML {
         }
 
         var body = ""
+        if let reviewPath = content.reviewPath {
+            body += "<a class=\"reviewlink\" href=\"\(DiffHTML.escAttr(reviewPath))\">🔍 Review the pending commit's diff</a>"
+        }
         if let command = content.command, !command.isEmpty {
             body += "<section class=\"block\"><h2>Command</h2><pre>\(DiffHTML.esc(command))</pre></section>"
         }
@@ -231,6 +240,9 @@ enum CommandHTML {
     .aname { font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Roboto Mono', monospace; font-size: 11px; font-weight: 700;
              opacity: .65; padding: 8px 12px 0; }
     .empty { padding: 24px; text-align: center; opacity: .7; }
+    .reviewlink { display: block; margin: 8px 8px 0; padding: 12px; border-radius: 10px;
+                  text-align: center; font-weight: 600; text-decoration: none;
+                  background: #ddf4ff66; border: 1px solid #0969da55; color: inherit; }
     .scopehint { font-size: 12px; opacity: .7; padding: 0 12px 6px; }
     .scoperow { display: flex; align-items: center; gap: 8px; padding: 4px 12px; }
     .scoperow label { flex: 0 0 34%; font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Roboto Mono', monospace;
@@ -275,6 +287,7 @@ enum CommandHTML {
       .scoperow .argname { border-color: #fff3; }
       .addcond { border-color: #fff4; }
       .chip { border-color: #58a6ff66; background: #10233a; }
+      .reviewlink { border-color: #58a6ff66; background: #10233a; }
     }
     """
 

--- a/Sources/Gavel/Review/DiffCapture.swift
+++ b/Sources/Gavel/Review/DiffCapture.swift
@@ -63,6 +63,19 @@ enum DiffCapture {
         )
     }
 
+    /// True when the command actually invokes `git … commit` — same shell
+    /// segment, quotes stripped. A bare "commit" substring shows up in grep
+    /// patterns, echo text, and commit-message mentions often enough that
+    /// every such command would otherwise pay a speculative git diff. The
+    /// lookahead rejects config keys like `-c commit.gpgsign=false`.
+    static func isGitCommit(_ command: String?) -> Bool {
+        guard let command else { return false }
+        let stripped = strippingQuotedSpans(command)
+        return stripped.range(
+            of: #"\bgit\b[^;&|\n]*\bcommit\b(?![.\w-])"#,
+            options: .regularExpression) != nil
+    }
+
     /// True when a `git add` segment precedes the commit in the same
     /// command ("git add -A && git commit …"): at approval time the add
     /// hasn't run, so the staged diff is empty and HEAD-relative capture

--- a/Sources/Gavel/Review/DiffCapture.swift
+++ b/Sources/Gavel/Review/DiffCapture.swift
@@ -118,7 +118,7 @@ enum DiffCapture {
     /// `$` are skipped (unresolvable) so the payload-cwd fallback applies.
     static func lastCdTarget(inHead head: String) -> String? {
         var target: String?
-        for rawSegment in head.components(separatedBy: CharacterSet(charactersIn: ";&|")) {
+        for rawSegment in head.components(separatedBy: CharacterSet(charactersIn: ";&|\n")) {
             let segment = rawSegment.trimmingCharacters(in: .whitespaces)
             guard segment.hasPrefix("cd ") || segment.hasPrefix("cd\t") else { continue }
             var arg = String(segment.dropFirst(2)).trimmingCharacters(in: .whitespaces)

--- a/Sources/Gavel/Review/DiffReviewServer.swift
+++ b/Sources/Gavel/Review/DiffReviewServer.swift
@@ -208,6 +208,13 @@ final class DiffReviewServer {
         return nonce
     }
 
+    /// Loopback URL for a registered page — the Mac-side twin of the tailnet
+    /// link, usable even when tailscale is down. Nil until start() has bound.
+    func localURL(nonce: String) -> String? {
+        guard let port = boundPort else { return nil }
+        return "http://127.0.0.1:\(port)/review/\(nonce)"
+    }
+
     private func session(for nonce: String) -> ReviewSession? {
         lock.lock()
         defer { lock.unlock() }

--- a/Tests/GavelTests/CommandReviewTests.swift
+++ b/Tests/GavelTests/CommandReviewTests.swift
@@ -27,7 +27,8 @@ final class CommandReviewTests: XCTestCase {
         args: [CommandArg] = [],
         withheldInline: Bool = false,
         offersScopedAllow: Bool = false,
-        suggestedPattern: String? = nil
+        suggestedPattern: String? = nil,
+        reviewPath: String? = nil
     ) -> CommandContent {
         CommandContent(
             sessionLabel: "argscope",
@@ -38,7 +39,8 @@ final class CommandReviewTests: XCTestCase {
             triggerReason: "Default rule: something fired",
             withheldInline: withheldInline,
             offersScopedAllow: offersScopedAllow,
-            suggestedPattern: suggestedPattern)
+            suggestedPattern: suggestedPattern,
+            reviewPath: reviewPath)
     }
 
     /// Pump the main queue — proposal adjudication and rule authoring hop to
@@ -116,6 +118,26 @@ final class CommandReviewTests: XCTestCase {
         let res = try request("/review/\(nonce)")
         XCTAssertFalse(res.body.contains("<script>alert(1)</script>"))
         XCTAssertTrue(res.body.contains("&lt;script&gt;alert(1)&lt;/script&gt;"))
+    }
+
+    func testCommandPageLinksToDiffReviewWhenRegistered() throws {
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(
+            command: makeCommand(reviewPath: "/review/diffnonce123"), resolvable: resolvable)
+
+        let res = try request("/review/\(nonce)")
+        // Relative href so the click-through works from tailnet AND loopback.
+        XCTAssertTrue(res.body.contains("href=\"/review/diffnonce123\""))
+        XCTAssertTrue(res.body.contains("Review the pending commit"))
+    }
+
+    func testCommandPageOmitsDiffLinkWithoutCapture() throws {
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(command: makeCommand(), resolvable: resolvable)
+
+        let res = try request("/review/\(nonce)")
+        XCTAssertFalse(res.body.contains("class=\"reviewlink\""))
+        XCTAssertFalse(res.body.contains("Review the pending commit"))
     }
 
     func testWithheldBannerShownOnPage() throws {

--- a/Tests/GavelTests/DiffCaptureTests.swift
+++ b/Tests/GavelTests/DiffCaptureTests.swift
@@ -20,6 +20,31 @@ final class DiffCaptureTests: XCTestCase {
         XCTAssertFalse(DiffCapture.commitUsesAllFlag("git commit -m 'add -a support later'"))
     }
 
+    // MARK: - Commit detection
+
+    func testIsGitCommitMatchesRealInvocations() {
+        XCTAssertTrue(DiffCapture.isGitCommit("git commit -m x"))
+        XCTAssertTrue(DiffCapture.isGitCommit("git add -A && git commit -m x"))
+        XCTAssertTrue(DiffCapture.isGitCommit("cd /repo\ngit commit -q -m 'multi line'"))
+        XCTAssertTrue(DiffCapture.isGitCommit("git -C /repo commit -m x"))
+        XCTAssertTrue(DiffCapture.isGitCommit("git -c user.email=t@t commit -q -m init"))
+        XCTAssertTrue(DiffCapture.isGitCommit("git commit --amend"))
+    }
+
+    func testIsGitCommitRejectsIncidentalMentions() {
+        XCTAssertFalse(DiffCapture.isGitCommit(nil))
+        // The word alone — grep patterns, logs, prose.
+        XCTAssertFalse(DiffCapture.isGitCommit("grep commit ~/.claude/gavel/gavel.log | tail -5"))
+        // Quoted mentions, even next to a real git invocation.
+        XCTAssertFalse(DiffCapture.isGitCommit(#"echo "git commit is next""#))
+        XCTAssertFalse(DiffCapture.isGitCommit(#"git log --grep "commit message""#))
+        // git and commit in different shell segments.
+        XCTAssertFalse(DiffCapture.isGitCommit("git push && echo commit done"))
+        XCTAssertFalse(DiffCapture.isGitCommit("git status\nsed -n 1p commit-log.txt"))
+        // Config keys are not the commit subcommand.
+        XCTAssertFalse(DiffCapture.isGitCommit("git -c commit.gpgsign=false push"))
+    }
+
     // MARK: - Stage-before-commit compounds
 
     func testDetectsAddBeforeCommit() {

--- a/Tests/GavelTests/DiffCaptureTests.swift
+++ b/Tests/GavelTests/DiffCaptureTests.swift
@@ -95,6 +95,27 @@ final class DiffCaptureTests: XCTestCase {
             "/tmp/my repo")
     }
 
+    func testRepoDirHonorsNewlineSeparatedCd() {
+        // Multi-line scripts: the cd segment ends at the newline, not at the
+        // next ;&| — regression for a real command whose cd target swallowed
+        // the following echo/helm lines and made git -C exit 128.
+        XCTAssertEqual(
+            DiffCapture.repoDir(
+                command: """
+                cd /tmp/argocd-applications
+                echo "=== validate render (loki branch) ==="
+                helm template apps ./apps -f envs/prod/values.yaml >/dev/null 2>/tmp/p2b.err; echo "EXIT=$?"; cat /tmp/p2b.err | head
+                echo "=== commit datasource to parked branch ==="
+                git add envs/prod/prometheus-stack-values.yaml
+                git commit -q -m "feat(loki): add Loki datasource to prod Grafana (phase 2)"
+                """,
+                fallback: "/repo"),
+            "/tmp/argocd-applications")
+        XCTAssertEqual(
+            DiffCapture.repoDir(command: "cd /a\ngit commit -m x", fallback: "/repo"),
+            "/a")
+    }
+
     func testRepoDirDashCOverridesCd() {
         XCTAssertEqual(
             DiffCapture.repoDir(command: "cd /a && git -C /b commit -m x", fallback: "/repo"),

--- a/Tests/GavelTests/DiffReviewServerTests.swift
+++ b/Tests/GavelTests/DiffReviewServerTests.swift
@@ -82,6 +82,17 @@ final class DiffReviewServerTests: XCTestCase {
         XCTAssertTrue(res.body.contains("scratch-repo"))
     }
 
+    func testLocalURLServesTheRegisteredPage() throws {
+        let resolvable = ResolvableApproval { _ in }
+        let nonce = server.register(content: makeContent(), resolvable: resolvable)
+
+        let localURL = try XCTUnwrap(server.localURL(nonce: nonce))
+        XCTAssertEqual(localURL, "http://127.0.0.1:\(port!)/review/\(nonce)")
+
+        let res = try request("/review/\(nonce)")
+        XCTAssertEqual(res.status, 200)
+    }
+
     func testUnknownNonceIs404() throws {
         let res = try request("/review/does-not-exist")
         XCTAssertEqual(res.status, 404)


### PR DESCRIPTION
Diff review for pending commits was phone-only, and multi-line commands broke it entirely.

## What was broken

- `DiffCapture.lastCdTarget` split command segments on `;&|` but not newlines. A multi-line `cd <repo> ... git commit` script swallowed the lines after the `cd` into the cd target, `git -C` exited 128, and no review page was created. Hit this live on an argocd-applications commit (gavel.log 2026-07-13 19:48Z).
- The Review diff link only existed as a Telegram button. The web command page never linked to it, and the Mac panel had nothing.
- The diff page was only registered on the remote-mirror path, so local-only sessions never got one.

## Changes

- Add `\n` to the cd segment separators (+ regression test with the exact multi-line command shape that failed).
- Register the diff page once in `requestApproval` for every commit prompt; the shared nonce feeds all three surfaces:
  - **Mac panel**: new Review diff button in the header, opens the loopback URL (`127.0.0.1:48765`) — works even when tailscale is down.
  - **Command page**: relative `/review/<nonce>` link, so it works from tailnet or loopback.
  - **Telegram**: existing button, unchanged behavior.
- Capture stays on the socket thread (local git only); the 10s-class tailscale base-URL lookup remains remote-mirror-only.

## Testing

- 797 tests pass, incl. new: `testRepoDirHonorsNewlineSeparatedCd`, `testCommandPageLinksToDiffReviewWhenRegistered`, `testCommandPageOmitsDiffLinkWithoutCapture`, `testLocalURLServesTheRegisteredPage`.
- Verified live via dev-daemon swap: reproduced the original failing command shape from a scratch repo — diff captured (`files=1`), page viewed, reviewed-signal attached to the approval. This PR's own commits were approved through the new flow.