### PR TITLE
fix(review): stop hung tailscale probes stalling approval links

### DIFF
--- a/Sources/Gavel/Review/TailscaleServe.swift
+++ b/Sources/Gavel/Review/TailscaleServe.swift
@@ -10,8 +10,9 @@ import Foundation
 /// Discovery + registration re-run per link with a short (60s) result
 /// cache: fresh enough that a `tailscale serve reset` or daemon flap can't
 /// leave stale links for long, but a burst of approvals (every one now
-/// carries a full-command link) doesn't fork two CLI probes each — and a
-/// down tailscale (10s command deadline) can't add 10s to every approval.
+/// carries a full-command link) doesn't fork two CLI probes each. A hung
+/// endpoint costs at most one status deadline per backoff window — probes
+/// that time out are skipped until the backoff lapses.
 ///
 /// A Mac can run SEVERAL independent backends at once: the Tailscale.app
 /// system extension plus any number of homebrew tailscaleds with custom
@@ -33,11 +34,16 @@ enum TailscaleServe {
         let hasOnlineIOSPeer: Bool
     }
 
-    /// Hard deadline per CLI invocation. `tailscale serve` BLOCKS
-    /// interactively when Serve isn't enabled on the tailnet (prints an
-    /// enable URL and waits) — without a deadline that would hang the
-    /// approval flow's worker thread.
+    /// Hard deadline for `tailscale serve`, which BLOCKS interactively when
+    /// Serve isn't enabled on the tailnet (prints an enable URL and waits) —
+    /// without a deadline that would hang the approval flow's worker thread.
     static let commandTimeout: TimeInterval = 10
+
+    /// Tighter deadline for `status --json`: a healthy backend answers this
+    /// local IPC read in milliseconds, but a probe can hang outright (seen
+    /// live: default GUI discovery from the launchd daemon context), and a
+    /// hung probe stalls every link that misses the result cache.
+    static let statusTimeout: TimeInterval = 2
 
     /// Test seam — production runs a tailscale CLI, tests stub responses.
     /// Returns (exitStatus, stdout); nil when the binary can't be run or
@@ -66,11 +72,12 @@ enum TailscaleServe {
             task.waitUntilExit()
             exited.signal()
         }
-        if exited.wait(timeout: .now() + commandTimeout) == .timedOut {
+        let deadline = args.contains("serve") ? commandTimeout : statusTimeout
+        if exited.wait(timeout: .now() + deadline) == .timedOut {
             task.terminate()
             _ = exited.wait(timeout: .now() + 2)
             _ = drained.wait(timeout: .now() + 2)
-            gavelLog("[review] tailscale \(args.first ?? "?") timed out after \(Int(commandTimeout))s — killed")
+            gavelLog("[review] tailscale \(args.joined(separator: " ")) timed out after \(Int(deadline))s — killed (\(binary))")
             // Partial stdout still matters: the blocked serve prints the
             // tailnet enable URL before waiting.
             return (124, String(decoding: data, as: UTF8.self))
@@ -101,6 +108,18 @@ enum TailscaleServe {
     private static let cacheLock = NSLock()
     static let cacheTTL: TimeInterval = 60
 
+    /// Endpoints whose status probe timed out, by key — skipped until the
+    /// backoff lapses. A probe that hangs does so deterministically (it's the
+    /// endpoint's environment, not load), so re-probing on every cache
+    /// refresh just re-pays the deadline; a healed endpoint is picked back up
+    /// within the backoff. Guarded by cacheLock.
+    private static var endpointTimeouts: [String: Date] = [:]
+    static let endpointBackoffTTL: TimeInterval = 15 * 60
+
+    static func endpointKey(binary: String, socketPath: String?) -> String {
+        "\(binary)|\(socketPath ?? "default")"
+    }
+
     /// Cached front-end for `reviewBaseURL()` — successes AND failures both
     /// hold for `cacheTTL` so per-approval links stay cheap either way.
     static func cachedReviewBaseURL(now: Date = Date()) -> String? {
@@ -117,10 +136,11 @@ enum TailscaleServe {
         return url
     }
 
-    /// Test seam — drop the cache so stubs take effect immediately.
+    /// Test seam — drop the caches so stubs take effect immediately.
     static func resetCache() {
         cacheLock.lock()
         cachedBase = nil
+        endpointTimeouts = [:]
         cacheLock.unlock()
     }
 
@@ -142,8 +162,23 @@ enum TailscaleServe {
 
         var running: [Backend] = []
         for endpoint in endpoints {
+            let key = endpointKey(binary: endpoint.binary, socketPath: endpoint.socketPath)
+            cacheLock.lock()
+            let lastTimeout = endpointTimeouts[key]
+            cacheLock.unlock()
+            if let lastTimeout, Date().timeIntervalSince(lastTimeout) < endpointBackoffTTL {
+                continue
+            }
             let args = socketArgs(endpoint.socketPath) + ["status", "--json"]
-            guard let result = runner(endpoint.binary, args), result.status == 0,
+            guard let result = runner(endpoint.binary, args) else { continue }
+            if result.status == 124 {
+                cacheLock.lock()
+                endpointTimeouts[key] = Date()
+                cacheLock.unlock()
+                gavelLog("[review] skipping \(key) for \(Int(endpointBackoffTTL / 60)) min after status timeout")
+                continue
+            }
+            guard result.status == 0,
                   let backend = backend(
                       binary: endpoint.binary, socketPath: endpoint.socketPath,
                       statusJSON: Data(result.stdout.utf8)) else { continue }

--- a/Tests/GavelTests/TailscaleServeTests.swift
+++ b/Tests/GavelTests/TailscaleServeTests.swift
@@ -11,11 +11,13 @@ final class TailscaleServeTests: XCTestCase {
         try XCTSkipIf(TailscaleServe.candidateBinaries().isEmpty, "no tailscale CLI installed")
         savedRunner = TailscaleServe.runner
         savedSockets = TailscaleServe.socketPaths
+        TailscaleServe.resetCache()
     }
 
     override func tearDown() {
         if savedRunner != nil { TailscaleServe.runner = savedRunner }
         if savedSockets != nil { TailscaleServe.socketPaths = savedSockets }
+        TailscaleServe.resetCache()
     }
 
     private func statusJSON(state: String, dns: String?, iosPeerOnline: Bool? = nil) -> String {
@@ -183,6 +185,54 @@ final class TailscaleServeTests: XCTestCase {
         TailscaleServe.socketPaths = { [] }
         TailscaleServe.runner = { _, _ in nil }
         XCTAssertNil(TailscaleServe.reviewBaseURL())
+    }
+
+    // MARK: - Timed-out endpoint backoff
+
+    func testTimedOutStatusProbeBacksOffAndHealthyEndpointStillWins() {
+        TailscaleServe.socketPaths = { ["/var/run/tailscaled-personal.sock"] }
+        var defaultProbes = 0
+        TailscaleServe.runner = { _, args in
+            if args.contains("--json") {
+                if self.socketArg(in: args) != nil {
+                    return (0, self.statusJSON(state: "Running", dns: "personal.tail2.ts.net.", iosPeerOnline: true))
+                }
+                // Hung default-discovery probe, killed at the deadline.
+                defaultProbes += 1
+                return (124, "")
+            }
+            return (0, "")
+        }
+
+        let expected = "https://personal.tail2.ts.net:\(GavelConstants.reviewTailnetHTTPSPort)"
+        XCTAssertEqual(TailscaleServe.reviewBaseURL(), expected)
+        let probesAfterFirst = defaultProbes
+        XCTAssertGreaterThan(probesAfterFirst, 0)
+
+        XCTAssertEqual(TailscaleServe.reviewBaseURL(), expected)
+        XCTAssertEqual(defaultProbes, probesAfterFirst,
+                       "a timed-out endpoint must not be re-probed within the backoff")
+    }
+
+    func testResetCacheClearsEndpointBackoff() {
+        TailscaleServe.socketPaths = { [] }
+        var probes = 0
+        TailscaleServe.runner = { _, args in
+            if args.contains("--json") {
+                probes += 1
+                return (124, "")
+            }
+            return (0, "")
+        }
+
+        XCTAssertNil(TailscaleServe.reviewBaseURL())
+        let probesAfterFirst = probes
+        XCTAssertNil(TailscaleServe.reviewBaseURL())
+        XCTAssertEqual(probes, probesAfterFirst)
+
+        TailscaleServe.resetCache()
+        XCTAssertNil(TailscaleServe.reviewBaseURL())
+        XCTAssertGreaterThan(probes, probesAfterFirst)
     }
 
     // MARK: - Serve-disabled enable URL


### PR DESCRIPTION
Follow-up to the diagnosis in #213: nearly every mirrored approval under the brew daemon was preceded by `tailscale status timed out after 10s — killed`, adding ~10s to Telegram card delivery (approval shown 19:48:42 → card sent 19:48:53 in gavel.log).

## Root cause

One endpoint's `status --json` probe (default GUI discovery — the timed-out log lines carry no `--socket=` arg) hangs deterministically in the launchd daemon context. The 60s result cache works as designed, but the hang re-occurs inside `reviewBaseURL()` on every cache refresh, and the healthy endpoint that actually wins has to wait behind the full 10s deadline each time. Notably the hang does not reproduce when the daemon runs from a shell context — it's environmental to launchd, so skipping the endpoint loses nothing.

## Changes

- `status --json` probes get a dedicated 2s deadline (healthy backends answer in milliseconds). `serve` keeps 10s — that deadline exists for its interactive Serve-not-enabled block.
- Per-endpoint backoff: a status probe that times out marks its endpoint skipped for 15 minutes instead of being re-probed (and re-waited) on every refresh. Healed endpoints are picked back up within the window; `resetCache()` clears the backoff.
- The timeout log line now includes the full args and binary, so the next hung endpoint is identifiable from the log alone.

Worst case drops from 10s per cache refresh to 2s per 15 minutes.

## Testing

- 795 tests pass, incl. new `testTimedOutStatusProbeBacksOffAndHealthyEndpointStillWins` (hung endpoint skipped on the next cycle, healthy backend still chosen) and `testResetCacheClearsEndpointBackoff`.
- The 124-timeout path is driven through the existing runner test seam; suite setUp/tearDown now reset the caches so backoff state can't leak between tests.